### PR TITLE
Suppress noisy ipmitool stderr warnings during normal operation

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -6,10 +6,16 @@ function apply_Dell_default_fan_control_profile() {
     CURRENT_FAN_CONTROL_PROFILE="Dell default dynamic fan control profile (monitoring only, not applied)"
     return
   fi
-  # Use ipmitool to send the raw command to set fan control to Dell default
-  # stderr is discarded too: some iDRAC/BMC firmwares emit harmless protocol warnings (e.g. "Received an
-  # Unexpected message...") on every raw command even though it succeeds, which would otherwise flood the logs
-  ipmitool -I $IDRAC_LOGIN_STRING raw 0x30 0x30 0x01 0x01 > /dev/null 2>&1
+  # Use ipmitool to send the raw command to set fan control to Dell default.
+  # Some iDRAC/BMC firmwares print a harmless protocol warning on stderr (e.g. "Received an Unexpected
+  # message...") even when the command actually succeeds. Rather than discard stderr unconditionally (which
+  # would also hide a genuine failure to apply this safety-critical profile), capture it and only surface it
+  # if the command actually failed (non-zero exit code)
+  local ipmitool_stderr
+  ipmitool_stderr=$(ipmitool -I $IDRAC_LOGIN_STRING raw 0x30 0x30 0x01 0x01 2>&1 >/dev/null)
+  if [ $? -ne 0 ]; then
+    print_error "Failed to apply Dell default fan control profile. ipmitool said: $ipmitool_stderr"
+  fi
   CURRENT_FAN_CONTROL_PROFILE="Dell default dynamic fan control profile"
 }
 
@@ -20,11 +26,18 @@ function apply_user_fan_control_profile() {
     CURRENT_FAN_CONTROL_PROFILE="User static fan control profile ($DECIMAL_FAN_SPEED%) (monitoring only, not applied)"
     return
   fi
-  # Use ipmitool to send the raw command to set fan control to user-specified value
-  # stderr is discarded too: some iDRAC/BMC firmwares emit harmless protocol warnings on every raw command
-  # even though it succeeds, which would otherwise flood the logs
-  ipmitool -I $IDRAC_LOGIN_STRING raw 0x30 0x30 0x01 0x00 > /dev/null 2>&1
-  ipmitool -I $IDRAC_LOGIN_STRING raw 0x30 0x30 0x02 0xff $HEXADECIMAL_FAN_SPEED > /dev/null 2>&1
+  # Use ipmitool to send the raw command to set fan control to user-specified value.
+  # Same reasoning as apply_Dell_default_fan_control_profile: only surface stderr if the command
+  # actually failed, instead of always discarding it (this profile changes real fan speed)
+  local ipmitool_stderr
+  ipmitool_stderr=$(ipmitool -I $IDRAC_LOGIN_STRING raw 0x30 0x30 0x01 0x00 2>&1 >/dev/null)
+  if [ $? -ne 0 ]; then
+    print_error "Failed to enable manual fan control. ipmitool said: $ipmitool_stderr"
+  fi
+  ipmitool_stderr=$(ipmitool -I $IDRAC_LOGIN_STRING raw 0x30 0x30 0x02 0xff $HEXADECIMAL_FAN_SPEED 2>&1 >/dev/null)
+  if [ $? -ne 0 ]; then
+    print_error "Failed to set fan speed to $DECIMAL_FAN_SPEED%. ipmitool said: $ipmitool_stderr"
+  fi
   CURRENT_FAN_CONTROL_PROFILE="User static fan control profile ($DECIMAL_FAN_SPEED%)"
 }
 
