### PR TITLE
Fix crashes and unsafe fallbacks on invalid or mis-parsed temperature readings

### DIFF
--- a/Dell_iDRAC_fan_controller.sh
+++ b/Dell_iDRAC_fan_controller.sh
@@ -31,14 +31,8 @@ if [[ ! $SERVER_MANUFACTURER == "DELL" ]]; then
   print_error_and_exit "Your server isn't a Dell product"
 fi
 
-# CPU temperature indexes are the same for every generation: retrieve_temperatures() now isolates the
-# sdr reading column before extracting digits, so CPU_DATA holds exactly one value per CPU sensor.
-# They used to differ (2 and 4 for Gen 14 and newer) only because the parsing extracted digits from the
-# whole sdr line: on Gen 14 and newer the CPU sensors' hexadecimal IDs are two digits (e.g. "01h", "02h"),
-# so each line leaked an extra bogus value and doubled the indexes. Now that the leak is gone, keeping
-# 2 and 4 would read CPU 2's temperature as CPU 1's and leave CPU 2 undetected, hence unmonitored
-readonly CPU1_TEMPERATURE_INDEX=1
-readonly CPU2_TEMPERATURE_INDEX=2
+# CPU temperature indexes are gone: retrieve_temperatures() now locates each CPU by its IPMI entity ID
+# instead of counting values, which no longer depends on the server generation
 
 # If server model is Gen 14 (*40) or newer
 if [[ $SERVER_MODEL =~ .*[RT][[:space:]]?[0-9][4-9]0.* ]]; then

--- a/Dell_iDRAC_fan_controller.sh
+++ b/Dell_iDRAC_fan_controller.sh
@@ -31,15 +31,20 @@ if [[ ! $SERVER_MANUFACTURER == "DELL" ]]; then
   print_error_and_exit "Your server isn't a Dell product"
 fi
 
+# CPU temperature indexes are the same for every generation: retrieve_temperatures() now isolates the
+# sdr reading column before extracting digits, so CPU_DATA holds exactly one value per CPU sensor.
+# They used to differ (2 and 4 for Gen 14 and newer) only because the parsing extracted digits from the
+# whole sdr line: on Gen 14 and newer the CPU sensors' hexadecimal IDs are two digits (e.g. "01h", "02h"),
+# so each line leaked an extra bogus value and doubled the indexes. Now that the leak is gone, keeping
+# 2 and 4 would read CPU 2's temperature as CPU 1's and leave CPU 2 undetected, hence unmonitored
+readonly CPU1_TEMPERATURE_INDEX=1
+readonly CPU2_TEMPERATURE_INDEX=2
+
 # If server model is Gen 14 (*40) or newer
 if [[ $SERVER_MODEL =~ .*[RT][[:space:]]?[0-9][4-9]0.* ]]; then
   readonly DELL_POWEREDGE_GEN_14_OR_NEWER=true
-  readonly CPU1_TEMPERATURE_INDEX=2
-  readonly CPU2_TEMPERATURE_INDEX=4
 else
   readonly DELL_POWEREDGE_GEN_14_OR_NEWER=false
-  readonly CPU1_TEMPERATURE_INDEX=1
-  readonly CPU2_TEMPERATURE_INDEX=2
 fi
 
 # Log main informations

--- a/functions.sh
+++ b/functions.sh
@@ -83,9 +83,12 @@ function retrieve_temperature_by_entity_id() {
   local -r SDR_DATA="$1"
   local -r ENTITY_ID="$2"
 
+  # The reading is matched on the "degrees" suffix rather than on a fixed two-digit width, so that an
+  # overheating CPU reporting three digits isn't truncated : "100 degrees C" used to be read as 10°C,
+  # silently keeping the user's low fan speed on a CPU that needed the Dell default profile
   echo "$SDR_DATA" | awk -F'|' -v entity="$ENTITY_ID" '
     { gsub(/^[[:space:]]+|[[:space:]]+$/, "", $4) }
-    $4 == entity { print $5; exit }' | grep -Po '\d{2}'
+    $4 == entity { print $5; exit }' | grep -Po '\d+(?=[[:space:]]*degrees)'
 }
 
 # Retrieve temperature sensors data using ipmitool

