### PR TITLE
Stop printing password to console

### DIFF
--- a/Dell_iDRAC_fan_controller.sh
+++ b/Dell_iDRAC_fan_controller.sh
@@ -32,7 +32,7 @@ if [[ $IDRAC_HOST == "local" ]]; then
   IDRAC_LOGIN_STRING='open'
 else
   echo "iDRAC/IPMI username: $IDRAC_USERNAME"
-  echo "iDRAC/IPMI password: $IDRAC_PASSWORD"
+  #echo "iDRAC/IPMI password: $IDRAC_PASSWORD"
   IDRAC_LOGIN_STRING="lanplus -H $IDRAC_HOST -U $IDRAC_USERNAME -P $IDRAC_PASSWORD"
 fi
 

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -16,7 +16,7 @@ if [[ $IDRAC_HOST == "local" ]]; then
   IDRAC_LOGIN_STRING='open'
 else
   echo "iDRAC/IPMI username: $IDRAC_USERNAME"
-  echo "iDRAC/IPMI password: $IDRAC_PASSWORD"
+  #echo "iDRAC/IPMI password: $IDRAC_PASSWORD"
   IDRAC_LOGIN_STRING="lanplus -H $IDRAC_HOST -U $IDRAC_USERNAME -P $IDRAC_PASSWORD"
 fi
 


### PR DESCRIPTION
Hello, this small change simply stops printing the password used to console.

While potentially helpful for debugging, this really shouldn't be the default behavior, especially when deployed into environments with container logging (eg, a Kubernetes cluster using the Grafana/Loki stack). Additionally, with such a simple application, debugging if a password is set correctly can be done more securely.