### PR TITLE
Add an automated test suite covering every Dell PowerEdge generation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 .github
 .devcontainer
 README.md
+tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,45 @@
+name: Tests
+
+on:
+  push:
+    paths-ignore:
+      - "**/README.md"
+  pull_request:
+    paths-ignore:
+      - "**/README.md"
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: Run the test suite
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run the test suite
+        run: ./tests/run_tests.sh
+
+  test-in-docker-image:
+    name: Run the test suite inside the Docker image
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build the Docker image
+        run: docker build --tag dell_idrac_fan_controller:test .
+
+      # Running the suite inside the image checks the published runtime itself
+      # (its bash, its GNU grep and awk) on top of the controller's behavior, and
+      # runs as root, which the few test cases needing a fake /dev/ipmi device
+      # skip on the runner
+      - name: Run the test suite inside the image
+        run: |
+          docker run --rm \
+            --entrypoint /bin/bash \
+            --volume "$PWD/tests:/app/tests:ro" \
+            dell_idrac_fan_controller:test \
+            /app/tests/run_tests.sh

--- a/README.md
+++ b/README.md
@@ -250,6 +250,21 @@ chmod +x Dell_iDRAC_fan_controller.sh
 ./Dell_iDRAC_fan_controller.sh
 ```
 
+### Automated tests
+
+The repository ships an automated test suite that runs the controller against a mocked `ipmitool`, so it needs **no Dell hardware, no iDRAC and no network** : `bash`, `coreutils`, GNU `grep` and `awk` are enough.
+
+```bash
+./tests/run_tests.sh                 # run everything
+./tests/run_tests.sh --list          # list the test cases without running them
+./tests/run_tests.sh -f temperature  # only run the test cases whose name matches
+./tests/run_tests.sh --tap           # emit TAP output for a CI parser
+```
+
+It covers every PowerEdge generation from the 9th (2006) to the 17th (2024) — including the recent ones whose firmware no longer accepts Dell's IPMI raw fan control commands — in their single, dual and quad socket variants, plus the sensor layouts they report (missing exhaust sensor, empty second socket, unreadable reading, two-digit sensor IDs...).
+
+The suite also runs on every push and pull request through the [`Tests`](.github/workflows/tests.yml) workflow, both directly and inside the built Docker image. See [`tests/README.md`](./tests/README.md) for the layout and for how to add a test case.
+
 <p align="right">(<a href="#top">back to top</a>)</p>
 
 <!-- LICENSE -->

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,83 @@
+# Test suite
+
+Automated tests for the Dell iDRAC fan controller. Everything runs against a
+mocked `ipmitool`, so the suite needs **no Dell hardware, no iDRAC and no
+network** : `bash`, `coreutils`, GNU `grep` and `awk` are enough.
+
+```bash
+./tests/run_tests.sh                 # run everything
+./tests/run_tests.sh --list          # list the test cases without running them
+./tests/run_tests.sh -f temperature  # only run the test cases whose name matches
+./tests/run_tests.sh --tap           # emit TAP version 13 output for a CI parser
+./tests/run_tests.sh --no-color      # disable colored output
+```
+
+It exits `0` when every test case passed, `1` otherwise.
+
+## What is covered
+
+| File | What it checks |
+| --- | --- |
+| `cases/10_shell_scripts.sh` | Syntax of every script, files shipped in the Docker image, healthcheck |
+| `cases/20_fan_speed_conversions.sh` | `FAN_SPEED` given as a percentage or as a hexadecimal byte |
+| `cases/30_idrac_login_string.sh` | Local (`/dev/ipmi0`) and network (`lanplus`) modes, password handling |
+| `cases/40_temperature_parsing.sh` | Reading the sensors out of `ipmitool sdr type temperature` |
+| `cases/50_server_model_detection.sh` | Identifying the server, and detecting Gen 14 or newer |
+| `cases/60_cpu_topologies.sh` | 1, 2 and 4 socket servers, missing sensors, table layout |
+| `cases/70_fan_control_profiles.sh` | The raw commands sent to the server, and their rejections |
+| `cases/80_temperature_thresholds.sh` | The overheating decision, including its fail-safe behavior |
+| `cases/85_power_state.sh` | Skipping the cycle when the target server is powered off |
+| `cases/90_integration.sh` | The whole controller, started like its Docker image does |
+
+Server generations are covered from the catalogue in
+`lib/dell_server_catalogue.sh`, which lists more than a hundred PowerEdge models
+from the 9th generation (2006) to the 17th (2024), each with its socket count and
+whether its firmware still accepts Dell's IPMI raw fan control commands.
+
+## Layout
+
+```
+tests/
+├── run_tests.sh                    entry point : discovers, runs and reports
+├── cases/                          the test cases themselves
+├── lib/
+│   ├── assertions.sh               assert_equals, assert_contains, fail, skip_test...
+│   ├── dell_server_catalogue.sh    every Dell PowerEdge model the suite knows about
+│   ├── fixtures.sh                 builders for the ipmitool outputs (FRU, SDR)
+│   └── harness.sh                  the environment a test case runs in, and its helpers
+└── mocks/                          fake ipmitool, date and sleep, put first in the PATH
+```
+
+Each test case runs in its own subshell, starting from the environment
+`setup_test_context` prepares : the mocks first in the `PATH`, and every variable
+the controller expects from its Docker image set to the Dockerfile's default. A
+test case only has to set what it is about.
+
+## Adding a test case
+
+Add a function named `test_<what it checks>` to the relevant file in `cases/` :
+the runner picks it up on its own, in declaration order, and turns its name into
+the line it reports. Nothing else to register.
+
+```bash
+function test_a_single_cpu_server_reports_one_cpu() {
+  export MOCK_IPMITOOL_SDR_OUTPUT
+  MOCK_IPMITOOL_SDR_OUTPUT=$(make_sdr_output --cpus 1 --cpu-temperatures "44")
+
+  retrieve_temperatures true true
+
+  assert_equals "1" "$NUMBER_OF_DETECTED_CPUS"
+}
+```
+
+Assertions record their outcome and let the test case carry on, so a loop over a
+hundred server models reports every offending model in one run. Use
+`assert_... || return 1` when the rest of the test case cannot run once the
+assertion failed.
+
+Describing the server to simulate is done through `simulate_server`,
+`make_fru_output` and `make_sdr_output` (see `lib/fixtures.sh` for their options),
+and what the server answers to a given command through the
+`MOCK_IPMITOOL_*` variables (see `mocks/ipmitool`). `count_ipmitool_calls_matching`
+reads back what was actually sent to it, and `run_controller` starts the whole
+controller the way its Docker image does.

--- a/tests/cases/10_shell_scripts.sh
+++ b/tests/cases/10_shell_scripts.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+# Checks on the scripts themselves, before any behavior is exercised : a syntax
+# error or a file missing from the Docker image breaks every server at once,
+# whatever its generation.
+
+function test_every_shell_script_has_a_valid_syntax() {
+  local SCRIPT
+  for SCRIPT in \
+    "$REPO_ROOT"/*.sh \
+    "$TESTS_DIRECTORY"/*.sh \
+    "$TESTS_DIRECTORY"/lib/*.sh \
+    "$TESTS_DIRECTORY"/cases/*.sh \
+    "$TESTS_DIRECTORY"/mocks/*; do
+    [ -f "$SCRIPT" ] || continue
+
+    local SYNTAX_ERRORS
+    if SYNTAX_ERRORS=$(bash -n "$SCRIPT" 2>&1); then
+      pass
+    else
+      fail "${SCRIPT#$REPO_ROOT/} has a syntax error" "$SYNTAX_ERRORS"
+    fi
+  done
+}
+
+function test_sourcing_functions_only_declares_functions() {
+  # functions.sh is sourced by the controller, by the healthcheck and by this
+  # suite : it must not run anything nor print anything on its own
+  local OUTPUT
+  OUTPUT=$(bash -c "source '$REPO_ROOT/functions.sh'" 2>&1)
+  local -r EXIT_CODE=$?
+
+  assert_equals 0 "$EXIT_CODE" "sourcing functions.sh should succeed"
+  assert_empty "$OUTPUT" "sourcing functions.sh should not print anything"
+}
+
+function test_every_file_sourced_at_runtime_is_shipped_in_the_docker_image() {
+  if [ ! -f "$REPO_ROOT/Dockerfile" ]; then
+    # The suite is running inside the built image, which does not carry the
+    # Dockerfile that produced it
+    skip_test "no Dockerfile next to the scripts"
+    return 0
+  fi
+
+  local -r DOCKERFILE_CONTENT=$(cat "$REPO_ROOT/Dockerfile")
+
+  local SOURCED_FILE
+  while IFS= read -r SOURCED_FILE; do
+    [ -n "$SOURCED_FILE" ] || continue
+
+    if [ ! -f "$REPO_ROOT/$SOURCED_FILE" ]; then
+      fail "$SOURCED_FILE is sourced at runtime but does not exist"
+      continue
+    fi
+
+    assert_matches "$DOCKERFILE_CONTENT" "(ADD|COPY) $SOURCED_FILE " \
+      "$SOURCED_FILE is sourced at runtime, the Dockerfile must copy it into the image"
+  done < <(grep -hoE '^source [A-Za-z0-9_.-]+\.sh' \
+    "$REPO_ROOT/Dell_iDRAC_fan_controller.sh" "$REPO_ROOT/healthcheck.sh" |
+    awk '{print $2}' | sort -u)
+}
+
+function test_the_healthcheck_succeeds_when_the_sensors_can_be_read() {
+  local OUTPUT
+  OUTPUT=$(bash "$REPO_ROOT/healthcheck.sh" 2>&1)
+  local -r EXIT_CODE=$?
+
+  assert_equals 0 "$EXIT_CODE" "the healthcheck should succeed when ipmitool answers"
+  assert_contains "$OUTPUT" "degrees C" "the healthcheck should print the sensor readings"
+}
+
+function test_the_healthcheck_fails_when_the_sensors_cannot_be_read() {
+  export MOCK_IPMITOOL_SDR_EXIT_CODE=1
+  export MOCK_IPMITOOL_SDR_OUTPUT=""
+
+  local EXIT_CODE=0
+  bash "$REPO_ROOT/healthcheck.sh" > /dev/null 2>&1 || EXIT_CODE=$?
+
+  assert_not_equals 0 "$EXIT_CODE" "the healthcheck should fail when ipmitool fails, so Docker restarts the container"
+}

--- a/tests/cases/20_fan_speed_conversions.sh
+++ b/tests/cases/20_fan_speed_conversions.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# FAN_SPEED can be given either as a percentage (5) or as the hexadecimal byte
+# ipmitool actually sends (0x05), and the controller keeps both representations :
+# the decimal one for the logs, the hexadecimal one for the raw IPMI command.
+
+function test_a_decimal_fan_speed_is_converted_to_hexadecimal() {
+  assert_equals "0x00" "$(convert_decimal_value_to_hexadecimal 0)"
+  assert_equals "0x05" "$(convert_decimal_value_to_hexadecimal 5)" "5% is the Docker image's default fan speed"
+  assert_equals "0x0a" "$(convert_decimal_value_to_hexadecimal 10)"
+  assert_equals "0x32" "$(convert_decimal_value_to_hexadecimal 50)"
+  assert_equals "0x64" "$(convert_decimal_value_to_hexadecimal 100)" "100% is the documented maximum fan speed"
+}
+
+function test_a_hexadecimal_fan_speed_is_converted_to_decimal() {
+  assert_equals "0" "$(convert_hexadecimal_value_to_decimal 0x00)"
+  assert_equals "5" "$(convert_hexadecimal_value_to_decimal 0x05)"
+  assert_equals "10" "$(convert_hexadecimal_value_to_decimal 0x0a)"
+  assert_equals "50" "$(convert_hexadecimal_value_to_decimal 0x32)"
+  assert_equals "100" "$(convert_hexadecimal_value_to_decimal 0x64)"
+}
+
+function test_an_uppercase_hexadecimal_fan_speed_is_accepted() {
+  # The README documents lowercase values, nothing stops a user from typing 0x0A
+  assert_equals "10" "$(convert_hexadecimal_value_to_decimal 0x0A)"
+  assert_equals "255" "$(convert_hexadecimal_value_to_decimal 0xFF)"
+}
+
+function test_a_hexadecimal_fan_speed_is_always_a_lowercase_two_digit_byte() {
+  # ipmitool expects a byte : a bare "0x5" would be sent as an incomplete value
+  local DECIMAL_VALUE
+  for DECIMAL_VALUE in 0 1 9 15 16 100 171 255; do
+    assert_matches "$(convert_decimal_value_to_hexadecimal "$DECIMAL_VALUE")" '^0x[0-9a-f]{2}$' \
+      "$DECIMAL_VALUE% should be converted to a two-digit lowercase hexadecimal byte"
+  done
+  assert_equals "0xab" "$(convert_decimal_value_to_hexadecimal 171)"
+}
+
+function test_every_valid_fan_speed_percentage_survives_a_round_trip() {
+  local PERCENTAGE
+  for ((PERCENTAGE = 0; PERCENTAGE <= 100; PERCENTAGE++)); do
+    local HEXADECIMAL_VALUE
+    HEXADECIMAL_VALUE=$(convert_decimal_value_to_hexadecimal "$PERCENTAGE")
+    assert_equals "$PERCENTAGE" "$(convert_hexadecimal_value_to_decimal "$HEXADECIMAL_VALUE")" \
+      "$PERCENTAGE% should survive the decimal -> hexadecimal -> decimal round trip"
+  done
+
+  # Out of the documented 0-100 range, but a user typo must not silently become
+  # another, valid speed : 256 stays 256 instead of wrapping around to 0
+  assert_equals "0x100" "$(convert_decimal_value_to_hexadecimal 256)"
+  assert_equals "256" "$(convert_hexadecimal_value_to_decimal 0x100)"
+}

--- a/tests/cases/30_idrac_login_string.sh
+++ b/tests/cases/30_idrac_login_string.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# The controller talks to the iDRAC either through the host's IPMI device
+# ("local" mode, the container runs on the server it cools) or over the network
+# ("lanplus"). Everything else in the script depends on the login string built
+# here, and the password must never leak into the container's process list.
+
+function test_local_mode_uses_the_open_interface() {
+  local IPMI_DEVICE_CREATED=false
+
+  if [ ! -e /dev/ipmi0 ] && [ ! -e /dev/ipmi/0 ] && [ ! -e /dev/ipmidev/0 ]; then
+    # No real IPMI device here : fake the one the function looks for. /dev is
+    # only writable when the suite runs as root (in the Docker image, or in a
+    # CI container), so give up gracefully rather than fail elsewhere
+    if ! (mkdir -p /dev/ipmi && touch /dev/ipmi/0) 2> /dev/null; then
+      skip_test "no IPMI device available and /dev is not writable"
+      return 0
+    fi
+    IPMI_DEVICE_CREATED=true
+  fi
+
+  set_iDRAC_login_string "local" "root" "calvin"
+  assert_equals "open" "$IDRAC_LOGIN_STRING"
+
+  if $IPMI_DEVICE_CREATED; then
+    rm -f /dev/ipmi/0
+    rmdir /dev/ipmi 2> /dev/null
+  fi
+}
+
+function test_local_mode_stops_the_controller_when_no_ipmi_device_is_exposed() {
+  if [ -e /dev/ipmi0 ] || [ -e /dev/ipmi/0 ] || [ -e /dev/ipmidev/0 ]; then
+    skip_test "this machine really has an IPMI device"
+    return 0
+  fi
+
+  local OUTPUT
+  OUTPUT=$(set_iDRAC_login_string "local" "root" "calvin" 2>&1)
+  local -r EXIT_CODE=$?
+
+  assert_equals 1 "$EXIT_CODE" "local mode without an IPMI device should stop the controller"
+  assert_contains "$OUTPUT" "/dev/ipmi0" "the error should name the device paths that were looked for"
+  assert_contains "$OUTPUT" "/dev/ipmi/0"
+  assert_contains "$OUTPUT" "/dev/ipmidev/0"
+  assert_contains "$OUTPUT" "stop using local mode" "the error should tell the user how to recover"
+}
+
+function test_network_mode_builds_a_lanplus_login_string() {
+  set_iDRAC_login_string "192.168.1.100" "root" "calvin" > /dev/null
+
+  assert_equals "lanplus -H 192.168.1.100 -U root -E" "$IDRAC_LOGIN_STRING"
+}
+
+function test_network_mode_never_puts_the_password_on_the_command_line() {
+  # -P would expose the password in `ps aux` and in /proc/<pid>/cmdline
+  set_iDRAC_login_string "192.168.1.100" "root" "SuperSecret" > /dev/null
+
+  assert_not_contains "$IDRAC_LOGIN_STRING" "SuperSecret" "the password must not end up in the ipmitool arguments"
+  assert_not_contains "$IDRAC_LOGIN_STRING" "-P" "the password must be passed through the environment, not with -P"
+  assert_contains "$IDRAC_LOGIN_STRING" "-E" "ipmitool must be told to read the password from IPMI_PASSWORD"
+  assert_equals "SuperSecret" "$IPMI_PASSWORD" "the password must be exported as IPMI_PASSWORD"
+}
+
+function test_network_mode_logs_the_username_but_never_the_password() {
+  local OUTPUT
+  OUTPUT=$(set_iDRAC_login_string "192.168.1.100" "administrator" "SuperSecret" 2>&1)
+
+  assert_contains "$OUTPUT" "administrator" "the username is logged to help debugging"
+  assert_not_contains "$OUTPUT" "SuperSecret" "the password must never be logged"
+}
+
+function test_network_mode_preserves_a_password_containing_special_characters() {
+  local -r COMPLEX_PASSWORD='a b$c"d'"'"'e\f'
+  set_iDRAC_login_string "192.168.1.100" "root" "$COMPLEX_PASSWORD" > /dev/null
+
+  assert_equals "$COMPLEX_PASSWORD" "$IPMI_PASSWORD" "the password must reach ipmitool untouched"
+}

--- a/tests/cases/40_temperature_parsing.sh
+++ b/tests/cases/40_temperature_parsing.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+
+# Parsing of "ipmitool sdr type temperature". This is where the generation of the
+# server used to leak into the code : sensor hexadecimal IDs, sensor ordering and
+# reading widths all vary from one PowerEdge generation to the next, so every
+# reading is located by its IPMI entity ID (or by its name for inlet and exhaust,
+# which share entity 7.1) and extracted from the reading column only.
+
+function test_a_temperature_is_read_from_a_standard_sensor_line() {
+  local -r SDR_LINE=$(make_sdr_line "Temp" "0Eh" "ok" "3.1" "45 degrees C")
+
+  assert_equals "45" "$(extract_temperature_from_sdr_line "$SDR_LINE")"
+}
+
+function test_a_single_digit_temperature_is_read() {
+  # A cold server idling in a cold room : "9 degrees C" used to match nothing,
+  # which callers could not tell apart from a missing sensor
+  local -r SDR_LINE=$(make_sdr_line "Inlet Temp" "04h" "ok" "7.1" "9 degrees C")
+
+  assert_equals "9" "$(extract_temperature_from_sdr_line "$SDR_LINE")"
+}
+
+function test_a_three_digit_temperature_is_read() {
+  # An overheating CPU : "100 degrees C" used to be truncated to 10 degrees,
+  # which would have kept the low user fan speed on a burning server
+  local -r SDR_LINE=$(make_sdr_line "Temp" "0Eh" "ok" "3.1" "100 degrees C")
+
+  assert_equals "100" "$(extract_temperature_from_sdr_line "$SDR_LINE")"
+}
+
+function test_the_hexadecimal_sensor_id_is_not_mistaken_for_a_temperature() {
+  # An R930 numbers its CPU sensors 09h, 0Ah... : the "09" used to be picked up
+  # as a reading of its own (issue #91)
+  local -r SDR_LINE=$(make_sdr_line "Temp" "09h" "ok" "3.1" "41 degrees C")
+
+  assert_equals "41" "$(extract_temperature_from_sdr_line "$SDR_LINE")"
+}
+
+function test_a_sensor_line_without_a_reading_yields_no_temperature() {
+  local -r DISABLED_SENSOR_LINE=$(make_sdr_line "Temp" "0Fh" "ns" "3.2" "Disabled")
+
+  assert_empty "$(extract_temperature_from_sdr_line "$DISABLED_SENSOR_LINE")" "a disabled sensor has no reading"
+  assert_empty "$(extract_temperature_from_sdr_line "")" "an empty line has no reading"
+}
+
+function test_each_cpu_is_located_by_its_ipmi_entity_id() {
+  local -r SDR_DATA=$(make_sdr_output --cpus 2 --cpu-temperatures "42 47")
+
+  assert_equals "42" "$(retrieve_temperature_by_entity_id "$SDR_DATA" "3.1")" "entity 3.1 is CPU 1"
+  assert_equals "47" "$(retrieve_temperature_by_entity_id "$SDR_DATA" "3.2")" "entity 3.2 is CPU 2"
+}
+
+function test_the_four_cpus_of_a_quad_socket_server_are_located_by_their_entity_ids() {
+  # R810, R910, R920, R930, R940, R860, R960... all report four processor entities
+  local -r SDR_DATA=$(make_sdr_output --cpus 4 --cpu-temperatures "41 40 39 38" --cpu-sensor-id-base 9)
+
+  assert_equals "41" "$(retrieve_temperature_by_entity_id "$SDR_DATA" "3.1")"
+  assert_equals "40" "$(retrieve_temperature_by_entity_id "$SDR_DATA" "3.2")"
+  assert_equals "39" "$(retrieve_temperature_by_entity_id "$SDR_DATA" "3.3")"
+  assert_equals "38" "$(retrieve_temperature_by_entity_id "$SDR_DATA" "3.4")"
+}
+
+function test_an_entity_id_is_matched_exactly_and_not_by_prefix() {
+  # A server with ten or more processor entities must not let 3.10 answer for 3.1
+  local -r SDR_DATA="$(make_sdr_line "Temp" "20h" "ok" "3.10" "70 degrees C")
+$(make_sdr_line "Temp" "0Eh" "ok" "3.1" "40 degrees C")"
+
+  assert_equals "40" "$(retrieve_temperature_by_entity_id "$SDR_DATA" "3.1")"
+  assert_equals "70" "$(retrieve_temperature_by_entity_id "$SDR_DATA" "3.10")"
+}
+
+function test_a_missing_or_disabled_sensor_yields_no_temperature() {
+  local -r SINGLE_SOCKET_DATA=$(make_sdr_output --cpus 1)
+  # Second socket physically empty : the sensor is listed but reports nothing
+  local -r EMPTY_SOCKET_DATA=$(make_sdr_output --cpus 2 --cpu2-disabled)
+  local -r NO_CHASSIS_SENSOR_DATA=$(make_sdr_output --no-inlet --no-exhaust)
+
+  assert_empty "$(retrieve_temperature_by_entity_id "$SINGLE_SOCKET_DATA" "3.2")" "a single socket server has no entity 3.2"
+  assert_empty "$(retrieve_temperature_by_entity_id "" "3.1")" "no data means no reading"
+  assert_not_empty "$(retrieve_temperature_by_entity_id "$EMPTY_SOCKET_DATA" "3.1")"
+  assert_empty "$(retrieve_temperature_by_entity_id "$EMPTY_SOCKET_DATA" "3.2")" "a disabled sensor has no reading"
+  assert_empty "$(retrieve_temperature_by_sensor_name "$NO_CHASSIS_SENSOR_DATA" "Inlet")"
+  assert_empty "$(retrieve_temperature_by_sensor_name "$NO_CHASSIS_SENSOR_DATA" "Exhaust")"
+}
+
+function test_inlet_and_exhaust_are_told_apart_by_their_name() {
+  # Both are reported as entity 7.1, so the entity ID cannot disambiguate them
+  local -r SDR_DATA=$(make_sdr_output --inlet 21 --exhaust 36)
+
+  assert_equals "21" "$(retrieve_temperature_by_sensor_name "$SDR_DATA" "Inlet")"
+  assert_equals "36" "$(retrieve_temperature_by_sensor_name "$SDR_DATA" "Exhaust")"
+}
+
+function test_the_last_matching_sensor_wins_when_several_share_a_name() {
+  # Big chassis report one inlet sensor per power supply on top of the main one
+  local -r SDR_DATA=$(make_sdr_output --inlet 21 --exhaust 36 --with-extra-sensors)
+
+  assert_equals "30" "$(retrieve_temperature_by_sensor_name "$SDR_DATA" "Inlet")" \
+    "PSU2 Inlet Temp is the last line matching \"Inlet\""
+}

--- a/tests/cases/50_server_model_detection.sh
+++ b/tests/cases/50_server_model_detection.sh
@@ -1,0 +1,177 @@
+#!/bin/bash
+
+# Identification of the server, and the single decision that depends on it :
+# whether it is a 14th generation PowerEdge or newer. Gen 14+ servers must not be
+# sent the third-party PCIe card cooling response command, which only exists on
+# Gen 13 and older.
+#
+# The catalogue driving these tests covers every generation from the 9th (2006)
+# to the 17th (2024), including the recent ones whose firmware no longer accepts
+# Dell's IPMI raw fan control commands at all.
+
+# Shared body of the nine per-generation test cases
+function assert_generation_is_detected_as_the_catalogue_expects() {
+  local -r GENERATION="$1"
+  local ENTRY MODEL EXPECTED_FLAG
+
+  while IFS= read -r ENTRY; do
+    IFS='|' read -r _ MODEL _ EXPECTED_FLAG _ <<< "$ENTRY"
+
+    local ACTUAL_FLAG=false
+    if is_detected_as_gen_14_or_newer "$MODEL"; then
+      ACTUAL_FLAG=true
+    fi
+
+    assert_equals "$EXPECTED_FLAG" "$ACTUAL_FLAG" \
+      "$MODEL (Gen $GENERATION) should be detected as gen 14 or newer = $EXPECTED_FLAG"
+  done < <(catalogue_entries_of_generation "$GENERATION")
+}
+
+function test_every_9th_generation_model_is_detected_as_the_catalogue_expects() {
+  assert_generation_is_detected_as_the_catalogue_expects 9
+}
+
+function test_every_10th_generation_model_is_detected_as_the_catalogue_expects() {
+  assert_generation_is_detected_as_the_catalogue_expects 10
+}
+
+function test_every_11th_generation_model_is_detected_as_the_catalogue_expects() {
+  assert_generation_is_detected_as_the_catalogue_expects 11
+}
+
+function test_every_12th_generation_model_is_detected_as_the_catalogue_expects() {
+  assert_generation_is_detected_as_the_catalogue_expects 12
+}
+
+function test_every_13th_generation_model_is_detected_as_the_catalogue_expects() {
+  assert_generation_is_detected_as_the_catalogue_expects 13
+}
+
+function test_every_14th_generation_model_is_detected_as_the_catalogue_expects() {
+  assert_generation_is_detected_as_the_catalogue_expects 14
+}
+
+function test_every_15th_generation_model_is_detected_as_the_catalogue_expects() {
+  assert_generation_is_detected_as_the_catalogue_expects 15
+}
+
+function test_every_16th_generation_model_is_detected_as_the_catalogue_expects() {
+  assert_generation_is_detected_as_the_catalogue_expects 16
+}
+
+function test_every_17th_generation_model_is_detected_as_the_catalogue_expects() {
+  assert_generation_is_detected_as_the_catalogue_expects 17
+}
+
+function test_the_models_named_outside_dells_usual_scheme_are_not_detected_as_gen_14_or_newer() {
+  # Documents a known blind spot of the name-based detection rather than a wish :
+  # these servers are Gen 14 or newer but their name carries no "[RT]<digit><digit>0",
+  # so the controller treats them as Gen 13 or older and keeps sending them the
+  # third-party PCIe card cooling response command (which their BMC rejects, and
+  # the controller discards that rejection on purpose)
+  local MODEL
+  for MODEL in \
+    "PowerEdge R6415" "PowerEdge R7425" "PowerEdge C6420" "PowerEdge M640" "PowerEdge MX740c" \
+    "PowerEdge R6515" "PowerEdge R7525" "PowerEdge XR11" \
+    "PowerEdge R6615" "PowerEdge R7625" "PowerEdge XE9680" \
+    "PowerEdge R6715" "PowerEdge R7725" "PowerEdge XE7745"; do
+    if is_detected_as_gen_14_or_newer "$MODEL"; then
+      fail "$MODEL is currently detected as gen 14 or newer" \
+        "the detection is a match on the model name, update the catalogue if it was improved"
+    else
+      pass
+    fi
+  done
+}
+
+function test_the_detection_relies_on_the_uppercase_letter_directly_before_the_digits() {
+  # The optional whitespace is what makes "PowerEdge R 740" work...
+  assert_matches "PowerEdge R 740" "$GENERATION_14_OR_NEWER_REGEX" "a space between the letter and the digits is tolerated"
+  assert_matches "PowerEdge T 640" "$GENERATION_14_OR_NEWER_REGEX"
+  # ...but the letter itself is matched case-sensitively, and nothing else stands in for it
+  if is_detected_as_gen_14_or_newer "poweredge r740"; then
+    fail "a lowercase model name should not be detected as gen 14 or newer"
+  else
+    pass
+  fi
+  if is_detected_as_gen_14_or_newer ""; then
+    fail "an empty model name should not be detected as gen 14 or newer"
+  else
+    pass
+  fi
+  if is_detected_as_gen_14_or_newer "Super Server X11DPi-N"; then
+    fail "a model name from another manufacturer should not be detected as gen 14 or newer"
+  else
+    pass
+  fi
+}
+
+function test_the_server_model_is_read_from_the_fru_product_fields() {
+  export MOCK_IPMITOOL_FRU_OUTPUT
+  MOCK_IPMITOOL_FRU_OUTPUT=$(make_fru_output --manufacturer "DELL" --model "PowerEdge R740xd")
+
+  get_Dell_server_model
+
+  assert_equals "DELL" "$SERVER_MANUFACTURER"
+  assert_equals "PowerEdge R740xd" "$SERVER_MODEL"
+}
+
+function test_the_server_model_falls_back_on_the_fru_board_fields() {
+  # Some servers leave the "Product *" fields empty and only fill the board ones
+  export MOCK_IPMITOOL_FRU_OUTPUT
+  MOCK_IPMITOOL_FRU_OUTPUT=$(make_fru_output --manufacturer "DELL" --model "PowerEdge R630" --board-fields-only)
+
+  get_Dell_server_model
+
+  assert_equals "DELL" "$SERVER_MANUFACTURER"
+  assert_equals "PowerEdge R630" "$SERVER_MODEL"
+}
+
+function test_a_failing_ipmi_connection_stops_the_controller_with_an_actionable_error() {
+  export MOCK_IPMITOOL_FRU_EXIT_CODE=1
+  export MOCK_IPMITOOL_FRU_OUTPUT="Error: Unable to establish IPMI v2 / RMCP+ session"
+
+  local OUTPUT
+  OUTPUT=$(get_Dell_server_model 2>&1)
+  local -r EXIT_CODE=$?
+
+  assert_equals 1 "$EXIT_CODE" "an unreachable iDRAC should stop the controller instead of silently continuing"
+  assert_contains "$OUTPUT" "Could not establish IPMI connection"
+  assert_contains "$OUTPUT" "IDRAC_HOST" "the error should name the variables to check"
+  assert_contains "$OUTPUT" "Unable to establish IPMI v2 / RMCP+ session" "the error should quote what ipmitool said"
+}
+
+function test_the_catalogue_covers_every_generation_and_typology_without_duplicates() {
+  local GENERATION
+  for GENERATION in "${DELL_SERVER_GENERATIONS[@]}"; do
+    local MODEL_COUNT
+    MODEL_COUNT=$(catalogue_entries_of_generation "$GENERATION" | wc -l)
+    if [ "$MODEL_COUNT" -ge 4 ]; then
+      pass
+    else
+      fail "generation $GENERATION is only covered by $MODEL_COUNT models"
+    fi
+  done
+
+  # Single, dual and quad socket servers must all be represented
+  local SOCKETS
+  for SOCKETS in 1 2 4; do
+    local TYPOLOGY_COUNT
+    TYPOLOGY_COUNT=$(catalogue_entries_with_sockets "$SOCKETS" | wc -l)
+    if [ "$TYPOLOGY_COUNT" -ge 4 ]; then
+      pass
+    else
+      fail "only $TYPOLOGY_COUNT models with $SOCKETS CPU sockets are catalogued"
+    fi
+  done
+
+  local DUPLICATED_MODELS
+  DUPLICATED_MODELS=$(printf '%s\n' "${DELL_SERVER_CATALOGUE[@]}" | cut -d'|' -f2 | sort | uniq -d)
+  assert_empty "$DUPLICATED_MODELS" "the catalogue should not list the same model twice"
+
+  local ENTRY
+  for ENTRY in "${DELL_SERVER_CATALOGUE[@]}"; do
+    assert_matches "$ENTRY" '^(9|1[0-7])\|[^|]+\|[124]\|(true|false)\|(supported|firmware-dependent|unsupported)$' \
+      "malformed catalogue entry"
+  done
+}

--- a/tests/cases/60_cpu_topologies.sh
+++ b/tests/cases/60_cpu_topologies.sh
@@ -1,0 +1,182 @@
+#!/bin/bash
+
+# Server typologies : single socket (R210, R240, R6515...), dual socket (R720,
+# R740, R760...) and quad socket (R910, R930, R940, R960...), with or without an
+# exhaust sensor, with an empty second socket, with an unreadable reading.
+#
+# The table is printed column by column, so the number of detected CPUs decides
+# both the header and every following line : a miscounted CPU shifts the whole
+# table and makes the logs unreadable.
+
+function test_a_single_cpu_server_reports_one_cpu() {
+  export MOCK_IPMITOOL_SDR_OUTPUT
+  MOCK_IPMITOOL_SDR_OUTPUT=$(make_sdr_output --cpus 1 --cpu-temperatures "44")
+
+  retrieve_temperatures true true
+
+  assert_equals "1" "$NUMBER_OF_DETECTED_CPUS"
+  assert_equals "44" "$CPU1_TEMPERATURE"
+  assert_equals "44" "$CPUS_TEMPERATURES"
+  assert_empty "$CPU2_TEMPERATURE" "a single socket server has no CPU 2 reading"
+}
+
+function test_a_dual_cpu_server_reports_two_cpus() {
+  export MOCK_IPMITOOL_SDR_OUTPUT
+  MOCK_IPMITOOL_SDR_OUTPUT=$(make_sdr_output --cpus 2 --cpu-temperatures "44 46")
+
+  retrieve_temperatures true true
+
+  assert_equals "2" "$NUMBER_OF_DETECTED_CPUS"
+  assert_equals "44" "$CPU1_TEMPERATURE"
+  assert_equals "46" "$CPU2_TEMPERATURE"
+  assert_equals "44;46" "$CPUS_TEMPERATURES"
+}
+
+function test_a_quad_cpu_server_only_reports_its_first_two_cpus() {
+  # Documents the current behavior : an R930 or an R940 exposes four processor
+  # entities but only CPU 1 and CPU 2 are read, and only those two drive the fans
+  export MOCK_IPMITOOL_SDR_OUTPUT
+  MOCK_IPMITOOL_SDR_OUTPUT=$(make_sdr_output --cpus 4 --cpu-temperatures "41 40 39 38" --cpu-sensor-id-base 9)
+
+  retrieve_temperatures true true
+
+  assert_equals "2" "$NUMBER_OF_DETECTED_CPUS" "CPU 3 and CPU 4 are not monitored"
+  assert_equals "41;40" "$CPUS_TEMPERATURES"
+}
+
+function test_an_empty_second_socket_is_not_counted_as_a_detected_cpu() {
+  # A dual socket server sold with one CPU lists the second sensor as disabled :
+  # counting it would add a column the header does not have
+  export MOCK_IPMITOOL_SDR_OUTPUT
+  MOCK_IPMITOOL_SDR_OUTPUT=$(make_sdr_output --cpus 2 --cpu-temperatures "44" --cpu2-disabled)
+
+  retrieve_temperatures true true
+
+  assert_equals "1" "$NUMBER_OF_DETECTED_CPUS"
+  assert_equals "44" "$CPUS_TEMPERATURES"
+}
+
+function test_the_sensors_known_to_be_absent_are_replaced_by_placeholders() {
+  export MOCK_IPMITOOL_SDR_OUTPUT
+  MOCK_IPMITOOL_SDR_OUTPUT=$(make_sdr_output --cpus 2 --cpu-temperatures "44 46" --exhaust 36)
+
+  # Once the controller has detected that a sensor is missing, it stops reading
+  # it, and the placeholder must not be counted as a detected CPU
+  retrieve_temperatures true false
+  assert_equals "-" "$CPU2_TEMPERATURE"
+  assert_equals "1" "$NUMBER_OF_DETECTED_CPUS"
+  assert_equals "44" "$CPUS_TEMPERATURES"
+
+  retrieve_temperatures false true
+  assert_equals "-" "$EXHAUST_TEMPERATURE"
+  assert_equals "2" "$NUMBER_OF_DETECTED_CPUS" "a missing exhaust sensor must not change the CPU count"
+}
+
+function test_a_server_without_an_inlet_or_exhaust_sensor_reports_no_reading() {
+  export MOCK_IPMITOOL_SDR_OUTPUT
+  MOCK_IPMITOOL_SDR_OUTPUT=$(make_sdr_output --cpus 2 --no-inlet --no-exhaust)
+
+  retrieve_temperatures true true
+
+  assert_empty "$INLET_TEMPERATURE"
+  assert_empty "$EXHAUST_TEMPERATURE" "an empty exhaust reading is how the controller detects the missing sensor"
+  assert_equals "2" "$NUMBER_OF_DETECTED_CPUS" "missing chassis sensors must not affect the CPU count"
+}
+
+function test_an_unreadable_cpu1_temperature_keeps_its_column() {
+  # CPU 1 unreadable : the reading itself stays empty so that the overheating
+  # check can fail safe on it, but the printed column falls back on a placeholder
+  export MOCK_IPMITOOL_SDR_OUTPUT
+  MOCK_IPMITOOL_SDR_OUTPUT=$(make_sdr_output --cpus 2 --cpu2-disabled)
+  MOCK_IPMITOOL_SDR_OUTPUT=$(printf '%s\n' "$MOCK_IPMITOOL_SDR_OUTPUT" | grep -v ' 3\.1 ')
+
+  retrieve_temperatures true true
+
+  assert_empty "$CPU1_TEMPERATURE" "the raw reading stays empty for the overheating check"
+  assert_equals "-" "$CPUS_TEMPERATURES" "the printed value falls back on a placeholder"
+  assert_equals "1" "$NUMBER_OF_DETECTED_CPUS"
+}
+
+function test_the_internal_functions_reject_a_wrong_number_of_parameters() {
+  local RETRIEVE_OUTPUT BUILD_HEADER_OUTPUT
+
+  RETRIEVE_OUTPUT=$(retrieve_temperatures true 2>&1)
+  local -r RETRIEVE_EXIT_CODE=$?
+  BUILD_HEADER_OUTPUT=$(build_header 2>&1)
+  local -r BUILD_HEADER_EXIT_CODE=$?
+
+  assert_equals 1 "$RETRIEVE_EXIT_CODE"
+  assert_contains "$RETRIEVE_OUTPUT" "Illegal number of parameters"
+  assert_equals 1 "$BUILD_HEADER_EXIT_CODE"
+  assert_contains "$BUILD_HEADER_OUTPUT" "requires an argument"
+}
+
+function test_the_header_of_a_single_cpu_server() {
+  local -r EXPECTED_HEADER="                     ---- Temperatures ---
+    Date & time      Inlet  CPU 1  Exhaust          Active fan speed profile          Third-party PCIe card Dell default cooling response  Comment"
+
+  assert_equals "$EXPECTED_HEADER" "$(build_header 1)"
+}
+
+function test_the_header_of_a_dual_cpu_server() {
+  local -r EXPECTED_HEADER="                     ------- Temperatures -------
+    Date & time      Inlet  CPU 1  CPU 2  Exhaust          Active fan speed profile          Third-party PCIe card Dell default cooling response  Comment"
+
+  assert_equals "$EXPECTED_HEADER" "$(build_header 2)"
+}
+
+function test_the_header_of_a_quad_cpu_server() {
+  local -r EXPECTED_HEADER="                     -------------- Temperatures --------------
+    Date & time      Inlet  CPU 1  CPU 2  CPU 3  CPU 4  Exhaust          Active fan speed profile          Third-party PCIe card Dell default cooling response  Comment"
+
+  assert_equals "$EXPECTED_HEADER" "$(build_header 4)"
+}
+
+function test_the_header_grows_with_the_cpu_count() {
+  local CPU_COUNT
+  for CPU_COUNT in 1 2 3 4 8; do
+    local TITLE_LINE COLUMNS_LINE
+    TITLE_LINE=$(build_header "$CPU_COUNT" | head -1)
+    COLUMNS_LINE=$(build_header "$CPU_COUNT" | tail -1)
+
+    # The "Temperatures" title is framed by a comparable number of dashes on
+    # each side (they can differ by one, the frame has no half dash to give)
+    local DASHES_BEFORE="${TITLE_LINE%% Temperatures *}"
+    DASHES_BEFORE="${DASHES_BEFORE##*[[:space:]]}"
+    local DASHES_AFTER="${TITLE_LINE##* Temperatures }"
+    local DIFFERENCE=$((${#DASHES_BEFORE} - ${#DASHES_AFTER}))
+    if [ "${DIFFERENCE#-}" -le 1 ]; then
+      pass
+    else
+      fail "the dashes are not balanced around the title for $CPU_COUNT CPUs" \
+        "before: ${#DASHES_BEFORE}" "after:  ${#DASHES_AFTER}"
+    fi
+
+    assert_contains "$COLUMNS_LINE" "CPU $CPU_COUNT " "the header should have a column for CPU $CPU_COUNT"
+    assert_equals "$CPU_COUNT" "$(grep -o 'CPU [0-9]' <<< "$COLUMNS_LINE" | wc -l | tr -d ' ')" \
+      "the header of a $CPU_COUNT CPU server should have exactly $CPU_COUNT CPU columns"
+  done
+}
+
+function test_the_temperature_line_has_one_column_per_detected_cpu() {
+  local -r SINGLE_CPU_LINE=$(print_temperature_array_line "23" "44" "36" "User static fan control profile (5%)" "Enabled" " -")
+  local -r DUAL_CPU_LINE=$(print_temperature_array_line "23" "44;46" "36" "User static fan control profile (5%)" "Enabled" " -")
+  local -r QUAD_CPU_LINE=$(print_temperature_array_line "23" "44;46;45;47" "36" "User static fan control profile (5%)" "Enabled" " -")
+
+  assert_equals "3" "$(grep -o '°C' <<< "$SINGLE_CPU_LINE" | wc -l | tr -d ' ')" "inlet, CPU 1 and exhaust"
+  assert_equals "4" "$(grep -o '°C' <<< "$DUAL_CPU_LINE" | wc -l | tr -d ' ')" "inlet, CPU 1, CPU 2 and exhaust"
+  assert_equals "6" "$(grep -o '°C' <<< "$QUAD_CPU_LINE" | wc -l | tr -d ' ')" "inlet, four CPUs and exhaust"
+
+  assert_contains "$DUAL_CPU_LINE" "01-01-2024 00:00:00" "every line starts with its timestamp"
+  assert_contains "$DUAL_CPU_LINE" "User static fan control profile (5%)"
+}
+
+function test_missing_readings_are_printed_without_shifting_the_columns() {
+  # A server with no exhaust sensor and an unreadable CPU 2 must still print a
+  # line of the same width as a complete one, or the table becomes unreadable
+  local -r COMPLETE_LINE=$(print_temperature_array_line "23" "44;46" "36" "Dell default dynamic fan control profile" "Enabled" " -")
+  local -r INCOMPLETE_LINE=$(print_temperature_array_line "" "-;-" "-" "Dell default dynamic fan control profile" "Enabled" " -")
+
+  assert_equals "${#COMPLETE_LINE}" "${#INCOMPLETE_LINE}" "both lines should have the same width"
+  assert_contains "$INCOMPLETE_LINE" "  -°C" "a missing reading is printed as a placeholder"
+}

--- a/tests/cases/70_fan_control_profiles.sh
+++ b/tests/cases/70_fan_control_profiles.sh
@@ -1,0 +1,217 @@
+#!/bin/bash
+
+# The commands actually sent to the server, and what happens when the server
+# refuses them - which is the normal situation on an iDRAC 9 running firmware
+# 3.30.30.30 or newer (Gen 15, 16) and on the iDRAC 10 of a Gen 17 server, where
+# Dell removed the IPMI raw fan control commands altogether.
+#
+# Applying a fan control profile is the one thing the controller exists for, so
+# a silent failure here is the worst possible outcome : the user believes their
+# fans are quiet while the server actually runs on whatever profile it had.
+
+readonly MANUAL_FAN_CONTROL_COMMAND="raw 0x30 0x30 0x01 0x00"
+readonly FAN_SPEED_COMMAND="raw 0x30 0x30 0x02 0xff"
+readonly DELL_DEFAULT_FAN_CONTROL_COMMAND="raw 0x30 0x30 0x01 0x01"
+readonly THIRD_PARTY_PCIE_CARD_COMMAND="raw 0x30 0xce 0x00 0x16 0x05"
+
+# What an iDRAC 9 running firmware >= 3.30.30.30 answers to a fan control command
+readonly REJECTED_BY_FIRMWARE_STDERR="Unable to send RAW command (channel=0x0 netfn=0x30 lun=0x0 cmd=0x30 rsp=0xd5): Command not supported in present state"
+
+function test_the_user_fan_control_profile_enables_manual_control_then_sets_the_speed() {
+  DECIMAL_FAN_SPEED=30
+  HEXADECIMAL_FAN_SPEED="0x1e"
+
+  apply_user_fan_control_profile
+
+  assert_equals "1" "$(count_ipmitool_calls_matching "$MANUAL_FAN_CONTROL_COMMAND")" \
+    "manual fan control must be enabled first"
+  assert_equals "1" "$(count_ipmitool_calls_matching "$FAN_SPEED_COMMAND 0x1e")" \
+    "the speed must be sent as the hexadecimal byte, applied to every fan (0xff)"
+  assert_equals "0" "$(count_ipmitool_calls_matching "$DELL_DEFAULT_FAN_CONTROL_COMMAND")"
+  assert_equals "User static fan control profile (30%)" "$CURRENT_FAN_CONTROL_PROFILE" \
+    "the table shows the percentage, not the hexadecimal byte"
+}
+
+function test_the_dell_default_fan_control_profile_has_its_own_raw_command() {
+  apply_Dell_default_fan_control_profile
+
+  assert_equals "1" "$(count_ipmitool_calls_matching "$DELL_DEFAULT_FAN_CONTROL_COMMAND")"
+  assert_equals "0" "$(count_ipmitool_calls_matching "$MANUAL_FAN_CONTROL_COMMAND")"
+  assert_equals "Dell default dynamic fan control profile" "$CURRENT_FAN_CONTROL_PROFILE"
+}
+
+function test_monitoring_only_mode_never_sends_a_fan_control_command() {
+  export MONITORING_ONLY_MODE=true
+
+  apply_user_fan_control_profile
+  assert_contains "$CURRENT_FAN_CONTROL_PROFILE" "not applied" "the table must say the profile was not applied"
+  assert_contains "$CURRENT_FAN_CONTROL_PROFILE" "User static fan control profile (5%)"
+
+  apply_Dell_default_fan_control_profile
+  assert_contains "$CURRENT_FAN_CONTROL_PROFILE" "not applied"
+  assert_contains "$CURRENT_FAN_CONTROL_PROFILE" "Dell default dynamic fan control profile"
+
+  assert_equals "0" "$(count_ipmitool_calls_matching "raw 0x30 0x30")" \
+    "monitoring only mode must not send a single fan control command"
+}
+
+function test_harmless_firmware_noise_is_not_reported_when_the_command_succeeds() {
+  # Some iDRAC firmwares print a protocol warning on stderr even when the command
+  # worked : reporting it on every cycle floods the logs for nothing (issue #96)
+  export MOCK_IPMITOOL_RAW_STDERR="Received an Unexpected message"
+  export MOCK_IPMITOOL_RAW_EXIT_CODE=0
+
+  capture_output apply_user_fan_control_profile
+
+  assert_empty "$CAPTURED_OUTPUT" "a successful command must stay silent even when the firmware talks"
+  assert_equals "User static fan control profile (5%)" "$CURRENT_FAN_CONTROL_PROFILE"
+}
+
+function test_a_rejected_manual_fan_control_command_is_reported() {
+  # A Gen 15/16/17 server, or a Gen 14 whose firmware was updated past 3.30.30.30
+  export MOCK_IPMITOOL_RAW_FAIL_PATTERN="0x30 0x30 0x01 0x00"
+  export MOCK_IPMITOOL_RAW_FAIL_STDERR="$REJECTED_BY_FIRMWARE_STDERR"
+
+  local OUTPUT
+  OUTPUT=$(apply_user_fan_control_profile 2>&1)
+
+  assert_contains "$OUTPUT" "Failed to enable manual fan control" \
+    "the user must be told their fans are not under the controller's control"
+  assert_contains "$OUTPUT" "Command not supported in present state" \
+    "the error must quote what ipmitool said, it is the only clue about the firmware"
+}
+
+function test_a_rejected_fan_speed_command_is_reported_with_the_requested_speed() {
+  DECIMAL_FAN_SPEED=30
+  HEXADECIMAL_FAN_SPEED="0x1e"
+  export MOCK_IPMITOOL_RAW_FAIL_PATTERN="0x30 0x30 0x02"
+  export MOCK_IPMITOOL_RAW_FAIL_STDERR="$REJECTED_BY_FIRMWARE_STDERR"
+
+  local OUTPUT
+  OUTPUT=$(apply_user_fan_control_profile 2>&1)
+
+  assert_contains "$OUTPUT" "Failed to set fan speed to 30%"
+  assert_contains "$OUTPUT" "Command not supported in present state"
+  assert_not_contains "$OUTPUT" "Failed to enable manual fan control" \
+    "only the command that actually failed should be reported"
+}
+
+function test_a_rejected_dell_default_command_is_reported() {
+  # The safety profile : failing to apply it must be as loud as possible
+  export MOCK_IPMITOOL_RAW_FAIL_PATTERN="0x30 0x30 0x01 0x01"
+  export MOCK_IPMITOOL_RAW_FAIL_STDERR="$REJECTED_BY_FIRMWARE_STDERR"
+
+  local OUTPUT
+  OUTPUT=$(apply_Dell_default_fan_control_profile 2>&1)
+
+  assert_contains "$OUTPUT" "Failed to apply Dell default fan control profile"
+  assert_contains "$OUTPUT" "Command not supported in present state"
+}
+
+function test_every_recent_generation_that_rejects_the_commands_is_reported_the_same_way() {
+  # Gen 15, 16 and 17 servers : their firmware answers "Command not supported in
+  # present state" to the fan control commands. Whatever the model, the
+  # controller must identify the server, then report a readable error rather
+  # than crash or silently pretend the profile was applied
+  export MOCK_IPMITOOL_RAW_FAIL_PATTERN="0x30 0x30"
+  export MOCK_IPMITOOL_RAW_FAIL_STDERR="$REJECTED_BY_FIRMWARE_STDERR"
+
+  local ENTRY MODEL SOCKETS
+  while IFS= read -r ENTRY; do
+    IFS='|' read -r _ MODEL SOCKETS _ _ <<< "$ENTRY"
+    simulate_server "$MODEL" --cpus "$SOCKETS"
+
+    get_Dell_server_model
+    assert_equals "$MODEL" "$SERVER_MODEL" "$MODEL should be identified"
+
+    capture_output apply_Dell_default_fan_control_profile
+    assert_contains "$CAPTURED_OUTPUT" "Failed to apply Dell default fan control profile" \
+      "$MODEL should report the rejected safety profile"
+
+    capture_output apply_user_fan_control_profile
+    assert_contains "$CAPTURED_OUTPUT" "Failed to enable manual fan control" \
+      "$MODEL should report the rejected user profile"
+  done < <(catalogue_entries_with_fan_control_support "unsupported")
+}
+
+function test_the_third_party_pcie_card_cooling_response_is_toggled_with_dells_oem_command() {
+  enable_third_party_PCIe_card_Dell_default_cooling_response
+  assert_equals "1" "$(count_ipmitool_calls_matching "$THIRD_PARTY_PCIE_CARD_COMMAND 0x00 0x00 0x00 0x05 0x00 0x00 0x00 0x00")" \
+    "enabling sends the Dell default cooling response payload"
+
+  forget_recorded_ipmitool_calls
+
+  disable_third_party_PCIe_card_Dell_default_cooling_response
+  assert_equals "1" "$(count_ipmitool_calls_matching "$THIRD_PARTY_PCIE_CARD_COMMAND 0x00 0x00 0x00 0x05 0x00 0x01 0x00 0x00")" \
+    "disabling only differs by one byte"
+}
+
+function test_an_unsupported_third_party_pcie_card_command_stays_silent() {
+  # On a Gen 14+ server, or on hardware that never supported this Dell OEM
+  # command, it fails the exact same way on every single cycle : reporting it
+  # would flood the logs with a permanent, non-actionable error
+  export MOCK_IPMITOOL_RAW_FAIL_PATTERN="0x30 0xce"
+  export MOCK_IPMITOOL_RAW_FAIL_STDERR="Unable to send RAW command (channel=0x0 netfn=0x30 lun=0x0 cmd=0xce rsp=0xc1): Invalid command"
+
+  capture_output enable_third_party_PCIe_card_Dell_default_cooling_response
+  assert_empty "$CAPTURED_OUTPUT" "an unsupported enable command must not flood the logs"
+
+  capture_output disable_third_party_PCIe_card_Dell_default_cooling_response
+  assert_empty "$CAPTURED_OUTPUT" "an unsupported disable command must not flood the logs"
+}
+
+function test_monitoring_only_mode_never_changes_the_third_party_pcie_card_cooling_response() {
+  export MONITORING_ONLY_MODE=true
+
+  enable_third_party_PCIe_card_Dell_default_cooling_response
+  disable_third_party_PCIe_card_Dell_default_cooling_response
+
+  assert_equals "0" "$(count_ipmitool_calls_matching "raw 0x30 0xce")"
+}
+
+function test_stopping_the_container_restores_the_dell_default_fan_control_profile() {
+  # Without this, stopping the container would leave the server running forever
+  # on the low static speed the user chose, with nothing left to raise it
+  local OUTPUT
+  OUTPUT=$(graceful_exit 2>&1)
+  local -r EXIT_CODE=$?
+
+  assert_equals 0 "$EXIT_CODE"
+  assert_contains "$OUTPUT" "Dell default dynamic fan control profile applied for safety"
+}
+
+function test_stopping_the_container_honors_the_third_party_pcie_card_setting() {
+  export KEEP_THIRD_PARTY_PCIE_CARD_COOLING_RESPONSE_STATE_ON_EXIT=false
+
+  # graceful_exit ends with "exit 0", so it has to run in a subshell of its own,
+  # otherwise it would stop the test case right here. The mocked ipmitool records
+  # its calls in a file, which outlives that subshell
+  (graceful_exit) > /dev/null 2>&1
+
+  assert_equals "1" "$(count_ipmitool_calls_matching "$DELL_DEFAULT_FAN_CONTROL_COMMAND")"
+  assert_equals "1" "$(count_ipmitool_calls_matching "$THIRD_PARTY_PCIE_CARD_COMMAND 0x00 0x00 0x00 0x05 0x00 0x00 0x00 0x00")" \
+    "the cooling response must be reset to Dell's default"
+
+  forget_recorded_ipmitool_calls
+  export KEEP_THIRD_PARTY_PCIE_CARD_COOLING_RESPONSE_STATE_ON_EXIT=true
+
+  (graceful_exit) > /dev/null 2>&1
+
+  assert_equals "1" "$(count_ipmitool_calls_matching "$DELL_DEFAULT_FAN_CONTROL_COMMAND")" \
+    "the fan control profile is always restored, whatever this setting"
+  assert_equals "0" "$(count_ipmitool_calls_matching "raw 0x30 0xce")" \
+    "the cooling response must be left as it is when the user asked for it"
+}
+
+function test_stopping_the_container_in_monitoring_only_mode_changes_nothing() {
+  export MONITORING_ONLY_MODE=true
+
+  local OUTPUT
+  OUTPUT=$(graceful_exit 2>&1)
+  local -r EXIT_CODE=$?
+
+  assert_equals 0 "$EXIT_CODE"
+  assert_contains "$OUTPUT" "no fan control profile was ever applied"
+  assert_equals "0" "$(count_ipmitool_calls_matching "raw 0x30")" \
+    "a monitoring only container must leave the server exactly as it found it"
+}

--- a/tests/cases/80_temperature_thresholds.sh
+++ b/tests/cases/80_temperature_thresholds.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+
+# The overheating decision. Everything here is safety-critical : a reading that
+# cannot be trusted must send the server back to Dell's own dynamic profile, not
+# leave it running on the low static speed the user asked for.
+
+# CPU1_OVERHEATING and CPU2_OVERHEATING answer through their exit code and read
+# the temperature from a global, so these two wrappers keep the test cases
+# readable and give the failure diagnostic the numbers that produced it
+function assert_cpu_is_overheating() {
+  local -r CPU_NUMBER="$1"
+  local -r MESSAGE="${2:-CPU $CPU_NUMBER should be reported as overheating}"
+
+  if "CPU${CPU_NUMBER}_OVERHEATING"; then
+    pass
+  else
+    local -r TEMPERATURE_VARIABLE="CPU${CPU_NUMBER}_TEMPERATURE"
+    fail "$MESSAGE" "reading:   [${!TEMPERATURE_VARIABLE}]" "threshold: [$CPU_TEMPERATURE_THRESHOLD]"
+  fi
+}
+
+function assert_cpu_is_not_overheating() {
+  local -r CPU_NUMBER="$1"
+  local -r MESSAGE="${2:-CPU $CPU_NUMBER should not be reported as overheating}"
+
+  if "CPU${CPU_NUMBER}_OVERHEATING"; then
+    local -r TEMPERATURE_VARIABLE="CPU${CPU_NUMBER}_TEMPERATURE"
+    fail "$MESSAGE" "reading:   [${!TEMPERATURE_VARIABLE}]" "threshold: [$CPU_TEMPERATURE_THRESHOLD]"
+  else
+    pass
+  fi
+}
+
+function test_a_cpu_temperature_below_the_threshold_is_not_overheating() {
+  export CPU_TEMPERATURE_THRESHOLD=50
+  CPU1_TEMPERATURE=45
+  CPU2_TEMPERATURE=30
+
+  assert_cpu_is_not_overheating 1
+  assert_cpu_is_not_overheating 2
+}
+
+function test_a_cpu_temperature_equal_to_the_threshold_is_not_overheating() {
+  # The README describes the threshold as the value "beyond which" Dell's profile
+  # takes over : reaching it exactly is still fine
+  export CPU_TEMPERATURE_THRESHOLD=50
+  CPU1_TEMPERATURE=50
+  CPU2_TEMPERATURE=50
+
+  assert_cpu_is_not_overheating 1
+  assert_cpu_is_not_overheating 2
+}
+
+function test_a_cpu_temperature_above_the_threshold_is_overheating() {
+  export CPU_TEMPERATURE_THRESHOLD=50
+  CPU1_TEMPERATURE=51
+  CPU2_TEMPERATURE=51
+
+  assert_cpu_is_overheating 1
+  assert_cpu_is_overheating 2
+
+  # A three-digit reading must be compared as a number, not as text
+  CPU1_TEMPERATURE=100
+  CPU2_TEMPERATURE=100
+
+  assert_cpu_is_overheating 1 "100 degrees is above 50, not below it"
+  assert_cpu_is_overheating 2 "100 degrees is above 50, not below it"
+}
+
+function test_a_missing_reading_fails_safe_and_reports_overheating() {
+  export CPU_TEMPERATURE_THRESHOLD=50
+  CPU1_TEMPERATURE=""
+  CPU2_TEMPERATURE=""
+
+  assert_cpu_is_overheating 1 "an unreadable CPU 1 must fall back on Dell's dynamic profile"
+  assert_cpu_is_overheating 2 "an unreadable CPU 2 must fall back on Dell's dynamic profile"
+}
+
+function test_a_non_numeric_reading_fails_safe_and_reports_overheating() {
+  # A mis-parsed reading used to make bash throw "unary operator expected" and
+  # crash the container, or worse, silently keep the user's low fan speed
+  export CPU_TEMPERATURE_THRESHOLD=50
+
+  local UNUSABLE_READING
+  for UNUSABLE_READING in "n/a" "-" "Disabled" "4 5" "45.5" "-10" "no reading"; do
+    CPU1_TEMPERATURE="$UNUSABLE_READING"
+    CPU2_TEMPERATURE="$UNUSABLE_READING"
+
+    assert_cpu_is_overheating 1 "an unusable CPU 1 reading must fail safe"
+    assert_cpu_is_overheating 2 "an unusable CPU 2 reading must fail safe"
+  done
+}
+
+function test_a_reading_with_a_leading_zero_is_not_read_as_octal() {
+  # "09" is not a valid octal number : bash used to abort on it
+  export CPU_TEMPERATURE_THRESHOLD=50
+  CPU1_TEMPERATURE="09"
+  CPU2_TEMPERATURE="08"
+
+  assert_cpu_is_not_overheating 1 "09 degrees is 9 degrees, not an invalid octal number"
+  assert_cpu_is_not_overheating 2 "08 degrees is 8 degrees, not an invalid octal number"
+}
+
+function test_the_threshold_is_honored_whatever_its_value() {
+  # The README suggests setting it just below the CPU's Tcase, which ranges from
+  # about 60 degrees on an old Xeon E5 to over 90 on a recent Scalable
+  local THRESHOLD
+  for THRESHOLD in 0 40 60 63 85 100; do
+    export CPU_TEMPERATURE_THRESHOLD="$THRESHOLD"
+
+    CPU1_TEMPERATURE=$((THRESHOLD + 1))
+    assert_cpu_is_overheating 1 "one degree above the threshold is overheating"
+
+    CPU1_TEMPERATURE="$THRESHOLD"
+    assert_cpu_is_not_overheating 1 "reaching the threshold exactly is not overheating"
+  done
+}
+
+function test_temperatures_are_printed_right_aligned_on_three_characters() {
+  assert_equals "  5" "$(format_temperature_for_display 5)"
+  assert_equals " 45" "$(format_temperature_for_display 45)"
+  assert_equals "100" "$(format_temperature_for_display 100)"
+  assert_equals "  9" "$(format_temperature_for_display 09)" "a leading zero must not be read as octal"
+}
+
+function test_an_unreadable_temperature_is_printed_as_a_placeholder() {
+  # printf %d would abort on any of these, taking the whole container down
+  local UNUSABLE_READING
+  for UNUSABLE_READING in "" "-" "n/a" "Disabled" "45.5" "-10"; do
+    assert_equals "  -" "$(format_temperature_for_display "$UNUSABLE_READING")" \
+      "\"$UNUSABLE_READING\" should be printed as a placeholder"
+  done
+}

--- a/tests/cases/85_power_state.sh
+++ b/tests/cases/85_power_state.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# In network mode the container keeps running while the server it cools is
+# powered off. Reading temperatures then would be meaningless, and applying a fan
+# control profile would either fail or wake the fans of a sleeping chassis, so
+# the whole cycle is skipped. Anything that is not a clear "powered on" answer
+# must therefore be treated as powered off.
+
+function test_a_powered_on_server_is_detected() {
+  export MOCK_IPMITOOL_POWER_STATUS="Chassis Power is on"
+
+  assert_command_succeeds "a server answering \"Chassis Power is on\" is powered on" is_server_powered_on
+}
+
+function test_a_powered_off_server_is_detected() {
+  export MOCK_IPMITOOL_POWER_STATUS="Chassis Power is off"
+
+  assert_command_fails "a server answering \"Chassis Power is off\" is powered off" is_server_powered_on
+}
+
+function test_an_empty_power_status_is_treated_as_powered_off() {
+  export MOCK_IPMITOOL_POWER_STATUS=""
+
+  assert_command_fails "no answer at all must not be read as powered on" is_server_powered_on
+}
+
+function test_a_failing_power_status_query_is_treated_as_powered_off() {
+  # An iDRAC that stopped answering, a wrong password, a network outage : none of
+  # them is a reason to start sending fan control commands into the void
+  export MOCK_IPMITOOL_POWER_EXIT_CODE=1
+  export MOCK_IPMITOOL_POWER_STATUS="Error: Unable to establish IPMI v2 / RMCP+ session"
+
+  assert_command_fails "a failing query must not be read as powered on" is_server_powered_on
+}
+
+function test_the_power_status_is_queried_through_the_idrac_login_string() {
+  IDRAC_LOGIN_STRING="lanplus -H 10.0.0.42 -U administrator -E"
+
+  is_server_powered_on
+
+  assert_equals "1" "$(count_ipmitool_calls_matching "chassis power status")"
+  assert_contains "$(recorded_ipmitool_calls)" "-H 10.0.0.42 -U administrator -E" \
+    "the power status must be read from the same iDRAC as the temperatures"
+}

--- a/tests/cases/90_integration.sh
+++ b/tests/cases/90_integration.sh
@@ -1,0 +1,224 @@
+#!/bin/bash
+
+# The whole controller, started exactly like its Docker image does, against a
+# mocked iDRAC. Each test case describes one server and reads back what the user
+# would see in "docker logs", then stops the container with SIGTERM like
+# "docker stop" does.
+
+function test_the_controller_applies_the_user_fan_control_profile_on_a_healthy_server() {
+  simulate_server "PowerEdge R730xd" --cpus 2 --cpu-temperatures "42 44" --inlet 21 --exhaust 34
+
+  local -r OUTPUT=$(run_controller)
+
+  assert_contains "$OUTPUT" "Server model: DELL PowerEdge R730xd"
+  assert_contains "$OUTPUT" "Fan speed objective: 5%"
+  assert_contains "$OUTPUT" "CPU temperature threshold: 50°C"
+  assert_contains "$OUTPUT" "Check interval: 60s"
+  assert_contains "$OUTPUT" "CPU 1  CPU 2 " "a dual CPU server gets two CPU columns"
+  assert_contains "$OUTPUT" "User static fan control profile (5%)"
+  assert_contains "$OUTPUT" "CPU temperature decreased and is now OK (<= 50°C), user's fan control profile applied."
+  assert_not_contains "$OUTPUT" "temperature is too high" "cold CPUs must never trigger the safety profile"
+  assert_equals "1" "$(count_ipmitool_calls_matching "raw 0x30 0x30 0x01 0x01")" \
+    "Dell's dynamic profile is only applied once, when the container is stopped"
+}
+
+function test_the_controller_falls_back_on_the_dell_default_profile_when_a_cpu_starts_overheating() {
+  # Cold CPUs on the first cycle, CPU 2 above the threshold from the second one :
+  # the profile change is what the user must see in the logs
+  simulate_server "PowerEdge R730xd" --cpus 2 --cpu-temperatures "42 44"
+  export MOCK_IPMITOOL_SDR_SECOND_OUTPUT
+  MOCK_IPMITOOL_SDR_SECOND_OUTPUT=$(make_sdr_output --cpus 2 --cpu-temperatures "42 78")
+  export MOCK_IPMITOOL_SDR_SWITCH_AFTER_CALLS=1
+
+  local -r OUTPUT=$(run_controller "temperature is too high")
+
+  assert_contains "$OUTPUT" "CPU 2 temperature is too high, Dell default dynamic fan control profile applied for safety"
+  assert_contains "$OUTPUT" "Dell default dynamic fan control profile"
+  if [ "$(count_ipmitool_calls_matching "raw 0x30 0x30 0x01 0x01")" -ge 1 ]; then
+    pass
+  else
+    fail "Dell's dynamic fan control profile should have been applied to the overheating server"
+  fi
+}
+
+function test_the_controller_reports_both_cpus_when_they_are_overheating_together() {
+  simulate_server "PowerEdge R630" --cpus 2 --cpu-temperatures "42 44"
+  export MOCK_IPMITOOL_SDR_SECOND_OUTPUT
+  MOCK_IPMITOOL_SDR_SECOND_OUTPUT=$(make_sdr_output --cpus 2 --cpu-temperatures "81 78")
+  export MOCK_IPMITOOL_SDR_SWITCH_AFTER_CALLS=1
+
+  local -r OUTPUT=$(run_controller "temperatures are too high")
+
+  assert_contains "$OUTPUT" "CPU 1 and CPU 2 temperatures are too high, Dell default dynamic fan control profile applied for safety"
+}
+
+function test_the_controller_reports_a_single_cpu_server() {
+  simulate_server "PowerEdge R230" --cpus 1 --cpu-temperatures "38"
+
+  local -r OUTPUT=$(run_controller)
+
+  assert_contains "$OUTPUT" "No CPU2 temperature sensor detected."
+  assert_contains "$OUTPUT" "Inlet  CPU 1  Exhaust" "a single CPU server gets a single CPU column"
+  assert_not_contains "$OUTPUT" "CPU 2 "
+}
+
+function test_the_controller_reports_a_quad_cpu_server() {
+  # An R930 also exercises the CPU sensor IDs (09h, 0Ah...) that used to be
+  # mistaken for temperature readings
+  simulate_server "PowerEdge R930" --cpus 4 --cpu-temperatures "41 40 39 38" --cpu-sensor-id-base 9
+
+  local -r OUTPUT=$(run_controller)
+
+  assert_contains "$OUTPUT" "Server model: DELL PowerEdge R930"
+  assert_contains "$OUTPUT" "CPU 1  CPU 2  Exhaust" "only the first two CPUs are monitored today"
+  assert_not_contains "$OUTPUT" "CPU 3 "
+  assert_contains "$OUTPUT" " 41°C   40°C" "the readings must not be shifted by the two-digit sensor IDs"
+}
+
+function test_the_controller_reports_a_server_without_an_exhaust_sensor() {
+  simulate_server "PowerEdge R720" --cpus 2 --no-exhaust
+
+  local -r OUTPUT=$(run_controller)
+
+  assert_contains "$OUTPUT" "No exhaust temperature sensor detected."
+  assert_contains "$OUTPUT" "User static fan control profile (5%)" "a missing sensor must not stop the fan control"
+}
+
+function test_the_controller_manages_the_third_party_pcie_card_setting_on_gen_13_and_older() {
+  export DISABLE_THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE=true
+  simulate_server "PowerEdge R730xd" --cpus 2
+
+  local -r OUTPUT=$(run_controller)
+
+  assert_contains "$OUTPUT" "Third-party PCIe card Dell default cooling response"
+  assert_contains "$OUTPUT" "Disabled"
+  if [ "$(count_ipmitool_calls_matching "raw 0x30 0xce")" -ge 1 ]; then
+    pass
+  else
+    fail "a Gen 13 server must be sent the third-party PCIe card cooling response command"
+  fi
+}
+
+function test_the_controller_leaves_the_third_party_pcie_card_setting_alone_on_gen_14_and_newer() {
+  # The Dell OEM command does not exist on Gen 14+, sending it would only produce
+  # a rejection on every single cycle.
+  # KEEP_..._ON_EXIT is set so that the graceful exit does not send that same
+  # command itself : it resets the cooling response whatever the generation, so
+  # leaving it to its default would hide what this test is about
+  export DISABLE_THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE=true
+  export KEEP_THIRD_PARTY_PCIE_CARD_COOLING_RESPONSE_STATE_ON_EXIT=true
+  simulate_server "PowerEdge R740xd" --cpus 2
+
+  local -r OUTPUT=$(run_controller)
+
+  assert_contains "$OUTPUT" "Server model: DELL PowerEdge R740xd"
+  assert_equals "0" "$(count_ipmitool_calls_matching "raw 0x30 0xce")"
+}
+
+function test_the_controller_survives_a_recent_server_that_rejects_the_fan_control_commands() {
+  # A Gen 16 server : its iDRAC 9 firmware no longer accepts the raw fan control
+  # commands. The controller must say so and keep monitoring, not crash
+  simulate_server "PowerEdge R760" --cpus 2 --cpu-temperatures "45 46"
+  export MOCK_IPMITOOL_RAW_FAIL_PATTERN="0x30 0x30"
+  export MOCK_IPMITOOL_RAW_FAIL_STDERR="Unable to send RAW command (channel=0x0 netfn=0x30 lun=0x0 cmd=0x30 rsp=0xd5): Command not supported in present state"
+
+  local -r OUTPUT=$(run_controller)
+
+  assert_contains "$OUTPUT" "Server model: DELL PowerEdge R760"
+  assert_contains "$OUTPUT" "Failed to enable manual fan control"
+  assert_contains "$OUTPUT" "Command not supported in present state"
+  assert_contains "$OUTPUT" "45°C" "the temperatures must still be monitored and logged"
+}
+
+function test_the_controller_refuses_to_run_on_a_server_that_is_not_a_dell() {
+  export MOCK_IPMITOOL_FRU_OUTPUT
+  MOCK_IPMITOOL_FRU_OUTPUT=$(make_fru_output --manufacturer "Supermicro" --model "Super Server X11DPi-N")
+
+  local OUTPUT
+  OUTPUT=$(run_controller)
+  local -r EXIT_CODE=$?
+
+  assert_equals 1 "$EXIT_CODE"
+  assert_contains "$OUTPUT" "Your server isn't a Dell product"
+  assert_equals "0" "$(count_ipmitool_calls_matching "raw 0x30")" \
+    "no fan control command must ever reach a non-Dell server"
+}
+
+function test_the_controller_stops_when_the_ipmi_connection_cannot_be_established() {
+  export MOCK_IPMITOOL_FRU_EXIT_CODE=1
+  export MOCK_IPMITOOL_FRU_OUTPUT="Error: Unable to establish IPMI v2 / RMCP+ session"
+
+  local OUTPUT
+  OUTPUT=$(run_controller)
+  local -r EXIT_CODE=$?
+
+  assert_equals 1 "$EXIT_CODE"
+  assert_contains "$OUTPUT" "Could not establish IPMI connection"
+  assert_contains "$OUTPUT" "192.168.1.100" "the error should name the host that could not be reached"
+}
+
+function test_the_controller_skips_the_cycle_when_the_target_server_is_powered_off() {
+  simulate_server "PowerEdge R740" --cpus 2
+  export MOCK_IPMITOOL_POWER_STATUS="Chassis Power is off"
+
+  # A powered off server never gets a temperature line, so the cycle it does
+  # print is what tells the harness the controller reached its steady state
+  local -r OUTPUT=$(run_controller "Target server is powered off, no fan control profile applied\.")
+
+  assert_contains "$OUTPUT" "Target server is powered off, no fan control profile applied."
+  assert_equals "0" "$(count_ipmitool_calls_matching "raw 0x30 0x30 0x01 0x00")" \
+    "manual fan control must not be enabled on a powered off server"
+  assert_equals "0" "$(count_ipmitool_calls_matching "raw 0x30 0x30 0x02")" \
+    "no fan speed must be sent to a powered off server"
+  assert_not_contains "$OUTPUT" "User static fan control profile" \
+    "no temperature line must be printed for a server that is off"
+}
+
+function test_monitoring_only_mode_never_touches_the_fans() {
+  export MONITORING_ONLY_MODE=true
+  simulate_server "PowerEdge R640" --cpus 2 --cpu-temperatures "42 78"
+
+  local -r OUTPUT=$(run_controller)
+
+  assert_contains "$OUTPUT" "Monitoring only mode: Enabled"
+  assert_contains "$OUTPUT" "monitoring only, not applied"
+  assert_contains "$OUTPUT" "78°C" "the temperatures must still be logged"
+  assert_equals "0" "$(count_ipmitool_calls_matching "raw 0x30")" \
+    "not a single command may be sent in monitoring only mode, even for an overheating CPU"
+}
+
+function test_a_fan_speed_given_in_hexadecimal_is_logged_as_a_percentage() {
+  export FAN_SPEED=0x1e
+  simulate_server "PowerEdge R730" --cpus 2
+
+  local -r OUTPUT=$(run_controller)
+
+  assert_contains "$OUTPUT" "Fan speed objective: 30%"
+  assert_contains "$OUTPUT" "User static fan control profile (30%)"
+  if [ "$(count_ipmitool_calls_matching "raw 0x30 0x30 0x02 0xff 0x1e")" -ge 1 ]; then
+    pass
+  else
+    fail "the hexadecimal speed should reach ipmitool untouched" "calls: $(recorded_ipmitool_calls)"
+  fi
+}
+
+function test_stopping_the_container_restores_dells_profile_whatever_the_generation() {
+  # SIGTERM is what "docker stop" sends : whichever generation it runs on, the
+  # container must hand the fans back to the server before leaving
+  local MODEL
+  for MODEL in "PowerEdge 2950" "PowerEdge R710" "PowerEdge R730xd" "PowerEdge R740" "PowerEdge R760" "PowerEdge R770"; do
+    forget_recorded_ipmitool_calls
+    simulate_server "$MODEL" --cpus 2
+
+    local OUTPUT
+    OUTPUT=$(run_controller)
+
+    assert_contains "$OUTPUT" "Container stopped, Dell default dynamic fan control profile applied for safety" \
+      "$MODEL should hand the fans back on exit"
+    if [ "$(count_ipmitool_calls_matching "raw 0x30 0x30 0x01 0x01")" -ge 1 ]; then
+      pass
+    else
+      fail "$MODEL should be sent Dell's dynamic fan control profile on exit"
+    fi
+  done
+}

--- a/tests/lib/assertions.sh
+++ b/tests/lib/assertions.sh
@@ -1,0 +1,192 @@
+#!/bin/bash
+
+# Assertion helpers.
+#
+# Each test runs in its own subshell, so an assertion cannot simply increment a
+# counter: the outcome is recorded in the two files the runner prepares before
+# every test ($TEST_ASSERTIONS_FILE and $TEST_DIAGNOSTICS_FILE).
+#
+# Assertions return 0 on success and 1 on failure but never abort the test, so
+# that a data-driven test looping over a hundred server models reports every
+# offending model in one run instead of only the first one. Use
+# "assert_... || return 1" in the rare cases where the rest of the test cannot
+# run once the assertion failed.
+
+function _record_assertion() {
+  printf '.' >> "$TEST_ASSERTIONS_FILE"
+}
+
+function _record_failure() {
+  local -r TITLE="$1"
+  shift
+
+  {
+    printf '%s\n' "$TITLE"
+    local DETAIL
+    for DETAIL in "$@"; do
+      printf '  %s\n' "$DETAIL"
+    done
+  } >> "$TEST_DIAGNOSTICS_FILE"
+}
+
+# Record a passing assertion, for the tests that run the check themselves
+# Usage : if <check>; then pass; else fail "..."; fi
+function pass() {
+  _record_assertion
+}
+
+# Unconditionally fail the current test
+# Usage : fail "message" ["detail" ...]
+function fail() {
+  local -r MESSAGE="$1"
+  shift
+
+  _record_assertion
+  _record_failure "$MESSAGE" "$@"
+  return 1
+}
+
+# Usage : assert_equals "$EXPECTED" "$ACTUAL" ["message"]
+function assert_equals() {
+  local -r EXPECTED="$1"
+  local -r ACTUAL="$2"
+  local -r MESSAGE="${3:-values should be equal}"
+
+  _record_assertion
+  if [ "$EXPECTED" == "$ACTUAL" ]; then
+    return 0
+  fi
+
+  _record_failure "$MESSAGE" "expected: [$EXPECTED]" "actual:   [$ACTUAL]"
+  return 1
+}
+
+# Usage : assert_not_equals "$UNEXPECTED" "$ACTUAL" ["message"]
+function assert_not_equals() {
+  local -r UNEXPECTED="$1"
+  local -r ACTUAL="$2"
+  local -r MESSAGE="${3:-values should differ}"
+
+  _record_assertion
+  if [ "$UNEXPECTED" != "$ACTUAL" ]; then
+    return 0
+  fi
+
+  _record_failure "$MESSAGE" "both values are: [$ACTUAL]"
+  return 1
+}
+
+# Usage : assert_contains "$HAYSTACK" "$NEEDLE" ["message"]
+function assert_contains() {
+  local -r HAYSTACK="$1"
+  local -r NEEDLE="$2"
+  local -r MESSAGE="${3:-text should contain substring}"
+
+  _record_assertion
+  if [[ "$HAYSTACK" == *"$NEEDLE"* ]]; then
+    return 0
+  fi
+
+  _record_failure "$MESSAGE" "substring: [$NEEDLE]" "text:      [$HAYSTACK]"
+  return 1
+}
+
+# Usage : assert_not_contains "$HAYSTACK" "$NEEDLE" ["message"]
+function assert_not_contains() {
+  local -r HAYSTACK="$1"
+  local -r NEEDLE="$2"
+  local -r MESSAGE="${3:-text should not contain substring}"
+
+  _record_assertion
+  if [[ "$HAYSTACK" != *"$NEEDLE"* ]]; then
+    return 0
+  fi
+
+  _record_failure "$MESSAGE" "substring: [$NEEDLE]" "text:      [$HAYSTACK]"
+  return 1
+}
+
+# Usage : assert_matches "$VALUE" "$EXTENDED_REGEX" ["message"]
+function assert_matches() {
+  local -r VALUE="$1"
+  local -r REGEX="$2"
+  local -r MESSAGE="${3:-value should match regex}"
+
+  _record_assertion
+  if [[ "$VALUE" =~ $REGEX ]]; then
+    return 0
+  fi
+
+  _record_failure "$MESSAGE" "regex: [$REGEX]" "value: [$VALUE]"
+  return 1
+}
+
+# Usage : assert_empty "$VALUE" ["message"]
+function assert_empty() {
+  local -r VALUE="$1"
+  local -r MESSAGE="${2:-value should be empty}"
+
+  _record_assertion
+  if [ -z "$VALUE" ]; then
+    return 0
+  fi
+
+  _record_failure "$MESSAGE" "value: [$VALUE]"
+  return 1
+}
+
+# Usage : assert_not_empty "$VALUE" ["message"]
+function assert_not_empty() {
+  local -r VALUE="$1"
+  local -r MESSAGE="${2:-value should not be empty}"
+
+  _record_assertion
+  if [ -n "$VALUE" ]; then
+    return 0
+  fi
+
+  _record_failure "$MESSAGE" "value is empty"
+  return 1
+}
+
+# Usage : assert_command_succeeds "message" command [argument ...]
+function assert_command_succeeds() {
+  local -r MESSAGE="$1"
+  shift
+
+  local ACTUAL_EXIT_CODE=0
+  "$@" > /dev/null 2>&1 || ACTUAL_EXIT_CODE=$?
+
+  _record_assertion
+  if [ "$ACTUAL_EXIT_CODE" -eq 0 ]; then
+    return 0
+  fi
+
+  _record_failure "$MESSAGE" "command:   [$*]" "exit code: [$ACTUAL_EXIT_CODE]"
+  return 1
+}
+
+# Usage : assert_command_fails "message" command [argument ...]
+function assert_command_fails() {
+  local -r MESSAGE="$1"
+  shift
+
+  local ACTUAL_EXIT_CODE=0
+  "$@" > /dev/null 2>&1 || ACTUAL_EXIT_CODE=$?
+
+  _record_assertion
+  if [ "$ACTUAL_EXIT_CODE" -ne 0 ]; then
+    return 0
+  fi
+
+  _record_failure "$MESSAGE" "command: [$*]" "it succeeded instead"
+  return 1
+}
+
+# Skip the current test, reporting why. Used for the few cases that need a
+# capability the environment may not provide (creating a fake /dev/ipmi device
+# requires write access to /dev, which an unprivileged CI runner doesn't have)
+# Usage : skip_test "reason"
+function skip_test() {
+  printf '%s\n' "$1" > "$TEST_SKIPPED_FILE"
+}

--- a/tests/lib/dell_server_catalogue.sh
+++ b/tests/lib/dell_server_catalogue.sh
@@ -1,0 +1,227 @@
+#!/bin/bash
+
+# Catalogue of Dell PowerEdge servers, from the 9th generation (2006) to the
+# 17th (2024), used to drive the model detection tests.
+#
+# Columns, pipe-separated :
+#   1. PowerEdge generation number (9 to 17)
+#   2. model, as "ipmitool fru" reports it in "Product Name"
+#   3. maximum number of CPU sockets of that model
+#   4. expected value of the controller's DELL_POWEREDGE_GEN_14_OR_NEWER flag
+#   5. whether Dell's IPMI raw fan control commands work on that server :
+#        supported          - iDRAC 6/7/8, the raw commands work
+#        firmware-dependent - iDRAC 9, works below firmware 3.30.30.30 only
+#        unsupported        - iDRAC 9 (recent firmware) / iDRAC 10, the raw
+#                             commands are rejected by the BMC
+#
+# /!\ Column 4 records what the controller CURRENTLY detects, not the actual
+# generation of the server. The detection is a match on the model name
+# ("[RT]<digit>[4-9]0"), so it structurally cannot recognize the models Dell
+# named differently : the AMD ones (R6515, R7525, R6615, R7725...), the dense
+# and modular ones (C6420, M640, MX740c), and the specialty ones (XR11, XE9680).
+# Those are Gen 14 or newer yet detected as older, which makes the controller
+# send them the Gen 13-and-older third-party PCIe card cooling response command.
+# It is harmless (the BMC rejects an unknown command and the controller discards
+# that error on purpose) but it is a real blind spot, so the catalogue records it
+# explicitly instead of hiding it, and one test documents it on its own.
+
+readonly DELL_SERVER_CATALOGUE=(
+  # 9th generation (2006) - BMC / DRAC 5
+  "9|PowerEdge 1950|2|false|supported"
+  "9|PowerEdge 1955|2|false|supported"
+  "9|PowerEdge 2900|2|false|supported"
+  "9|PowerEdge 2950|2|false|supported"
+
+  # 10th generation (2007) - iDRAC 6
+  "10|PowerEdge R300|1|false|supported"
+  "10|PowerEdge T300|1|false|supported"
+  "10|PowerEdge R805|2|false|supported"
+  "10|PowerEdge T605|2|false|supported"
+  "10|PowerEdge R900|4|false|supported"
+  "10|PowerEdge R905|4|false|supported"
+
+  # 11th generation (2009) - iDRAC 6
+  "11|PowerEdge R210|1|false|supported"
+  "11|PowerEdge R310|1|false|supported"
+  "11|PowerEdge T110|1|false|supported"
+  "11|PowerEdge T310|1|false|supported"
+  "11|PowerEdge R410|2|false|supported"
+  "11|PowerEdge R415|2|false|supported"
+  "11|PowerEdge R510|2|false|supported"
+  "11|PowerEdge R610|2|false|supported"
+  "11|PowerEdge R710|2|false|supported"
+  "11|PowerEdge R715|2|false|supported"
+  "11|PowerEdge T610|2|false|supported"
+  "11|PowerEdge T710|2|false|supported"
+  "11|PowerEdge R810|4|false|supported"
+  "11|PowerEdge R815|4|false|supported"
+  "11|PowerEdge R910|4|false|supported"
+
+  # 12th generation (2012) - iDRAC 7
+  "12|PowerEdge R220|1|false|supported"
+  "12|PowerEdge R320|1|false|supported"
+  "12|PowerEdge T320|1|false|supported"
+  "12|PowerEdge R420|2|false|supported"
+  "12|PowerEdge R520|2|false|supported"
+  "12|PowerEdge R620|2|false|supported"
+  "12|PowerEdge R720|2|false|supported"
+  "12|PowerEdge R720xd|2|false|supported"
+  "12|PowerEdge T420|2|false|supported"
+  "12|PowerEdge T620|2|false|supported"
+  "12|PowerEdge M620|2|false|supported"
+  "12|PowerEdge R820|4|false|supported"
+  "12|PowerEdge R920|4|false|supported"
+
+  # 13th generation (2014) - iDRAC 8
+  "13|PowerEdge R230|1|false|supported"
+  "13|PowerEdge R330|1|false|supported"
+  "13|PowerEdge T130|1|false|supported"
+  "13|PowerEdge T330|1|false|supported"
+  "13|PowerEdge R430|2|false|supported"
+  "13|PowerEdge R530|2|false|supported"
+  "13|PowerEdge R630|2|false|supported"
+  "13|PowerEdge R730|2|false|supported"
+  "13|PowerEdge R730xd|2|false|supported"
+  "13|PowerEdge T430|2|false|supported"
+  "13|PowerEdge T630|2|false|supported"
+  "13|PowerEdge M630|2|false|supported"
+  "13|PowerEdge FC630|2|false|supported"
+  "13|PowerEdge R830|4|false|supported"
+  "13|PowerEdge R930|4|false|supported"
+
+  # 14th generation (2017) - iDRAC 9
+  "14|PowerEdge R240|1|true|firmware-dependent"
+  "14|PowerEdge R340|1|true|firmware-dependent"
+  "14|PowerEdge T140|1|true|firmware-dependent"
+  "14|PowerEdge T340|1|true|firmware-dependent"
+  "14|PowerEdge R440|2|true|firmware-dependent"
+  "14|PowerEdge R540|2|true|firmware-dependent"
+  "14|PowerEdge R640|2|true|firmware-dependent"
+  "14|PowerEdge R740|2|true|firmware-dependent"
+  "14|PowerEdge R740xd|2|true|firmware-dependent"
+  "14|PowerEdge T440|2|true|firmware-dependent"
+  "14|PowerEdge T640|2|true|firmware-dependent"
+  "14|PowerEdge R840|4|true|firmware-dependent"
+  "14|PowerEdge R940|4|true|firmware-dependent"
+  "14|PowerEdge R940xa|4|true|firmware-dependent"
+  # Models Dell named outside the "[RT]<digit><digit>0" scheme : detected as Gen 13 or older
+  "14|PowerEdge R6415|1|false|firmware-dependent"
+  "14|PowerEdge R7415|1|false|firmware-dependent"
+  "14|PowerEdge R7425|2|false|firmware-dependent"
+  "14|PowerEdge C6420|2|false|firmware-dependent"
+  "14|PowerEdge M640|2|false|firmware-dependent"
+  "14|PowerEdge MX740c|2|false|firmware-dependent"
+
+  # 15th generation (2021) - iDRAC 9, IPMI raw fan control removed by firmware
+  "15|PowerEdge R250|1|true|unsupported"
+  "15|PowerEdge R350|1|true|unsupported"
+  "15|PowerEdge T150|1|true|unsupported"
+  "15|PowerEdge T350|1|true|unsupported"
+  "15|PowerEdge R450|2|true|unsupported"
+  "15|PowerEdge R550|2|true|unsupported"
+  "15|PowerEdge R650|2|true|unsupported"
+  "15|PowerEdge R650xs|2|true|unsupported"
+  "15|PowerEdge R750|2|true|unsupported"
+  "15|PowerEdge R750xa|2|true|unsupported"
+  "15|PowerEdge R750xs|2|true|unsupported"
+  "15|PowerEdge T550|2|true|unsupported"
+  "15|PowerEdge R6515|1|false|unsupported"
+  "15|PowerEdge R7515|1|false|unsupported"
+  "15|PowerEdge XR11|1|false|unsupported"
+  "15|PowerEdge XR12|1|false|unsupported"
+  "15|PowerEdge R6525|2|false|unsupported"
+  "15|PowerEdge R7525|2|false|unsupported"
+
+  # 16th generation (2023) - iDRAC 9, IPMI raw fan control removed by firmware
+  "16|PowerEdge R260|1|true|unsupported"
+  "16|PowerEdge R360|1|true|unsupported"
+  "16|PowerEdge T160|1|true|unsupported"
+  "16|PowerEdge T360|1|true|unsupported"
+  "16|PowerEdge R460|2|true|unsupported"
+  "16|PowerEdge R560|2|true|unsupported"
+  "16|PowerEdge R660|2|true|unsupported"
+  "16|PowerEdge R760|2|true|unsupported"
+  "16|PowerEdge R760xa|2|true|unsupported"
+  "16|PowerEdge T560|2|true|unsupported"
+  "16|PowerEdge R860|4|true|unsupported"
+  "16|PowerEdge R960|4|true|unsupported"
+  "16|PowerEdge R6615|1|false|unsupported"
+  "16|PowerEdge R7615|1|false|unsupported"
+  "16|PowerEdge R6625|2|false|unsupported"
+  "16|PowerEdge R7625|2|false|unsupported"
+  "16|PowerEdge C6620|2|false|unsupported"
+  "16|PowerEdge XE9680|2|false|unsupported"
+
+  # 17th generation (2024) - iDRAC 10, no IPMI raw fan control at all
+  "17|PowerEdge R470|2|true|unsupported"
+  "17|PowerEdge R570|2|true|unsupported"
+  "17|PowerEdge R670|2|true|unsupported"
+  "17|PowerEdge R770|2|true|unsupported"
+  "17|PowerEdge R6715|1|false|unsupported"
+  "17|PowerEdge R7715|1|false|unsupported"
+  "17|PowerEdge R6725|2|false|unsupported"
+  "17|PowerEdge R7725|2|false|unsupported"
+  "17|PowerEdge XE7745|2|false|unsupported"
+)
+
+# Every generation the catalogue covers
+readonly DELL_SERVER_GENERATIONS=(9 10 11 12 13 14 15 16 17)
+
+# Print the catalogue entries of a given generation
+# Usage : catalogue_entries_of_generation $GENERATION
+function catalogue_entries_of_generation() {
+  local -r GENERATION="$1"
+  local ENTRY
+
+  for ENTRY in "${DELL_SERVER_CATALOGUE[@]}"; do
+    if [ "${ENTRY%%|*}" == "$GENERATION" ]; then
+      printf '%s\n' "$ENTRY"
+    fi
+  done
+}
+
+# Print the catalogue entries whose IPMI fan control support column matches
+# Usage : catalogue_entries_with_fan_control_support "unsupported"
+function catalogue_entries_with_fan_control_support() {
+  local -r SUPPORT="$1"
+  local ENTRY
+
+  for ENTRY in "${DELL_SERVER_CATALOGUE[@]}"; do
+    if [ "${ENTRY##*|}" == "$SUPPORT" ]; then
+      printf '%s\n' "$ENTRY"
+    fi
+  done
+}
+
+# Print the catalogue entries whose model has the given number of CPU sockets
+# Usage : catalogue_entries_with_sockets 4
+function catalogue_entries_with_sockets() {
+  local -r SOCKETS="$1"
+  local ENTRY
+  local ENTRY_SOCKETS
+
+  for ENTRY in "${DELL_SERVER_CATALOGUE[@]}"; do
+    IFS='|' read -r _ _ ENTRY_SOCKETS _ _ <<< "$ENTRY"
+    if [ "$ENTRY_SOCKETS" == "$SOCKETS" ]; then
+      printf '%s\n' "$ENTRY"
+    fi
+  done
+}
+
+# Reproduce the controller's own generation detection, so that a test asserts
+# against the very expression Dell_iDRAC_fan_controller.sh uses. The expression
+# is read from the script instead of being copied here, so that the tests cannot
+# silently keep validating an outdated copy of it
+# Usage : is_detected_as_gen_14_or_newer "$SERVER_MODEL"
+function is_detected_as_gen_14_or_newer() {
+  local -r SERVER_MODEL="$1"
+
+  [[ $SERVER_MODEL =~ $GENERATION_14_OR_NEWER_REGEX ]]
+}
+
+# Extract the generation detection regular expression from the controller script
+# Usage : GENERATION_14_OR_NEWER_REGEX=$(read_generation_detection_regex)
+function read_generation_detection_regex() {
+  grep -oE '^if \[\[ \$SERVER_MODEL =~ .* \]\]; then$' "$REPO_ROOT/Dell_iDRAC_fan_controller.sh" |
+    sed -E 's/^if \[\[ \$SERVER_MODEL =~ //; s/ \]\]; then$//'
+}

--- a/tests/lib/fixtures.sh
+++ b/tests/lib/fixtures.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+
+# Builders for the two ipmitool outputs the controller parses: the FRU inventory
+# ("ipmitool fru", used to identify the server) and the temperature sensor
+# records ("ipmitool sdr type temperature").
+#
+# Both are generated rather than stored as flat files because the interesting
+# dimension is combinatorial: every generation from 9 to 17, in 1, 2 and 4 CPU
+# variants, with or without an inlet sensor, an exhaust sensor, a disabled CPU 2,
+# etc. The exact column layout below is the real one, reproduced verbatim from
+# ipmitool's "sdr type" output.
+
+# Build an "ipmitool fru" output
+# Usage : make_fru_output [--manufacturer NAME] [--model NAME] [--board-fields-only] [--no-manufacturer]
+#
+# --board-fields-only reproduces the servers that don't fill the "Product *"
+# fields at all and only expose "Board Mfg" / "Board Product", which
+# get_Dell_server_model() falls back on
+function make_fru_output() {
+  local MANUFACTURER="DELL"
+  local MODEL="PowerEdge R730xd"
+  local BOARD_FIELDS_ONLY=false
+  local WITH_MANUFACTURER=true
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --manufacturer) MANUFACTURER="$2"; shift 2 ;;
+      --model) MODEL="$2"; shift 2 ;;
+      --board-fields-only) BOARD_FIELDS_ONLY=true; shift ;;
+      --no-manufacturer) WITH_MANUFACTURER=false; shift ;;
+      *) printf 'make_fru_output: unknown option "%s"\n' "$1" >&2; return 1 ;;
+    esac
+  done
+
+  printf 'FRU Device Description : Builtin FRU Device (ID 0)\n'
+  printf ' Board Mfg Date        : Mon Jan  1 00:00:00 1996\n'
+  if $WITH_MANUFACTURER; then
+    printf ' Board Mfg             : %s\n' "$MANUFACTURER"
+  fi
+  printf ' Board Product         : %s\n' "$MODEL"
+  printf ' Board Serial          : CN7016360I0026\n'
+  printf ' Board Part Number     : 0599V5A05\n'
+
+  if $BOARD_FIELDS_ONLY; then
+    return 0
+  fi
+
+  if $WITH_MANUFACTURER; then
+    printf ' Product Manufacturer  : %s\n' "$MANUFACTURER"
+  fi
+  printf ' Product Name          : %s\n' "$MODEL"
+  printf ' Product Part Number   : 0599V5A05\n'
+  printf ' Product Version       : A05\n'
+  printf ' Product Serial        : 5N7XXX2\n'
+  printf ' Product Asset Tag     :\n'
+}
+
+# Build a single "ipmitool sdr type temperature" line
+# Usage : make_sdr_line "$SENSOR_NAME" "$SENSOR_ID" "$STATUS" "$ENTITY_ID" "$READING"
+function make_sdr_line() {
+  printf '%-16s | %s | %-3s | %4s | %s\n' "$1" "$2" "$3" "$4" "$5"
+}
+
+# Build an "ipmitool sdr type temperature" output
+# Usage : make_sdr_output [option ...]
+#   --cpus N                   number of CPU sensors, reported as entities 3.1 to 3.N
+#   --cpu-temperatures "40 41" explicit readings, one per CPU (default 40, 41, 42...)
+#   --cpu-sensor-id-base N     decimal value of the first CPU sensor's hexadecimal ID.
+#                              Defaults to 14 (0Eh, 0Fh...); pass 9 to reproduce an
+#                              R930, whose CPU sensor IDs (09h, 0Ah...) used to be
+#                              mistaken for temperature readings (issue #91)
+#   --inlet N / --no-inlet     inlet sensor reading, or no inlet sensor at all
+#   --exhaust N / --no-exhaust exhaust sensor reading, or no exhaust sensor at all
+#   --cpu2-disabled            CPU 2 is listed but has no reading ("ns | Disabled"),
+#                              like a second socket left empty
+#   --with-extra-sensors       add the non-CPU, non-inlet, non-exhaust temperature
+#                              sensors bigger servers report (board, PCIe risers)
+function make_sdr_output() {
+  local CPU_COUNT=2
+  local CPU_TEMPERATURES=""
+  local CPU_SENSOR_ID_BASE=14
+  local INLET_TEMPERATURE=23
+  local EXHAUST_TEMPERATURE=34
+  local WITH_INLET=true
+  local WITH_EXHAUST=true
+  local CPU2_DISABLED=false
+  local WITH_EXTRA_SENSORS=false
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --cpus) CPU_COUNT="$2"; shift 2 ;;
+      --cpu-temperatures) CPU_TEMPERATURES="$2"; shift 2 ;;
+      --cpu-sensor-id-base) CPU_SENSOR_ID_BASE="$2"; shift 2 ;;
+      --inlet) INLET_TEMPERATURE="$2"; WITH_INLET=true; shift 2 ;;
+      --exhaust) EXHAUST_TEMPERATURE="$2"; WITH_EXHAUST=true; shift 2 ;;
+      --no-inlet) WITH_INLET=false; shift ;;
+      --no-exhaust) WITH_EXHAUST=false; shift ;;
+      --cpu2-disabled) CPU2_DISABLED=true; shift ;;
+      --with-extra-sensors) WITH_EXTRA_SENSORS=true; shift ;;
+      *) printf 'make_sdr_output: unknown option "%s"\n' "$1" >&2; return 1 ;;
+    esac
+  done
+
+  # Inlet and exhaust are both reported as entity 7.1: only their name tells them apart
+  if $WITH_INLET; then
+    make_sdr_line "Inlet Temp" "04h" "ok" "7.1" "$INLET_TEMPERATURE degrees C"
+  fi
+  if $WITH_EXHAUST; then
+    make_sdr_line "Exhaust Temp" "01h" "ok" "7.1" "$EXHAUST_TEMPERATURE degrees C"
+  fi
+
+  local -a REQUESTED_CPU_TEMPERATURES=($CPU_TEMPERATURES)
+  local CPU_INDEX
+  for ((CPU_INDEX = 1; CPU_INDEX <= CPU_COUNT; CPU_INDEX++)); do
+    local SENSOR_ID
+    SENSOR_ID=$(printf '%02Xh' "$((CPU_SENSOR_ID_BASE + CPU_INDEX - 1))")
+
+    if $CPU2_DISABLED && [ "$CPU_INDEX" -eq 2 ]; then
+      make_sdr_line "Temp" "$SENSOR_ID" "ns" "3.$CPU_INDEX" "Disabled"
+      continue
+    fi
+
+    local CPU_TEMPERATURE="${REQUESTED_CPU_TEMPERATURES[$((CPU_INDEX - 1))]:-$((39 + CPU_INDEX))}"
+    make_sdr_line "Temp" "$SENSOR_ID" "ok" "3.$CPU_INDEX" "$CPU_TEMPERATURE degrees C"
+  done
+
+  if $WITH_EXTRA_SENSORS; then
+    make_sdr_line "Temp" "0Ah" "ok" "10.1" "38 degrees C"
+    make_sdr_line "Temp" "0Bh" "ok" "10.2" "37 degrees C"
+    make_sdr_line "PSU1 Inlet Temp" "68h" "ok" "10.1" "29 degrees C"
+    make_sdr_line "PSU2 Inlet Temp" "69h" "ok" "10.2" "30 degrees C"
+  fi
+}
+
+# Point the mocked ipmitool at a given server
+# Usage : simulate_server "$SERVER_MODEL" [make_sdr_output option ...]
+function simulate_server() {
+  local -r SERVER_MODEL="$1"
+  shift
+
+  export MOCK_IPMITOOL_FRU_OUTPUT
+  MOCK_IPMITOOL_FRU_OUTPUT="$(make_fru_output --model "$SERVER_MODEL")"
+  export MOCK_IPMITOOL_SDR_OUTPUT
+  MOCK_IPMITOOL_SDR_OUTPUT="$(make_sdr_output "$@")"
+}

--- a/tests/lib/harness.sh
+++ b/tests/lib/harness.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+
+# The environment every test case runs in, and the few helpers that talk to the
+# code under test : the mocked ipmitool's call log, and running the controller
+# itself from end to end.
+
+# Prepare the environment a test case starts from : the mocks come first in the
+# PATH, and every variable the controller expects from its Docker image gets the
+# Dockerfile's default value, so a test only has to set what it is about
+function setup_test_context() {
+  PATH="$TESTS_DIRECTORY/mocks:$PATH"
+  export PATH
+
+  # Dockerfile defaults
+  export IDRAC_HOST="192.168.1.100"
+  export IDRAC_USERNAME="root"
+  export IDRAC_PASSWORD="calvin"
+  export FAN_SPEED=5
+  export CPU_TEMPERATURE_THRESHOLD=50
+  export CHECK_INTERVAL=60
+  export DISABLE_THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE=false
+  export KEEP_THIRD_PARTY_PCIE_CARD_COOLING_RESPONSE_STATE_ON_EXIT=false
+  export MONITORING_ONLY_MODE=false
+
+  # Values Dell_iDRAC_fan_controller.sh computes before entering its loop
+  DECIMAL_FAN_SPEED=5
+  HEXADECIMAL_FAN_SPEED="0x05"
+  IDRAC_LOGIN_STRING="lanplus -H $IDRAC_HOST -U $IDRAC_USERNAME -E"
+
+  # Mock defaults : a healthy, powered-on dual CPU Gen 13 server
+  export MOCK_IPMITOOL_CALL_LOG="$TEST_TEMPORARY_DIRECTORY/ipmitool_calls.log"
+  : > "$MOCK_IPMITOOL_CALL_LOG"
+  export MOCK_IPMITOOL_FRU_OUTPUT
+  MOCK_IPMITOOL_FRU_OUTPUT="$(make_fru_output)"
+  export MOCK_IPMITOOL_SDR_OUTPUT
+  MOCK_IPMITOOL_SDR_OUTPUT="$(make_sdr_output)"
+  export MOCK_IPMITOOL_POWER_STATUS="Chassis Power is on"
+  export MOCK_DATE_OUTPUT="01-01-2024 00:00:00"
+  # Short enough to keep the suite fast, long enough for run_controller to stop
+  # the controller while it is idle between two cycles rather than mid-cycle
+  export MOCK_SLEEP_SECONDS="0.25"
+}
+
+# Every ipmitool invocation recorded so far by the mock
+function recorded_ipmitool_calls() {
+  cat "$MOCK_IPMITOOL_CALL_LOG"
+}
+
+# Number of recorded invocations matching an extended regular expression
+# Usage : count_ipmitool_calls_matching "raw 0x30 0x30"
+function count_ipmitool_calls_matching() {
+  grep -cE -- "$1" "$MOCK_IPMITOOL_CALL_LOG" || true
+}
+
+# Forget the invocations recorded so far
+function forget_recorded_ipmitool_calls() {
+  : > "$MOCK_IPMITOOL_CALL_LOG"
+}
+
+# Run a function with its output (stdout and stderr merged) captured in
+# $CAPTURED_OUTPUT, without the subshell a command substitution would create :
+# the variables the function sets stay visible to the test
+# Usage : capture_output apply_user_fan_control_profile
+function capture_output() {
+  local -r CAPTURE_FILE="$TEST_TEMPORARY_DIRECTORY/captured_output"
+
+  local EXIT_CODE=0
+  "$@" > "$CAPTURE_FILE" 2>&1 || EXIT_CODE=$?
+  CAPTURED_OUTPUT=$(cat "$CAPTURE_FILE")
+
+  return "$EXIT_CODE"
+}
+
+# A COMPLETE line of the temperature table. The controller prints a line with
+# several printf calls (one per column group), so matching on the readings alone
+# would match a line still being written, and the controller would be signaled in
+# the middle of a cycle instead of between two of them
+readonly CONTROLLER_TEMPERATURE_LINE_PATTERN='°C .*fan control profile'
+
+# Run the whole controller with the mocks in place, until what the test is
+# waiting for shows up in its output (by default one line of the temperature
+# table), then stop it with SIGTERM, exactly like "docker stop" does, so that its
+# graceful exit is exercised too. A controller that stops on its own is not
+# signaled at all.
+#
+# Waiting for the output rather than for a fixed duration is what makes these
+# test cases reproducible : the signal is always delivered at the same point of
+# the cycle, right after a line was printed, while the controller is idle waiting
+# for its next check interval.
+#
+# Its output (stdout and stderr merged, like "docker logs" shows it) is printed,
+# and its exit code is returned
+# Usage : CONTROLLER_OUTPUT=$(run_controller ["extended regex to wait for"])
+function run_controller() {
+  local -r AWAITED_PATTERN="${1:-$CONTROLLER_TEMPERATURE_LINE_PATTERN}"
+  local -r OUTPUT_FILE="$TEST_TEMPORARY_DIRECTORY/controller_output"
+  # 400 polls of 20ms : 8 seconds, only ever reached when the controller does not
+  # print what the test is waiting for, which the assertions then report
+  local -r MAXIMUM_POLLS=400
+
+  : > "$OUTPUT_FILE"
+
+  local EXIT_CODE=0
+  (
+    cd "$REPO_ROOT" || exit 1
+
+    bash ./Dell_iDRAC_fan_controller.sh > "$OUTPUT_FILE" 2>&1 &
+    CONTROLLER_PID=$!
+
+    POLLS=0
+    while [ "$POLLS" -lt "$MAXIMUM_POLLS" ]; do
+      # The controller stopped on its own (it refused to run, or it crashed)
+      kill -0 "$CONTROLLER_PID" 2> /dev/null || break
+      grep -qE "$AWAITED_PATTERN" "$OUTPUT_FILE" && break
+      # "command -p" looks the real sleep up in the system's default PATH, the
+      # mocked one being first in this shell's own PATH
+      command -p sleep 0.02
+      POLLS=$((POLLS + 1))
+    done
+
+    kill -TERM "$CONTROLLER_PID" 2> /dev/null
+    wait "$CONTROLLER_PID"
+  ) || EXIT_CODE=$?
+
+  cat "$OUTPUT_FILE"
+  return "$EXIT_CODE"
+}

--- a/tests/mocks/date
+++ b/tests/mocks/date
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Fake date used by the test suite, so that the timestamp column of the
+# temperature table is reproducible and can be asserted on.
+#
+# The controller only ever calls `date +"%d-%m-%Y %T"`, so the requested format
+# is deliberately ignored and the frozen timestamp is printed instead.
+
+printf '%s\n' "${MOCK_DATE_OUTPUT:-01-01-2024 00:00:00}"

--- a/tests/mocks/ipmitool
+++ b/tests/mocks/ipmitool
@@ -1,0 +1,121 @@
+#!/bin/bash
+
+# Fake ipmitool used by the test suite.
+#
+# It stands in for a real iDRAC/BMC so that every code path can be exercised
+# without any Dell hardware, and it is driven entirely through environment
+# variables so that a test can describe the server it wants to simulate.
+#
+# Every invocation is appended verbatim to $MOCK_IPMITOOL_CALL_LOG (when set),
+# which is how tests assert that the expected raw commands were (or were not)
+# sent to the server.
+#
+# Recognized environment variables:
+#   MOCK_IPMITOOL_CALL_LOG         file the invocations are appended to
+#   MOCK_IPMITOOL_FRU_OUTPUT       stdout of "ipmitool fru"
+#   MOCK_IPMITOOL_FRU_EXIT_CODE    exit code of "ipmitool fru" (default 0). When
+#                                  non-zero, MOCK_IPMITOOL_FRU_OUTPUT is printed
+#                                  on stderr instead of stdout, like the real
+#                                  tool does when the connection fails
+#   MOCK_IPMITOOL_SDR_OUTPUT       stdout of "ipmitool sdr type temperature"
+#   MOCK_IPMITOOL_SDR_STDERR       stderr of the same command (firmware noise)
+#   MOCK_IPMITOOL_SDR_EXIT_CODE    its exit code (default 0)
+#   MOCK_IPMITOOL_SDR_SECOND_OUTPUT          readings returned from the
+#                                            MOCK_IPMITOOL_SDR_SWITCH_AFTER_CALLS+1-th
+#                                            call onwards, so that a running
+#                                            controller can be made to see the
+#                                            temperatures change between two cycles
+#   MOCK_IPMITOOL_SDR_SWITCH_AFTER_CALLS     when to switch (default 1)
+#   MOCK_IPMITOOL_POWER_STATUS     stdout of "ipmitool chassis power status"
+#   MOCK_IPMITOOL_POWER_EXIT_CODE  its exit code (default 0)
+#   MOCK_IPMITOOL_RAW_STDERR       stderr printed by every "ipmitool raw" call
+#   MOCK_IPMITOOL_RAW_EXIT_CODE    exit code of every "ipmitool raw" call
+#   MOCK_IPMITOOL_RAW_FAIL_PATTERN extended regex matched against the raw
+#                                  command's arguments. When it matches, that
+#                                  single command fails with
+#                                  MOCK_IPMITOOL_RAW_FAIL_STDERR /
+#                                  MOCK_IPMITOOL_RAW_FAIL_EXIT_CODE. This is how
+#                                  a specific command is made to fail (an iDRAC 9
+#                                  firmware >= 3.30.30.30 rejecting 0x30 0x30, or
+#                                  a Gen 14+ server rejecting 0x30 0xce) while
+#                                  the others keep succeeding
+
+if [ -n "${MOCK_IPMITOOL_CALL_LOG:-}" ]; then
+  printf '%s\n' "$*" >> "$MOCK_IPMITOOL_CALL_LOG"
+fi
+
+# Skip the connection options ("-I open", "-I lanplus -H host -U user -E") to
+# find the sub-command and its own arguments
+declare -a ARGUMENTS=()
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -I | -H | -U | -P | -p | -L | -y)
+      # These options take a value, drop both
+      shift 2
+      ;;
+    -E | -v | -N | -R)
+      shift
+      ;;
+    *)
+      ARGUMENTS+=("$1")
+      shift
+      ;;
+  esac
+done
+
+readonly SUB_COMMAND="${ARGUMENTS[0]:-}"
+
+case "$SUB_COMMAND" in
+  fru)
+    if [ "${MOCK_IPMITOOL_FRU_EXIT_CODE:-0}" -ne 0 ]; then
+      printf '%s\n' "${MOCK_IPMITOOL_FRU_OUTPUT:-}" >&2
+      exit "${MOCK_IPMITOOL_FRU_EXIT_CODE}"
+    fi
+    printf '%s\n' "${MOCK_IPMITOOL_FRU_OUTPUT:-}"
+    ;;
+
+  sdr)
+    if [ -n "${MOCK_IPMITOOL_SDR_STDERR:-}" ]; then
+      printf '%s\n' "$MOCK_IPMITOOL_SDR_STDERR" >&2
+    fi
+
+    SDR_OUTPUT="${MOCK_IPMITOOL_SDR_OUTPUT:-}"
+    if [ -n "${MOCK_IPMITOOL_SDR_SECOND_OUTPUT:-}" ] && [ -n "${MOCK_IPMITOOL_CALL_LOG:-}" ]; then
+      # The current call is already in the log, so this counts it too
+      SDR_CALL_NUMBER=$(grep -c ' sdr ' "$MOCK_IPMITOOL_CALL_LOG")
+      if [ "$SDR_CALL_NUMBER" -gt "${MOCK_IPMITOOL_SDR_SWITCH_AFTER_CALLS:-1}" ]; then
+        SDR_OUTPUT="$MOCK_IPMITOOL_SDR_SECOND_OUTPUT"
+      fi
+    fi
+
+    if [ -n "$SDR_OUTPUT" ]; then
+      printf '%s\n' "$SDR_OUTPUT"
+    fi
+    exit "${MOCK_IPMITOOL_SDR_EXIT_CODE:-0}"
+    ;;
+
+  chassis)
+    # Set but empty means "the iDRAC answered nothing", which is not the same as
+    # unset, so the fallback deliberately does not use the ":-" form here
+    printf '%s\n' "${MOCK_IPMITOOL_POWER_STATUS-Chassis Power is on}"
+    exit "${MOCK_IPMITOOL_POWER_EXIT_CODE:-0}"
+    ;;
+
+  raw)
+    RAW_ARGUMENTS="${ARGUMENTS[*]:1}"
+    if [ -n "${MOCK_IPMITOOL_RAW_FAIL_PATTERN:-}" ] &&
+      [[ "$RAW_ARGUMENTS" =~ $MOCK_IPMITOOL_RAW_FAIL_PATTERN ]]; then
+      printf '%s\n' "${MOCK_IPMITOOL_RAW_FAIL_STDERR:-Unable to send RAW command (channel=0x0 netfn=0x30 lun=0x0 cmd=0x30 rsp=0xd5): Command not supported in present state}" >&2
+      exit "${MOCK_IPMITOOL_RAW_FAIL_EXIT_CODE:-1}"
+    fi
+    if [ -n "${MOCK_IPMITOOL_RAW_STDERR:-}" ]; then
+      printf '%s\n' "$MOCK_IPMITOOL_RAW_STDERR" >&2
+    fi
+    exit "${MOCK_IPMITOOL_RAW_EXIT_CODE:-0}"
+    ;;
+
+  *)
+    printf 'mock ipmitool: unsupported sub-command "%s"\n' "$SUB_COMMAND" >&2
+    exit 127
+    ;;
+esac

--- a/tests/mocks/sleep
+++ b/tests/mocks/sleep
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Fake sleep used by the integration tests, so that a CHECK_INTERVAL of 60
+# seconds does not make a test take a minute.
+#
+# The requested duration is ignored and replaced by MOCK_SLEEP_SECONDS, short
+# enough to keep the suite fast but long enough for the monitoring loop to
+# behave like it does in production (the timer really is started in background
+# and really is waited on).
+
+for REAL_SLEEP in /bin/sleep /usr/bin/sleep; do
+  if [ -x "$REAL_SLEEP" ]; then
+    exec "$REAL_SLEEP" "${MOCK_SLEEP_SECONDS:-0.05}"
+  fi
+done
+
+printf 'mock sleep: no real sleep binary found\n' >&2
+exit 127

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,0 +1,259 @@
+#!/bin/bash
+
+# Automated test suite for the Dell iDRAC fan controller.
+#
+# Everything runs against a mocked ipmitool (tests/mocks/ipmitool), so the suite
+# needs no Dell hardware, no iDRAC and no network : bash, coreutils, GNU grep and
+# awk are enough. Run it with :
+#
+#   ./tests/run_tests.sh                 # run everything
+#   ./tests/run_tests.sh --list          # list the test cases without running them
+#   ./tests/run_tests.sh -f temperature  # run the test cases whose name matches
+#   ./tests/run_tests.sh --tap           # emit TAP output for a CI parser
+#
+# It exits 0 when every test passed, 1 otherwise.
+
+TESTS_DIRECTORY="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TESTS_DIRECTORY/.." && pwd)"
+readonly TESTS_DIRECTORY REPO_ROOT
+export TESTS_DIRECTORY REPO_ROOT
+
+FILTER=""
+LIST_ONLY=false
+TAP_OUTPUT=false
+USE_COLOR=true
+
+function print_usage() {
+  cat << 'EOF'
+Usage: tests/run_tests.sh [option ...]
+
+  -f, --filter PATTERN  only run the test cases whose name matches PATTERN
+  -l, --list            list the test cases without running them
+      --tap             emit TAP version 13 output
+      --no-color        disable colored output
+  -h, --help            show this help
+EOF
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -f | --filter) FILTER="$2"; shift 2 ;;
+    -l | --list) LIST_ONLY=true; shift ;;
+    --tap) TAP_OUTPUT=true; USE_COLOR=false; shift ;;
+    --no-color) USE_COLOR=false; shift ;;
+    -h | --help) print_usage; exit 0 ;;
+    *) printf 'Unknown option "%s"\n\n' "$1" >&2; print_usage >&2; exit 2 ;;
+  esac
+done
+
+if [ ! -t 1 ]; then
+  USE_COLOR=false
+fi
+
+if $USE_COLOR; then
+  readonly COLOR_RESET=$'\e[0m'
+  readonly COLOR_BOLD=$'\e[1m'
+  readonly COLOR_DIM=$'\e[2m'
+  readonly COLOR_GREEN=$'\e[32m'
+  readonly COLOR_RED=$'\e[31m'
+  readonly COLOR_YELLOW=$'\e[33m'
+else
+  readonly COLOR_RESET="" COLOR_BOLD="" COLOR_DIM="" COLOR_GREEN="" COLOR_RED="" COLOR_YELLOW=""
+fi
+
+# Load the helpers, then the code under test
+source "$TESTS_DIRECTORY/lib/assertions.sh"
+source "$TESTS_DIRECTORY/lib/fixtures.sh"
+source "$TESTS_DIRECTORY/lib/dell_server_catalogue.sh"
+source "$TESTS_DIRECTORY/lib/harness.sh"
+source "$REPO_ROOT/functions.sh"
+source "$REPO_ROOT/constants.sh"
+
+GENERATION_14_OR_NEWER_REGEX="$(read_generation_detection_regex)"
+readonly GENERATION_14_OR_NEWER_REGEX
+if [ -z "$GENERATION_14_OR_NEWER_REGEX" ]; then
+  printf 'Could not read the generation detection regular expression from Dell_iDRAC_fan_controller.sh\n' >&2
+  exit 1
+fi
+
+# Collect the test case names of a file, in declaration order (declare -F would
+# sort them alphabetically, which would scramble the story each file tells)
+function test_case_names_of_file() {
+  grep -oE '^(function )?test_[A-Za-z0-9_]+\(\)' "$1" | sed -E 's/^function //; s/\(\)$//'
+}
+
+# "test_the_fan_speed_is_applied" -> "the fan speed is applied"
+function humanize_test_case_name() {
+  local -r NAME="${1#test_}"
+  printf '%s' "${NAME//_/ }"
+}
+
+# tests/cases/20_conversions.sh -> "conversions"
+function humanize_test_file_name() {
+  local NAME
+  NAME="$(basename "$1" .sh)"
+  NAME="${NAME#*_}"
+  printf '%s' "${NAME//_/ }"
+}
+
+declare -a TEST_FILES=()
+while IFS= read -r TEST_FILE; do
+  TEST_FILES+=("$TEST_FILE")
+done < <(find "$TESTS_DIRECTORY/cases" -name '*.sh' -type f | sort)
+
+if [ "${#TEST_FILES[@]}" -eq 0 ]; then
+  printf 'No test case file found in %s\n' "$TESTS_DIRECTORY/cases" >&2
+  exit 1
+fi
+
+for TEST_FILE in "${TEST_FILES[@]}"; do
+  source "$TEST_FILE"
+done
+
+# Build the ordered list of test cases to run, as "file<tab>function" pairs
+declare -a SELECTED_TEST_CASES=()
+for TEST_FILE in "${TEST_FILES[@]}"; do
+  while IFS= read -r TEST_CASE_NAME; do
+    [ -n "$TEST_CASE_NAME" ] || continue
+    if [ -n "$FILTER" ] && [[ ! "$TEST_CASE_NAME" =~ $FILTER ]] && [[ ! "$TEST_FILE" =~ $FILTER ]]; then
+      continue
+    fi
+    SELECTED_TEST_CASES+=("$TEST_FILE"$'\t'"$TEST_CASE_NAME")
+  done < <(test_case_names_of_file "$TEST_FILE")
+done
+
+readonly TOTAL_TEST_CASES="${#SELECTED_TEST_CASES[@]}"
+
+if [ "$TOTAL_TEST_CASES" -eq 0 ]; then
+  printf 'No test case matched "%s"\n' "$FILTER" >&2
+  exit 1
+fi
+
+if $LIST_ONLY; then
+  CURRENT_TEST_FILE=""
+  for TEST_CASE in "${SELECTED_TEST_CASES[@]}"; do
+    TEST_FILE="${TEST_CASE%%$'\t'*}"
+    TEST_CASE_NAME="${TEST_CASE##*$'\t'}"
+    if [ "$TEST_FILE" != "$CURRENT_TEST_FILE" ]; then
+      CURRENT_TEST_FILE="$TEST_FILE"
+      printf '\n%s\n' "$(humanize_test_file_name "$TEST_FILE")"
+    fi
+    printf '  %s\n' "$(humanize_test_case_name "$TEST_CASE_NAME")"
+  done
+  printf '\n%d test cases\n' "$TOTAL_TEST_CASES"
+  exit 0
+fi
+
+TEST_TEMPORARY_DIRECTORY="$(mktemp -d)"
+readonly TEST_TEMPORARY_DIRECTORY
+export TEST_TEMPORARY_DIRECTORY
+trap 'rm -rf "$TEST_TEMPORARY_DIRECTORY"' EXIT
+
+TEST_ASSERTIONS_FILE="$TEST_TEMPORARY_DIRECTORY/assertions"
+TEST_DIAGNOSTICS_FILE="$TEST_TEMPORARY_DIRECTORY/diagnostics"
+TEST_SKIPPED_FILE="$TEST_TEMPORARY_DIRECTORY/skipped"
+readonly TEST_ASSERTIONS_FILE TEST_DIAGNOSTICS_FILE TEST_SKIPPED_FILE
+export TEST_ASSERTIONS_FILE TEST_DIAGNOSTICS_FILE TEST_SKIPPED_FILE
+
+if $TAP_OUTPUT; then
+  printf 'TAP version 13\n'
+  printf '1..%d\n' "$TOTAL_TEST_CASES"
+else
+  printf '%sDell iDRAC fan controller - automated test suite%s\n' "$COLOR_BOLD" "$COLOR_RESET"
+  printf '%s%s, %s%s\n\n' "$COLOR_DIM" "$(bash --version | head -1)" "$REPO_ROOT" "$COLOR_RESET"
+fi
+
+PASSED_TEST_CASES=0
+FAILED_TEST_CASES=0
+SKIPPED_TEST_CASES=0
+TOTAL_ASSERTIONS=0
+TEST_CASE_INDEX=0
+CURRENT_TEST_FILE=""
+declare -a FAILED_TEST_CASE_NAMES=()
+
+for TEST_CASE in "${SELECTED_TEST_CASES[@]}"; do
+  TEST_FILE="${TEST_CASE%%$'\t'*}"
+  TEST_CASE_NAME="${TEST_CASE##*$'\t'}"
+  ((TEST_CASE_INDEX++))
+
+  if [ "$TEST_FILE" != "$CURRENT_TEST_FILE" ]; then
+    CURRENT_TEST_FILE="$TEST_FILE"
+    if ! $TAP_OUTPUT; then
+      printf '%s%s%s\n' "$COLOR_BOLD" "$(humanize_test_file_name "$TEST_FILE")" "$COLOR_RESET"
+    fi
+  fi
+
+  : > "$TEST_ASSERTIONS_FILE"
+  : > "$TEST_DIAGNOSTICS_FILE"
+  rm -f "$TEST_SKIPPED_FILE"
+
+  # Each test case runs in its own subshell so that the variables, functions,
+  # PATH and working directory it changes cannot leak into the next one
+  TEST_CASE_EXIT_CODE=0
+  (
+    setup_test_context
+    cd "$REPO_ROOT" || exit 1
+    "$TEST_CASE_NAME"
+  ) > "$TEST_TEMPORARY_DIRECTORY/output" 2>&1 || TEST_CASE_EXIT_CODE=$?
+
+  TEST_CASE_ASSERTIONS=$(wc -c < "$TEST_ASSERTIONS_FILE" | tr -d ' ')
+  TOTAL_ASSERTIONS=$((TOTAL_ASSERTIONS + TEST_CASE_ASSERTIONS))
+  HUMAN_READABLE_NAME="$(humanize_test_case_name "$TEST_CASE_NAME")"
+
+  if [ -f "$TEST_SKIPPED_FILE" ]; then
+    ((SKIPPED_TEST_CASES++))
+    SKIP_REASON="$(cat "$TEST_SKIPPED_FILE")"
+    if $TAP_OUTPUT; then
+      printf 'ok %d - %s # SKIP %s\n' "$TEST_CASE_INDEX" "$HUMAN_READABLE_NAME" "$SKIP_REASON"
+    else
+      printf '  %sskip%s %s %s(%s)%s\n' "$COLOR_YELLOW" "$COLOR_RESET" "$HUMAN_READABLE_NAME" "$COLOR_DIM" "$SKIP_REASON" "$COLOR_RESET"
+    fi
+    continue
+  fi
+
+  if [ -s "$TEST_DIAGNOSTICS_FILE" ] || [ "$TEST_CASE_EXIT_CODE" -ne 0 ]; then
+    ((FAILED_TEST_CASES++))
+    FAILED_TEST_CASE_NAMES+=("$TEST_CASE_NAME")
+    if $TAP_OUTPUT; then
+      printf 'not ok %d - %s\n' "$TEST_CASE_INDEX" "$HUMAN_READABLE_NAME"
+      sed 's/^/# /' "$TEST_DIAGNOSTICS_FILE"
+    else
+      printf '  %sfail%s %s\n' "$COLOR_RED" "$COLOR_RESET" "$HUMAN_READABLE_NAME"
+      sed "s/^/       /" "$TEST_DIAGNOSTICS_FILE"
+    fi
+    # A non-zero exit code with no recorded failure means the test case itself
+    # crashed, which is worth showing whatever it wrote
+    if [ "$TEST_CASE_EXIT_CODE" -ne 0 ] && [ ! -s "$TEST_DIAGNOSTICS_FILE" ]; then
+      printf '       test case exited with code %d\n' "$TEST_CASE_EXIT_CODE"
+      sed 's/^/       /' "$TEST_TEMPORARY_DIRECTORY/output"
+    fi
+    continue
+  fi
+
+  ((PASSED_TEST_CASES++))
+  if $TAP_OUTPUT; then
+    printf 'ok %d - %s\n' "$TEST_CASE_INDEX" "$HUMAN_READABLE_NAME"
+  else
+    printf '  %sok%s   %s %s(%d assertions)%s\n' "$COLOR_GREEN" "$COLOR_RESET" "$HUMAN_READABLE_NAME" "$COLOR_DIM" "$TEST_CASE_ASSERTIONS" "$COLOR_RESET"
+  fi
+done
+
+if ! $TAP_OUTPUT; then
+  printf '\n'
+  if [ "$FAILED_TEST_CASES" -eq 0 ]; then
+    printf '%s%d test cases passed%s' "$COLOR_GREEN" "$PASSED_TEST_CASES" "$COLOR_RESET"
+  else
+    printf '%s%d test cases failed%s, %d passed' "$COLOR_RED" "$FAILED_TEST_CASES" "$COLOR_RESET" "$PASSED_TEST_CASES"
+  fi
+  if [ "$SKIPPED_TEST_CASES" -gt 0 ]; then
+    printf ', %d skipped' "$SKIPPED_TEST_CASES"
+  fi
+  printf ' (%d assertions)\n' "$TOTAL_ASSERTIONS"
+
+  if [ "$FAILED_TEST_CASES" -ne 0 ]; then
+    printf '\nRe-run a single failing test case with:\n'
+    printf '  tests/run_tests.sh --filter %s\n' "${FAILED_TEST_CASE_NAMES[0]}"
+  fi
+fi
+
+[ "$FAILED_TEST_CASES" -eq 0 ]


### PR DESCRIPTION
Closes #79.

The controller had no automated test at all: every change had to be validated by hand, on the one or two servers the author happens to own, while the code has to work from a 2006 PowerEdge 1950 to a 2024 R770.

This adds **99 test cases** running against a mocked `ipmitool`, so the suite needs no Dell hardware, no iDRAC and no network — `bash`, coreutils, GNU `grep` and `awk` are enough. It runs in about five seconds.

## What it covers

- Every generation from the 9th (2006) to the 17th (2024), through a catalogue of more than a hundred models, including the recent ones whose firmware no longer accepts Dell's IPMI raw fan control commands
- Single, dual and quad socket servers, plus the sensor layouts they report: missing exhaust sensor, empty second socket, unreadable reading, two-digit sensor IDs, PSU inlet sensors
- The raw commands actually sent to the server, and what the controller does when the server rejects them
- The overheating decision, including its fail-safe behaviour on readings that cannot be trusted
- The whole controller started like its Docker image does, and stopped with `SIGTERM` like `docker stop` does

## Layout

```
tests/run_tests.sh          entry point
tests/cases/                10 case files, numbered by area
tests/lib/                  harness, assertions, fixtures, model catalogue
tests/mocks/                ipmitool, sleep, date
.github/workflows/tests.yml on push + pull_request + workflow_dispatch
```

The suite runs on every push and pull request, both directly and inside the built Docker image.

## One deliberate choice worth flagging

The model catalogue records **what the controller currently detects**, not what the server actually is. The model-name-based detection has a blind spot — R6515, R7725, C6420, MX740c, XE9680 and others are Gen 14 or newer yet are detected as older — and the catalogue pins that behaviour rather than hiding it. So the suite documents the bug instead of asserting the code is right; fixing the detection is a separate change, and these tests will show exactly what it moves.

## Note for review

Merges cleanly onto `master` at the time of opening. Adds `tests/` and one workflow file; the only change to existing files is `.dockerignore` and a README section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0113269pY1tNuL5Twfhjj34g

---
_Generated by [Claude Code](https://claude.ai/code/session_0113269pY1tNuL5Twfhjj34g)_