### PR TITLE
Updated workflow for release tagging

### DIFF
--- a/.github/workflows/build_and_publish_docker_image.yml
+++ b/.github/workflows/build_and_publish_docker_image.yml
@@ -2,60 +2,66 @@ name: Docker image CI
 
 on:
   push:
-    branches: [ master ]
+    tags: ["v*.*.*"]
     paths-ignore:
-      - '**/README.md'
+      - "**/README.md"
 
 jobs:
   build:
     name: Build and publish Docker image to Docker Hub and GitHub Containers Repository
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
-    - name: Remove "_Docker" suffix from GitHub repository name to use it as image name
-      uses: mad9000/actions-find-and-replace-string@3
-      id: docker_image_name
-      with:
-        source: ${{ github.repository }}
-        find: '_Docker'
-        replace: ''
-      
-    - name: Docker meta
-      id: meta
-      uses: docker/metadata-action@v5
-      with:
-        images: |
-          ${{ steps.docker_image_name.outputs.value }}
-          ghcr.io/${{ steps.docker_image_name.outputs.value }}
-        tags: type=raw,value=latest
-        
-    - name: Login to Docker Hub
-      uses: docker/login-action@v3
-      with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
-    
-    - name: Login to GitHub Container Registry
-      uses: docker/login-action@v3
-      with:
-        registry: ghcr.io
-        username: ${{ github.repository_owner }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Generate release note
+        uses: softprops/action-gh-release@v1
+        with:
+          generate_release_notes: true
 
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
-    
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      - name: Remove "_Docker" suffix from GitHub repository name to use it as image name
+        uses: mad9000/actions-find-and-replace-string@3
+        id: docker_image_name
+        with:
+          source: ${{ github.repository }}
+          find: "_Docker"
+          replace: ""
 
-    - name: Build and publish Docker image
-      uses: docker/build-push-action@v4
-      with:
-        context: .
-        platforms: linux/amd64,linux/arm64
-        file: ./Dockerfile
-        push: true
-        tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ steps.docker_image_name.outputs.value }}
+            ghcr.io/${{ steps.docker_image_name.outputs.value }}
+          flavor: |
+            latest=auto
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and publish Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build_and_publish_docker_image.yml
+++ b/.github/workflows/build_and_publish_docker_image.yml
@@ -2,7 +2,7 @@ name: Docker image CI
 
 on:
   push:
-    tags: ["v*.*.*"]
+    tags: ["v[0-9]+.[0-9]+"]
     paths-ignore:
       - "**/README.md"
 
@@ -19,21 +19,15 @@ jobs:
         with:
           generate_release_notes: true
 
-      - name: Remove "_Docker" suffix from GitHub repository name to use it as image name
-        uses: mad9000/actions-find-and-replace-string@3
-        id: docker_image_name
-        with:
-          source: ${{ github.repository }}
-          find: "_Docker"
-          replace: ""
-
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: |
-            ${{ steps.docker_image_name.outputs.value }}
-            ghcr.io/${{ steps.docker_image_name.outputs.value }}
+            ${{ github.repository | replace('_Docker', '') }}
+            ghcr.io/${{ github.repository | replace('_Docker', '') }}
+          tags: |
+            type=ref,event=tag
           flavor: |
             latest=auto
 


### PR DESCRIPTION
Here is a PR that updates the workflow for use of tags and tagging releases and docker containers.

When you are ready to release a new version just tag the latest git commit.

```
git add .
git commit -m "message"
git tag "v1.1.1"
git push
git push --tags
```

