### PR TITLE
Stop passing iDRAC password as an ipmitool command-line argument

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -62,7 +62,10 @@ function set_iDRAC_login_string() {
   else
     echo "iDRAC/IPMI username: $IDRAC_USERNAME"
     #echo "iDRAC/IPMI password: $IDRAC_PASSWORD"
-    IDRAC_LOGIN_STRING="lanplus -H $IDRAC_HOST -U $IDRAC_USERNAME -P $IDRAC_PASSWORD"
+    # Pass the password via the IPMI_PASSWORD environment variable (-E) instead of the command line (-P)
+    # so it never appears in the container's process list (e.g. `ps aux`, /proc/<pid>/cmdline) or logs
+    export IPMI_PASSWORD="$IDRAC_PASSWORD"
+    IDRAC_LOGIN_STRING="lanplus -H $IDRAC_HOST -U $IDRAC_USERNAME -E"
   fi
 }
 


### PR DESCRIPTION
## Summary
- `IDRAC_PASSWORD` was passed to every `ipmitool` call via the `-P` flag, making it visible in the container's process list (`ps aux`, `/proc/<pid>/cmdline`) to anyone with access to the container.
- Switched to ipmitool's `-E` flag, which reads the password from the `IPMI_PASSWORD` environment variable instead, so it never appears as a command-line argument.

## Testing
- `bash -n` syntax check.
- Functional test with a mocked `ipmitool`: confirmed the password appears only in the `IPMI_PASSWORD` environment variable seen by the mock, never in `$*` (the command-line arguments), and `-P` no longer appears on any invocation.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C99hufKg147ydGvBFd3RNK)_