--- a/functions.sh
+++ b/functions.sh
@@ -66,6 +66,28 @@ function set_iDRAC_login_string() {
   fi
 }
 
+# Extract a single temperature reading from ipmitool sdr output, located by its IPMI entity ID
+# Usage : retrieve_temperature_by_entity_id "$SDR_DATA" $ENTITY_ID
+# Returns : the temperature in degrees Celsius, or an empty string if that entity has no reading
+#
+# An sdr line looks like "Temp             | 09h | ok  |  3.1 | 45 degrees C", the 4th pipe-delimited
+# column being the entity ID. Entity 3 is the processor, so 3.1 is CPU 1, 3.2 is CPU 2, and so on.
+#
+# Locating a CPU by its entity rather than by counting values makes the parsing independent from the
+# sensors' hexadecimal IDs, from the order iDRAC returns them in, and therefore from the server
+# generation. Counting used to require per-generation offsets because the digits were extracted from
+# the whole line: a sensor whose hexadecimal ID happens to be two digits (e.g. "09h" on an R930, or
+# every CPU sensor on some generations) contributed a second, bogus value per line, shifting
+# everything (see https://github.com/tigerblue77/Dell_iDRAC_fan_controller_Docker/issues/91)
+function retrieve_temperature_by_entity_id() {
+  local -r SDR_DATA="$1"
+  local -r ENTITY_ID="$2"
+
+  echo "$SDR_DATA" | awk -F'|' -v entity="$ENTITY_ID" '
+    { gsub(/^[[:space:]]+|[[:space:]]+$/, "", $4) }
+    $4 == entity { print $5; exit }' | grep -Po '\d{2}'
+}
+
 # Retrieve temperature sensors data using ipmitool
 # Usage : retrieve_temperatures $IS_EXHAUST_TEMPERATURE_SENSOR_PRESENT $IS_CPU2_TEMPERATURE_SENSOR_PRESENT
 function retrieve_temperatures() {
@@ -78,14 +100,10 @@ function retrieve_temperatures() {
 
   local -r DATA=$(ipmitool -I $IDRAC_LOGIN_STRING sdr type temperature | grep degrees)
 
-  # Parse CPU data. Each sdr line looks like "Temp | 09h | ok | 3.1 | 45 degrees C" : cut down to the
-  # 5th pipe-delimited column (the reading itself) before extracting digits, otherwise a sensor whose hex
-  # ID happens to be two digits (e.g. "09h") would leak an extra bogus reading into CPU_DATA and throw off
-  # the positional indexing below (see https://github.com/tigerblue77/Dell_iDRAC_fan_controller_Docker/issues/91)
-  local -r CPU_DATA=$(echo "$DATA" | grep "3\." | cut -d'|' -f5 | grep -Po '\d{2}')
-  CPU1_TEMPERATURE=$(echo $CPU_DATA | awk "{print \$$CPU1_TEMPERATURE_INDEX;}")
+  # Parse CPU data, each CPU being located by its IPMI entity ID (3.1 is CPU 1, 3.2 is CPU 2)
+  CPU1_TEMPERATURE=$(retrieve_temperature_by_entity_id "$DATA" "3.1")
   if $IS_CPU2_TEMPERATURE_SENSOR_PRESENT; then
-    CPU2_TEMPERATURE=$(echo $CPU_DATA | awk "{print \$$CPU2_TEMPERATURE_INDEX;}")
+    CPU2_TEMPERATURE=$(retrieve_temperature_by_entity_id "$DATA" "3.2")
   else
     CPU2_TEMPERATURE="-"
   fi

--- a/functions.sh
+++ b/functions.sh
@@ -90,12 +90,18 @@ function retrieve_temperatures() {
     CPU2_TEMPERATURE="-"
   fi
 
-  # Initialize CPUS_TEMPERATURES
-  CPUS_TEMPERATURES="$CPU1_TEMPERATURE"
+  # Initialize CPUS_TEMPERATURES. An unreadable CPU 1 reading falls back to the "-" placeholder so that it
+  # still takes up its column when the line is printed : CPUS_TEMPERATURES is split on whitespace to build
+  # the display array, so an empty value would be dropped and shift every following column to the left.
+  # CPU1_TEMPERATURE itself is left untouched, CPU1_OVERHEATING() must still see the invalid reading
+  CPUS_TEMPERATURES="${CPU1_TEMPERATURE:--}"
   NUMBER_OF_DETECTED_CPUS=1
 
-  # If CPU2 is present, parse its temperature data and add it to CPUS_TEMPERATURES
-  if [ -n "$CPU2_TEMPERATURE" ]; then
+  # If CPU2 is present, parse its temperature data and add it to CPUS_TEMPERATURES.
+  # "-" is the placeholder set above when the sensor is known to be absent, so it must not be counted as a
+  # detected CPU: otherwise servers without a CPU2 sensor get an extra column that the header, built once
+  # from the first reading (when the placeholder isn't set yet), doesn't account for
+  if [ -n "$CPU2_TEMPERATURE" ] && [ "$CPU2_TEMPERATURE" != "-" ]; then
     CPUS_TEMPERATURES+=";$CPU2_TEMPERATURE"
     ((NUMBER_OF_DETECTED_CPUS++))
   fi

--- a/functions.sh
+++ b/functions.sh
@@ -78,8 +78,11 @@ function retrieve_temperatures() {
 
   local -r DATA=$(ipmitool -I $IDRAC_LOGIN_STRING sdr type temperature | grep degrees)
 
-  # Parse CPU data
-  local -r CPU_DATA=$(echo "$DATA" | grep "3\." | grep -Po '\d{2}')
+  # Parse CPU data. Each sdr line looks like "Temp | 09h | ok | 3.1 | 45 degrees C" : cut down to the
+  # 5th pipe-delimited column (the reading itself) before extracting digits, otherwise a sensor whose hex
+  # ID happens to be two digits (e.g. "09h") would leak an extra bogus reading into CPU_DATA and throw off
+  # the positional indexing below (see https://github.com/tigerblue77/Dell_iDRAC_fan_controller_Docker/issues/91)
+  local -r CPU_DATA=$(echo "$DATA" | grep "3\." | cut -d'|' -f5 | grep -Po '\d{2}')
   CPU1_TEMPERATURE=$(echo $CPU_DATA | awk "{print \$$CPU1_TEMPERATURE_INDEX;}")
   if $IS_CPU2_TEMPERATURE_SENSOR_PRESENT; then
     CPU2_TEMPERATURE=$(echo $CPU_DATA | awk "{print \$$CPU2_TEMPERATURE_INDEX;}")
@@ -98,11 +101,11 @@ function retrieve_temperatures() {
   fi
 
   # Parse inlet temperature data
-  INLET_TEMPERATURE=$(echo "$DATA" | grep Inlet | grep -Po '\d{2}' | tail -1)
+  INLET_TEMPERATURE=$(echo "$DATA" | grep Inlet | cut -d'|' -f5 | grep -Po '\d{2}' | tail -1)
 
   # If exhaust temperature sensor is present, parse its temperature data
   if $IS_EXHAUST_TEMPERATURE_SENSOR_PRESENT; then
-    EXHAUST_TEMPERATURE=$(echo "$DATA" | grep Exhaust | grep -Po '\d{2}' | tail -1)
+    EXHAUST_TEMPERATURE=$(echo "$DATA" | grep Exhaust | cut -d'|' -f5 | grep -Po '\d{2}' | tail -1)
   else
     EXHAUST_TEMPERATURE="-"
   fi
@@ -233,18 +236,40 @@ function print_temperature_array_line() {
   # Creating an array from the string
   local -r CPUs_temperatures_array=(${LOCAL_CPUS_TEMPERATURES//;/ })
 
-  printf "%19s  %3d°C " "$(date +"%d-%m-%Y %T")" $LOCAL_INLET_TEMPERATURE
+  printf "%19s  %s°C " "$(date +"%d-%m-%Y %T")" "$(format_temperature_for_display "$LOCAL_INLET_TEMPERATURE")"
   # Itération sur les températures dans le tableau
   for temperature in "${CPUs_temperatures_array[@]}"; do
-    printf " %3d°C " $temperature
+    printf " %s°C " "$(format_temperature_for_display "$temperature")"
   done
 
   printf " %5s°C  %40s  %51s  %s\n" "$LOCAL_EXHAUST_TEMPERATURE" "$LOCAL_CURRENT_FAN_CONTROL_PROFILE" "$LOCAL_THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE_STATUS" "$LOCAL_COMMENT"
 }
 
-# Define functions to check if CPU 1 and CPU 2 temperatures are above the threshold
-function CPU1_OVERHEATING() { [ $CPU1_TEMPERATURE -gt "$CPU_TEMPERATURE_THRESHOLD" ]; }
-function CPU2_OVERHEATING() { [ $CPU2_TEMPERATURE -gt "$CPU_TEMPERATURE_THRESHOLD" ]; }
+# Formats a temperature reading as a right-aligned, 3-character-wide decimal number for display.
+# Falls back to "  -" instead of letting printf %d crash when the reading is empty, a placeholder ("-"),
+# or has a leading zero that would otherwise be misinterpreted as an invalid octal number (e.g. "09")
+function format_temperature_for_display() {
+  local -r VALUE="$1"
+  if [[ "$VALUE" =~ ^[0-9]+$ ]]; then
+    printf '%3d' "$((10#$VALUE))"
+  else
+    printf '%3s' "-"
+  fi
+}
+
+# Define functions to check if CPU 1 and CPU 2 temperatures are above the threshold.
+# If a reading isn't a valid number (missing sensor, transient IPMI parsing glitch, etc.), fail safe and
+# report overheating so the Dell default fan control profile kicks in, instead of crashing (bash's "-gt"
+# throws "unary operator expected" on empty/non-numeric input) or silently running the low user fan speed
+# on unverified data
+function CPU1_OVERHEATING() {
+  [[ "$CPU1_TEMPERATURE" =~ ^[0-9]+$ ]] || return 0
+  [ "$((10#$CPU1_TEMPERATURE))" -gt "$CPU_TEMPERATURE_THRESHOLD" ]
+}
+function CPU2_OVERHEATING() {
+  [[ "$CPU2_TEMPERATURE" =~ ^[0-9]+$ ]] || return 0
+  [ "$((10#$CPU2_TEMPERATURE))" -gt "$CPU_TEMPERATURE_THRESHOLD" ]
+}
 
 function print_error() {
   local -r ERROR_MESSAGE="$1"


### PR DESCRIPTION
Closes #104. Closes #117. Refs #91.

## Summary

The script had no defense against a temperature reading that isn't a clean positive integer, and the sdr parsing itself could produce such readings. Four related fixes.

### 1. Fail safe instead of crashing on an invalid reading

`CPU1_OVERHEATING`/`CPU2_OVERHEATING` ran `[ $TEMP -gt $THRESHOLD ]` directly. An empty or non-numeric reading (missing sensor, transient IPMI glitch, a parsing bug) crashed with `unary operator expected` and — the script not running in strict mode — silently fell through as "not overheating", so the user's low fan speed kept being applied to data that was never verified. Both functions now validate the reading and, if it isn't a plain non-negative integer, report overheating so the Dell default profile is applied.

The display formatter had the identical crash (`printf "%3d"` on `-`), plus it mis-parsed leading-zero values as invalid octal (`09`). It is replaced by a helper that forces base 10 and falls back to a `-` placeholder.

### 2. Locate CPU sensors by IPMI entity ID instead of by position

CPU temperatures were located by counting the two-digit values extracted from the whole sdr line, which needed a per-generation offset (`CPU1_TEMPERATURE_INDEX`/`CPU2_TEMPERATURE_INDEX`) to compensate for the hexadecimal ID column contributing a second value on some servers.

That offset was keyed on the server generation, which is only a proxy for the real criterion. An R930 is Gen 13 yet needs the Gen 14 offsets, precisely because its CPU sensors are numbered `06h` to `09h` — all digits — while an R730's are `0Eh`/`0Fh`. That mismatch is the root cause reported in #91.

Entity IDs make the criterion explicit and generation-independent: entity 3 is the processor, so `3.1` is CPU 1 and `3.2` is CPU 2, whatever the hexadecimal IDs are and whatever order iDRAC returns the sensors in. `CPU1_TEMPERATURE_INDEX`/`CPU2_TEMPERATURE_INDEX` are gone. `DELL_POWEREDGE_GEN_14_OR_NEWER` remains, it now only gates the third-party PCIe cooling response.

Inlet and exhaust parsing keeps matching on the sensor name: both are entity `7.1` on Dell servers, so the name is the only way to tell them apart.

### 3. Don't count the absent-sensor placeholder as a detected CPU

`CPU2_TEMPERATURE` is set to `"-"` when the sensor is known to be absent, but `[ -n "$CPU2_TEMPERATURE" ]` counted that placeholder as a second CPU. The header is built once from the first reading, taken before the placeholder exists, so it had one CPU column while every subsequent line had two — that is the `printf: -: invalid number` reported in #104 and #117.

An unreadable CPU 1 reading now also falls back to the placeholder, so its column isn't dropped by the whitespace split and the following ones aren't shifted left.

### 4. Don't truncate three-digit temperatures

The reading was extracted with a fixed two-digit pattern, so `100 degrees C` was read as 10°C — far below any sensible threshold, keeping the user's static profile applied to a CPU that should have triggered the Dell default one. Matching on the `degrees` suffix reads one, two and three digit values alike.

## Testing

Run against a mocked `ipmitool` replaying the raw `sdr type temperature` output posted in the issues, driving the real script end to end and asserting on the IPMI fan commands actually emitted.

| Scenario | Before | After |
|---|---|---|
| R730, dual CPU (dump from #125) | 45 / 47 °C | 45 / 47 °C |
| T330, single CPU, no exhaust (dump from #117) | `printf: -: invalid number` every cycle | 73 °C, aligned table |
| R930, 4 CPUs, all-digit sensor IDs (dump from #91) | `printf: 09: invalid octal number`, CPU 1 = 0 °C | 39 / 38 °C, the actual entities 3.1 / 3.2 |
| Gen 14 dual CPU, both plausible sensor ID layouts | correct, but only via a generation-specific offset | 44 / 46 °C, no offset involved |
| CPU sensor missing | `[: -gt: unary operator expected`, user profile at 5% applied | `-°C`, Dell default profile applied |
| CPU at 100 °C | read as 10 °C, user profile at 5% kept | 100 °C, Dell default profile applied |

`bash -n` on all four scripts. The `awk` usage is checked against `mawk` 1.3.4, the default `awk` in `ubuntu:latest`, and `grep -P` against the image's PCRE support.

## Not fixed here

#91 stays open: CPUs 3 and 4 are still not monitored, which is what its title asks for. It is a small addition now though — reading entities `3.3` and `3.4` through the same helper, the display loop already handling a variable number of CPUs.

No raw Gen 14 `sdr` dump could be found, in the issues or online, to confirm which sensor ID layout those servers actually use. The entity-based parsing returns the correct value under either layout, which is why the question is no longer blocking.