### PR TITLE
Read inlet and exhaust temperatures whatever their number of digits

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -86,12 +86,29 @@ function set_iDRAC_login_string() {
   fi
 }
 
+# Extract the temperature reading carried by a single ipmitool sdr line
+# Usage : extract_temperature_from_sdr_line "$SDR_LINE"
+# Returns : the temperature in degrees Celsius, or an empty string if that line carries no reading
+#
+# An sdr line looks like "Temp             | 09h | ok  |  3.1 | 45 degrees C", the reading being its
+# 5th pipe-delimited column. Isolating that column first keeps the other ones (most notably the
+# sensor's hexadecimal ID) from contributing digits of their own.
+#
+# The value is matched on its "degrees" suffix rather than on a fixed two-digit width, so that its
+# width stops mattering : "100 degrees C" used to be truncated to 10°C, and "9 degrees C" used to
+# match nothing at all, which callers cannot tell apart from a missing sensor
+function extract_temperature_from_sdr_line() {
+  local -r SDR_LINE="$1"
+
+  echo "$SDR_LINE" | cut -d'|' -f5 | grep -Po '\d+(?=[[:space:]]*degrees)'
+}
+
 # Extract a single temperature reading from ipmitool sdr output, located by its IPMI entity ID
 # Usage : retrieve_temperature_by_entity_id "$SDR_DATA" $ENTITY_ID
 # Returns : the temperature in degrees Celsius, or an empty string if that entity has no reading
 #
-# An sdr line looks like "Temp             | 09h | ok  |  3.1 | 45 degrees C", the 4th pipe-delimited
-# column being the entity ID. Entity 3 is the processor, so 3.1 is CPU 1, 3.2 is CPU 2, and so on.
+# The entity ID is the 4th pipe-delimited column of an sdr line. Entity 3 is the processor, so 3.1 is
+# CPU 1, 3.2 is CPU 2, and so on.
 #
 # Locating a CPU by its entity rather than by counting values makes the parsing independent from the
 # sensors' hexadecimal IDs, from the order iDRAC returns them in, and therefore from the server
