### PR TITLE
Detect and report failed IPMI connections instead of a misleading error

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -163,7 +163,14 @@ function graceful_exit() {
 
 # Helps debugging when people are posting their output
 function get_Dell_server_model() {
-  local -r IPMI_FRU_content=$(ipmitool -I $IDRAC_LOGIN_STRING fru 2>/dev/null) # FRU stands for "Field Replaceable Unit"
+  local IPMI_FRU_content
+  # FRU stands for "Field Replaceable Unit". Capture stderr too so a failed IPMI connection can be reported instead of silently discarded
+  IPMI_FRU_content=$(ipmitool -I $IDRAC_LOGIN_STRING fru 2>&1)
+  local -r ipmitool_exit_code=$?
+
+  if [ $ipmitool_exit_code -ne 0 ]; then
+    print_error_and_exit "Could not establish IPMI connection to iDRAC/IPMI host \"$IDRAC_HOST\". Check that IDRAC_HOST, IDRAC_USERNAME and IDRAC_PASSWORD are correct. ipmitool said: $IPMI_FRU_content"
+  fi
 
   SERVER_MANUFACTURER=$(echo "$IPMI_FRU_content" | grep "Product Manufacturer" | awk -F ': ' '{print $2}')
   SERVER_MODEL=$(echo "$IPMI_FRU_content" | grep "Product Name" | awk -F ': ' '{print $2}')


### PR DESCRIPTION
Closes #103.

## Summary
- Previously, a wrong `IDRAC_USERNAME`/`IDRAC_PASSWORD` (or any `ipmitool` connection failure) was silently discarded (stderr redirected to `/dev/null`), leaving `SERVER_MANUFACTURER` empty and surfacing the unrelated `Your server isn't a Dell product` error — confusing for anyone with a real connection/credentials problem.
- `get_Dell_server_model` now checks the `ipmitool` exit code and, on failure, reports the actual `ipmitool` error (e.g. `Unable to establish IPMI v2 / RMCP+ session`) so users can immediately tell a bad connection apart from a genuinely non-Dell server.

## Testing
- `bash -n` syntax check.
- Functional test with a mocked `ipmitool`: simulated failed connection (bad credentials) → clear error message + exit code 1.
- Functional test: simulated successful connection → confirmed unchanged behavior (regression check).

---
_Generated by [Claude Code](https://claude.ai/code/session_01C99hufKg147ydGvBFd3RNK)_