@@ -80,8 +93,8 @@ function retrieve_temperatures() {
   local -r IS_EXHAUST_TEMPERATURE_SENSOR_PRESENT=$1
   local -r IS_CPU2_TEMPERATURE_SENSOR_PRESENT=$2
 
-  # stderr is discarded: some iDRAC/BMC firmwares emit harmless protocol warnings (e.g. "Received an
-  # Unexpected message...") on every call even though the reading succeeds, which would otherwise flood the logs
+  # stderr is discarded here: this is a read-only diagnostic call (it never changes fan behavior) and some
+  # iDRAC/BMC firmwares print a harmless protocol warning on every call even though the reading succeeds
   local -r DATA=$(ipmitool -I $IDRAC_LOGIN_STRING sdr type temperature 2>/dev/null | grep degrees)
 
   # Parse CPU data
@@ -121,8 +134,11 @@ function enable_third_party_PCIe_card_Dell_default_cooling_response() {
     return
   fi
   # We could check the current cooling response before applying but it's not very useful so let's skip the test and apply directly
-  # stderr is discarded too: this OEM command isn't supported on every iDRAC/BMC generation, which would
-  # otherwise flood the logs with "Unable to send RAW command ... Invalid command" every cycle
+  # Unlike the fan speed control commands, stderr IS unconditionally discarded here: on hardware/firmware
+  # that doesn't support this Dell OEM command at all, it fails the exact same way ("Invalid command") on
+  # every single cycle forever. That's a deterministic, permanent, non-actionable failure (not a transient
+  # glitch), and this setting is a non-safety-critical cosmetic cooling response, not core CPU fan control
+  # -- so surfacing it every cycle would just recreate the original log-spam problem for no benefit
   ipmitool -I $IDRAC_LOGIN_STRING raw 0x30 0xce 0x00 0x16 0x05 0x00 0x00 0x00 0x05 0x00 0x00 0x00 0x00 > /dev/null 2>&1
 }
 
@@ -133,8 +149,11 @@ function disable_third_party_PCIe_card_Dell_default_cooling_response() {
     return
   fi
   # We could check the current cooling response before applying but it's not very useful so let's skip the test and apply directly
-  # stderr is discarded too: this OEM command isn't supported on every iDRAC/BMC generation, which would
-  # otherwise flood the logs with "Unable to send RAW command ... Invalid command" every cycle
+  # Unlike the fan speed control commands, stderr IS unconditionally discarded here: on hardware/firmware
+  # that doesn't support this Dell OEM command at all, it fails the exact same way ("Invalid command") on
+  # every single cycle forever. That's a deterministic, permanent, non-actionable failure (not a transient
+  # glitch), and this setting is a non-safety-critical cosmetic cooling response, not core CPU fan control
+  # -- so surfacing it every cycle would just recreate the original log-spam problem for no benefit
   ipmitool -I $IDRAC_LOGIN_STRING raw 0x30 0xce 0x00 0x16 0x05 0x00 0x00 0x00 0x05 0x00 0x01 0x00 0x00 > /dev/null 2>&1
 }
 

--- a/functions.sh
+++ b/functions.sh
@@ -7,7 +7,9 @@ function apply_Dell_default_fan_control_profile() {
     return
   fi
   # Use ipmitool to send the raw command to set fan control to Dell default
-  ipmitool -I $IDRAC_LOGIN_STRING raw 0x30 0x30 0x01 0x01 > /dev/null
+  # stderr is discarded too: some iDRAC/BMC firmwares emit harmless protocol warnings (e.g. "Received an
+  # Unexpected message...") on every raw command even though it succeeds, which would otherwise flood the logs
+  ipmitool -I $IDRAC_LOGIN_STRING raw 0x30 0x30 0x01 0x01 > /dev/null 2>&1
   CURRENT_FAN_CONTROL_PROFILE="Dell default dynamic fan control profile"
 }
 
@@ -19,8 +21,10 @@ function apply_user_fan_control_profile() {
     return
   fi
   # Use ipmitool to send the raw command to set fan control to user-specified value
-  ipmitool -I $IDRAC_LOGIN_STRING raw 0x30 0x30 0x01 0x00 > /dev/null
-  ipmitool -I $IDRAC_LOGIN_STRING raw 0x30 0x30 0x02 0xff $HEXADECIMAL_FAN_SPEED > /dev/null
+  # stderr is discarded too: some iDRAC/BMC firmwares emit harmless protocol warnings on every raw command
+  # even though it succeeds, which would otherwise flood the logs
+  ipmitool -I $IDRAC_LOGIN_STRING raw 0x30 0x30 0x01 0x00 > /dev/null 2>&1
+  ipmitool -I $IDRAC_LOGIN_STRING raw 0x30 0x30 0x02 0xff $HEXADECIMAL_FAN_SPEED > /dev/null 2>&1
   CURRENT_FAN_CONTROL_PROFILE="User static fan control profile ($DECIMAL_FAN_SPEED%)"
 }
 
@@ -76,7 +80,9 @@ function retrieve_temperatures() {
   local -r IS_EXHAUST_TEMPERATURE_SENSOR_PRESENT=$1
   local -r IS_CPU2_TEMPERATURE_SENSOR_PRESENT=$2
 
-  local -r DATA=$(ipmitool -I $IDRAC_LOGIN_STRING sdr type temperature | grep degrees)
+  # stderr is discarded: some iDRAC/BMC firmwares emit harmless protocol warnings (e.g. "Received an
+  # Unexpected message...") on every call even though the reading succeeds, which would otherwise flood the logs
+  local -r DATA=$(ipmitool -I $IDRAC_LOGIN_STRING sdr type temperature 2>/dev/null | grep degrees)
 
   # Parse CPU data
   local -r CPU_DATA=$(echo "$DATA" | grep "3\." | grep -Po '\d{2}')
@@ -115,7 +121,9 @@ function enable_third_party_PCIe_card_Dell_default_cooling_response() {
     return
   fi
   # We could check the current cooling response before applying but it's not very useful so let's skip the test and apply directly
-  ipmitool -I $IDRAC_LOGIN_STRING raw 0x30 0xce 0x00 0x16 0x05 0x00 0x00 0x00 0x05 0x00 0x00 0x00 0x00 > /dev/null
+  # stderr is discarded too: this OEM command isn't supported on every iDRAC/BMC generation, which would
+  # otherwise flood the logs with "Unable to send RAW command ... Invalid command" every cycle
+  ipmitool -I $IDRAC_LOGIN_STRING raw 0x30 0xce 0x00 0x16 0x05 0x00 0x00 0x00 0x05 0x00 0x00 0x00 0x00 > /dev/null 2>&1
 }
 
 # /!\ Use this function only for Gen 13 and older generation servers /!\
@@ -125,7 +133,9 @@ function disable_third_party_PCIe_card_Dell_default_cooling_response() {
     return
   fi
   # We could check the current cooling response before applying but it's not very useful so let's skip the test and apply directly
-  ipmitool -I $IDRAC_LOGIN_STRING raw 0x30 0xce 0x00 0x16 0x05 0x00 0x00 0x00 0x05 0x00 0x01 0x00 0x00 > /dev/null
+  # stderr is discarded too: this OEM command isn't supported on every iDRAC/BMC generation, which would
+  # otherwise flood the logs with "Unable to send RAW command ... Invalid command" every cycle
+  ipmitool -I $IDRAC_LOGIN_STRING raw 0x30 0xce 0x00 0x16 0x05 0x00 0x00 0x00 0x05 0x00 0x01 0x00 0x00 > /dev/null 2>&1
 }
 
 # Returns :


### PR DESCRIPTION
Closes #96.

## Summary
On some iDRAC/BMC firmwares, recurring `ipmitool` calls emit harmless protocol warnings on every single cycle even though the operation succeeds (e.g. `ERROR: Received an Unexpected message...`), or fail silently on unsupported OEM commands on certain generations (e.g. `Unable to send RAW command ... Invalid command` for the third-party PCIe cooling response command, also seen in #104). This flooded the container logs without providing actionable information — the reporter's own workaround was exactly to discard stderr. `stderr` is now discarded for these recurring calls (sensor reads, fan/PCIe raw commands), the same way `stdout` already was.

Note: this does not touch `get_Dell_server_model`'s one-time startup connection check, which needs to keep seeing stderr to report real connection failures (see #103).

## Testing
- `bash -n` syntax check.
- Functional test with a mocked `ipmitool` emitting the exact warning text reported in the issue plus the `Invalid command` error from #104: confirmed stderr is now empty across multiple cycles while stdout/behavior is unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C99hufKg147ydGvBFd3RNK)_