@@ -103,12 +120,31 @@ function retrieve_temperature_by_entity_id() {
   local -r SDR_DATA="$1"
   local -r ENTITY_ID="$2"
 
-  # The reading is matched on the "degrees" suffix rather than on a fixed two-digit width, so that an
-  # overheating CPU reporting three digits isn't truncated : "100 degrees C" used to be read as 10°C,
-  # silently keeping the user's low fan speed on a CPU that needed the Dell default profile
-  echo "$SDR_DATA" | awk -F'|' -v entity="$ENTITY_ID" '
-    { gsub(/^[[:space:]]+|[[:space:]]+$/, "", $4) }
-    $4 == entity { print $5; exit }' | grep -Po '\d+(?=[[:space:]]*degrees)'
+  # The entity ID is trimmed through a copy rather than in place, so that the line is printed
+  # untouched : assigning to a field makes awk rebuild the whole record with OFS (a space) as its
+  # separator, which would strip the pipe delimiters the extraction relies on
+  local -r SDR_LINE=$(echo "$SDR_DATA" | awk -F'|' -v entity="$ENTITY_ID" '
+    { entity_id = $4; gsub(/^[[:space:]]+|[[:space:]]+$/, "", entity_id) }
+    entity_id == entity { print; exit }')
+
+  extract_temperature_from_sdr_line "$SDR_LINE"
+}
+
+# Extract a single temperature reading from ipmitool sdr output, located by its sensor name
+# Usage : retrieve_temperature_by_sensor_name "$SDR_DATA" "$SENSOR_NAME"
+# Returns : the temperature in degrees Celsius, or an empty string if no such sensor has a reading
+#
+# Inlet and exhaust are both reported as entity 7.1 on Dell servers, so their name is the only thing
+# telling them apart and they cannot use retrieve_temperature_by_entity_id()
+function retrieve_temperature_by_sensor_name() {
+  local -r SDR_DATA="$1"
+  local -r SENSOR_NAME="$2"
+
+  # On the (unexpected) event of several sensors matching the name, the last one wins, as it did when
+  # the reading was picked with "grep -Po ... | tail -1"
+  local -r SDR_LINE=$(echo "$SDR_DATA" | grep "$SENSOR_NAME" | tail -1)
+
+  extract_temperature_from_sdr_line "$SDR_LINE"
 }
 
 # Retrieve temperature sensors data using ipmitool
@@ -149,12 +185,12 @@ function retrieve_temperatures() {
     ((NUMBER_OF_DETECTED_CPUS++))
   fi
 
-  # Parse inlet temperature data
-  INLET_TEMPERATURE=$(echo "$DATA" | grep Inlet | cut -d'|' -f5 | grep -Po '\d{2}' | tail -1)
+  # Parse inlet temperature data, the sensor being located by its name
+  INLET_TEMPERATURE=$(retrieve_temperature_by_sensor_name "$DATA" "Inlet")
 
   # If exhaust temperature sensor is present, parse its temperature data
   if $IS_EXHAUST_TEMPERATURE_SENSOR_PRESENT; then
-    EXHAUST_TEMPERATURE=$(echo "$DATA" | grep Exhaust | cut -d'|' -f5 | grep -Po '\d{2}' | tail -1)
+    EXHAUST_TEMPERATURE=$(retrieve_temperature_by_sensor_name "$DATA" "Exhaust")
   else
     EXHAUST_TEMPERATURE="-"
   fi


### PR DESCRIPTION
Closes #145. Follow-up to #134 (b0ff306), which fixed the same defect for CPU readings only.

## Problem

Inlet and exhaust readings were extracted with `grep -Po '\d{2}'`, a pattern matching *exactly* two digits, so anything outside the 10–99 range was misread.

**3-digit readings were truncated.** `100 degrees C` came out as `10`. Exhaust is the sensor most likely to reach three digits, and a heavily loaded server held at a low manual fan speed is precisely the situation where the operator needs that number to be right. Both values are display-only, so no hardware was ever endangered — but the temperature table is what users paste into issue reports, so a wrong value here actively misleads troubleshooting.

**Single-digit readings came back empty**, and that one reaches past the display. `Dell_iDRAC_fan_controller.sh:84` reads an empty value as a missing sensor, and `IS_EXHAUST_TEMPERATURE_SENSOR_PRESENT` is never re-evaluated afterwards: a server whose exhaust sensor happened to read below 10 °C on the very first poll got exhaust monitoring disabled for the whole run, and was told it had no exhaust sensor at all. An inlet below 10 °C (cold room, garage, winter) is realistic too — for that one `format_temperature_for_display()` caught the empty value and the damage stopped at a `-` in the table.

## Change

Both readings are now matched on their `degrees` suffix, as CPU readings already were, which reads one, two and three digit values alike:

```bash
grep -Po '\d+(?=[[:space:]]*degrees)'
```

The three call sites converge on a single `extract_temperature_from_sdr_line()` helper holding that pattern, so the next parsing fix doesn't have to be applied in three places again. Above it sit the two ways of locating a line:

- `retrieve_temperature_by_entity_id()` — unchanged behaviour, used for CPUs.
- `retrieve_temperature_by_sensor_name()` — new, used for inlet and exhaust. Both are entity 7.1 on Dell servers, so their name remains the only way to tell them apart and they can't reuse the by-entity lookup.

One subtlety while splitting the entity lookup: it used to trim the entity ID field in place, and assigning to a field makes `awk` rebuild the record with `OFS` (a space) as separator, which would strip the pipe delimiters the extraction now relies on. The trim is done through a copy instead, so the line is passed on untouched.

## Verification

No test harness exists in the repository, so the helpers were exercised against representative `ipmitool sdr type temperature` output — the R730 shape, the R930 shape from #91 (4 CPUs, two-digit hexadecimal sensor IDs, unordered entities), plus the two failure modes and the absent-sensor cases. 24 checks, all passing:

| Case | Before | After |
| --- | --- | --- |
| Inlet `100 degrees C` | `10` | `100` |
| Exhaust `105 degrees C` | `10` | `105` |
| Inlet `9 degrees C` | *(empty)* | `9` |
| Exhaust `8 degrees C` | *(empty)* → exhaust monitoring disabled for the run | `8` |
| Inlet/exhaust/CPU, normal 2-digit values | correct | unchanged |
| CPU 1/2 on R930 (hex IDs `06h`–`09h`) | correct | unchanged |
| Absent exhaust / CPU 2 sensor | empty → detected as absent | unchanged |
| Exhaust known absent | `-` placeholder | unchanged |

A 3-digit exhaust value keeps its column alignment in the table, the field already being printed with `%5s`.

## Out of scope

Two neighbouring points, deliberately left alone:

- `IS_EXHAUST_TEMPERATURE_SENSOR_PRESENT` is still evaluated once, from the very first reading. The parsing bug was the reason a working sensor could be misdetected, and that's fixed here — but a transient failure on that first poll would still disable exhaust monitoring for the whole run. Happy to open a separate issue if you want that probe made resilient.
- #49 (behaviour change below 10 °C inlet) is unblocked by this fix, not implemented by it.

Credit to @kchiem, who had already spotted this parsing was fragile while working on #64.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y5bKA3yKVYcVmUgsXRxjnM)_