### PR TITLE
Dependabot: weekly grouped GitHub Actions updates + auto-merge for minor/patch ones

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,22 @@
 
 version: 2
 updates:
- - package-ecosystem: "devcontainers"
-   directory: "/"
-   schedule:
-     interval: weekly
+  - package-ecosystem: "devcontainers"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      # Minor and patch updates are grouped into a single PR,
+      # auto-merged by the dependabot-auto-merge workflow.
+      # Major updates stay out of the group: one separate PR each,
+      # waiting for manual review (potentially breaking changes).
+      github-actions-minor-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -10,6 +10,7 @@ jobs:
   auto-merge:
     name: Auto-merge minor and patch GitHub Actions updates
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: github.event.pull_request.user.login == 'dependabot[bot]'
     steps:
       - name: Fetch Dependabot metadata
@@ -18,13 +19,18 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      # Major updates are excluded: their PRs wait for manual review
+      # Major updates are excluded: their PRs wait for manual review.
+      # 'gh pr merge --auto' requires "Allow auto-merge" in the repo
+      # settings plus branch protection with required checks; when either
+      # is missing it exits non-zero, so fall back to an immediate direct
+      # merge (if branch protection exists, it still blocks any direct
+      # merge that would skip required checks).
       - name: Enable auto-merge
         if: >-
           steps.metadata.outputs.package-ecosystem == 'github_actions' &&
           (steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
            steps.metadata.outputs.update-type == 'version-update:semver-patch')
-        run: gh pr merge --auto --squash "$PR_URL"
+        run: gh pr merge --auto --squash "$PR_URL" || gh pr merge --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,30 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    name: Auto-merge minor and patch GitHub Actions updates
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Major updates are excluded: their PRs wait for manual review
+      - name: Enable auto-merge
+        if: >-
+          steps.metadata.outputs.package-ecosystem == 'github_actions' &&
+          (steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
+           steps.metadata.outputs.update-type == 'version-update:semver-patch')
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Closes #137

## Goal

Have Dependabot open PRs every week for out-of-date GitHub Actions, in two streams:

- **minor/patch**: a single grouped PR (`github-actions-minor-patch`) → merged automatically
- **major**: a separate PR per action → waits for your review (potentially breaking changes, cf. `checkout` v7)

## Changes

- `.github/dependabot.yml`: added the `github-actions` ecosystem (weekly) with a group limited to `minor` and `patch` updates. Major ones stay outside the group, hence in individual PRs. The existing `devcontainers` entry is kept (indentation simply normalized to 2 spaces).
- `.github/workflows/dependabot-auto-merge.yml`: new workflow that merges Dependabot PRs, only if the ecosystem is `github_actions` **and** the update is minor or patch (metadata via `dependabot/fetch-metadata@v2`). Major ones are never auto-merged, and `devcontainers` PRs are not concerned. Hardened since the first version: it tries `gh pr merge --auto` (a merge that waits for the required checks) and, if auto-merge cannot be enabled on the repository, falls back to an **immediate direct merge**; `timeout-minutes` added.

## To check / enable on the repository settings side

- For the merge to **wait for a CI**: tick **"Allow auto-merge"** in *Settings → General → Pull Requests* **and** define a branch protection with required checks. Without that, the fallback merges the grouped PR immediately — accepted behaviour for minor/patch action updates, but worth knowing.
- The current build workflow only triggers on `v*` tags, so no check runs on PRs today: if you want a safeguard, it will take a check triggered on `pull_request` + a branch protection requiring it.

Actions currently used in this repository (concerned by these updates): `actions/checkout@v4`, `softprops/action-gh-release@v1`, `docker/login-action@v3`, `docker/metadata-action@v5`, `docker/setup-qemu-action@v3`, `docker/setup-buildx-action@v3`, `docker/build-push-action@v4`.
