### PR TITLE
Allow a release build to be re-run without deleting and re-pushing its tag

### DIFF
--- a/.github/workflows/build_and_publish_docker_image.yml
+++ b/.github/workflows/build_and_publish_docker_image.yml
@@ -5,11 +5,18 @@ on:
     tags: ["v[0-9]+.[0-9]+"]
     paths-ignore:
       - "**/README.md"
+  # Lets a release build be re-fired from the Actions tab against a tag that
+  # already exists, instead of having to delete and re-push it
+  workflow_dispatch:
 
 jobs:
   build:
     name: Build and publish Docker image to Docker Hub and GitHub Containers Repository
     runs-on: ubuntu-latest
+    # The workflow_dispatch ref dropdown offers branches too. Publishing an image
+    # built from a branch would move "latest" onto unreleased code, so only run
+    # when the ref is a version tag
+    if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -33,8 +40,11 @@ jobs:
           images: |
             ${{ steps.docker_image_name.outputs.value }} # docker.io/tigerblue77/dell_idrac_fan_controller
             ghcr.io/${{ steps.docker_image_name.outputs.value }} # ghcr.io/tigerblue77/dell_idrac_fan_controller
+          # github.ref_name is the tag name on both the push and the workflow_dispatch
+          # paths, whereas "type=ref,event=tag" only resolves on a push tag event and
+          # would leave a dispatched run with no tag at all
           tags: |
-            type=ref,event=tag
+            type=raw,value=${{ github.ref_name }},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
           flavor: |
             latest=auto


### PR DESCRIPTION
Closes #154.

A tag push is currently the only thing that can start this workflow. When a tag fails to trigger it there is no run to re-run, so the only way to build that version is to delete the tag and push it again — which detaches the Release that `Generate release note` created and leaves it behind as an untagged draft.

`v1.18` needed exactly that today, and left exactly that behind (`untagged-e646754539320e40ed50`).

## The change

Three hunks in one file.

**1. `workflow_dispatch:` on the `on:` block** — the actual fix. A missed build can now be re-fired from the Actions tab against the tag that is already there.

**2. Job guard `if: startsWith(github.ref, 'refs/tags/v')`** — the dispatch ref dropdown offers branches as well as tags. Without this, dispatching on `master` would build unreleased code and push it as `latest`.

**3. `type=ref,event=tag` → `type=raw,value=${{ github.ref_name }}`** — this one is not cosmetic, and it is why the PR is three hunks rather than one. `type=ref,event=tag` resolves only on a **push** tag event; `docker/metadata-action` reads the event name, and on `workflow_dispatch` that condition is false. A dispatched run would therefore compute a tag list containing only `latest` and publish an image with no version tag, silently moving `latest` while leaving no `v*` tag behind.

`github.ref_name` is the tag name on both paths, so this produces the identical result on the existing push path — for `refs/tags/v1.19` both forms yield `v1.19` — while also working under dispatch.

## What this does *not* fix

#154 also records a second defect in this workflow: `latest` is applied to every `v*` tag with no version comparison, so concurrent tag builds race and the **last to finish** wins. That is what put `latest` on the older `v1.18` image earlier today. Closing it needs either a "is this the highest version tag" guard or a `concurrency` group, and it is a separate behavioural decision — deliberately left out of this PR.

## Verification

`git diff` against `master` touches one file and nothing else. No change to the build steps, the registries, the platforms, the credentials or the `latest` semantics on the push path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0113269pY1tNuL5Twfhjj34g

---
_Generated by [Claude Code](https://claude.ai/code/session_0113269pY1tNuL5Twfhjj34g)_