### PR TITLE
Say when a fan control fallback was caused by an unreadable reading

### DIFF
--- a/Dell_iDRAC_fan_controller.sh
+++ b/Dell_iDRAC_fan_controller.sh
@@ -133,9 +133,9 @@ while true; do
       # If CPU 2 temperature sensor is present, check if it is overheating too.
       # Do not apply Dell default dynamic fan control profile as it has already been applied before
       if $IS_CPU2_TEMPERATURE_SENSOR_PRESENT && CPU2_OVERHEATING; then
-        COMMENT="CPU 1 and CPU 2 temperatures are too high, Dell default dynamic fan control profile applied for safety"
+        COMMENT=$(build_fan_control_fallback_comment "CPU 1" "$CPU1_TEMPERATURE" "CPU 2" "$CPU2_TEMPERATURE")
       else
-        COMMENT="CPU 1 temperature is too high, Dell default dynamic fan control profile applied for safety"
+        COMMENT=$(build_fan_control_fallback_comment "CPU 1" "$CPU1_TEMPERATURE")
       fi
     fi
   # If CPU 2 temperature sensor is present, check if it is overheating then apply Dell default dynamic fan control profile if true
@@ -144,7 +144,7 @@ while true; do
 
     if ! $IS_DELL_DEFAULT_FAN_CONTROL_PROFILE_APPLIED; then
       IS_DELL_DEFAULT_FAN_CONTROL_PROFILE_APPLIED=true
-      COMMENT="CPU 2 temperature is too high, Dell default dynamic fan control profile applied for safety"
+      COMMENT=$(build_fan_control_fallback_comment "CPU 2" "$CPU2_TEMPERATURE")
     fi
   else
     apply_user_fan_control_profile

--- a/functions.sh
+++ b/functions.sh
@@ -367,18 +367,79 @@ function format_temperature_for_display() {
   fi
 }
 
+# Returns 0 (true) if the given temperature reading is usable, i.e. a plain non-negative integer.
+# A missing sensor, a transient IPMI parsing glitch or an "ns"/"Disabled" sensor all yield something
+# that isn't
+function is_temperature_reading_valid() {
+  [[ "$1" =~ ^[0-9]+$ ]]
+}
+
 # Define functions to check if CPU 1 and CPU 2 temperatures are above the threshold.
-# If a reading isn't a valid number (missing sensor, transient IPMI parsing glitch, etc.), fail safe and
-# report overheating so the Dell default fan control profile kicks in, instead of crashing (bash's "-gt"
-# throws "unary operator expected" on empty/non-numeric input) or silently running the low user fan speed
-# on unverified data
+# If a reading isn't valid, fail safe and report overheating so the Dell default fan control profile
+# kicks in, instead of crashing (bash's "-gt" throws "unary operator expected" on empty/non-numeric
+# input) or silently running the low user fan speed on unverified data
 function CPU1_OVERHEATING() {
-  [[ "$CPU1_TEMPERATURE" =~ ^[0-9]+$ ]] || return 0
+  is_temperature_reading_valid "$CPU1_TEMPERATURE" || return 0
   [ "$((10#$CPU1_TEMPERATURE))" -gt "$CPU_TEMPERATURE_THRESHOLD" ]
 }
 function CPU2_OVERHEATING() {
-  [[ "$CPU2_TEMPERATURE" =~ ^[0-9]+$ ]] || return 0
+  is_temperature_reading_valid "$CPU2_TEMPERATURE" || return 0
   [ "$((10#$CPU2_TEMPERATURE))" -gt "$CPU_TEMPERATURE_THRESHOLD" ]
+}
+
+# Join the given items into an enumeration : "CPU 1", "CPU 1 and CPU 2", "CPU 1, CPU 2 and CPU 3"...
+# Usage : join_with_and $ITEM...
+function join_with_and() {
+  local result=""
+  local i
+
+  for (( i = 1; i <= $#; i++ )); do
+    if (( i == 1 )); then
+      result="${!i}"
+    elif (( i == $# )); then
+      result+=" and ${!i}"
+    else
+      result+=", ${!i}"
+    fi
+  done
+
+  echo "$result"
+}
+
+# Build the comment explaining why the Dell default fan control profile was applied.
+# Usage : build_fan_control_fallback_comment $CPU_NAME $CPU_TEMPERATURE [$CPU_NAME $CPU_TEMPERATURE]...
+#
+# CPU1_OVERHEATING()/CPU2_OVERHEATING() deliberately return true both when a CPU is genuinely too hot
+# and when its reading is unusable, so an unverifiable temperature still falls back to Dell's profile.
+# The comment has to tell the two apart : reporting "temperature is too high" on a reading that was
+# never obtained sends the user chasing a cooling problem instead of the sensor problem they have
+function build_fan_control_fallback_comment() {
+  local -a too_hot=()
+  local -a unreadable=()
+  local -a reasons=()
+
+  while (( $# >= 2 )); do
+    if is_temperature_reading_valid "$2"; then
+      too_hot+=("$1")
+    else
+      unreadable+=("$1")
+    fi
+    shift 2
+  done
+
+  if (( ${#too_hot[@]} == 1 )); then
+    reasons+=("${too_hot[0]} temperature is too high")
+  elif (( ${#too_hot[@]} > 1 )); then
+    reasons+=("$(join_with_and "${too_hot[@]}") temperatures are too high")
+  fi
+
+  if (( ${#unreadable[@]} == 1 )); then
+    reasons+=("${unreadable[0]} temperature could not be read")
+  elif (( ${#unreadable[@]} > 1 )); then
+    reasons+=("$(join_with_and "${unreadable[@]}") temperatures could not be read")
+  fi
+
+  echo "$(join_with_and "${reasons[@]}"), Dell default dynamic fan control profile applied for safety"
 }
 
 function print_error() {


### PR DESCRIPTION
Closes #159.

## Summary

`CPU1_OVERHEATING()`/`CPU2_OVERHEATING()` return true both when a CPU is genuinely above the threshold and when its reading is unusable, so that a temperature which could not be verified still falls back to Dell's profile instead of silently keeping the user's low static fan speed. The comment printed alongside that fallback only ever knew the first case, so a missing sensor or a transient IPMI glitch was reported as `CPU 1 temperature is too high` — on the very same line that shows `-` instead of a temperature.

The comment is now built from the readings themselves:

| Situation | Comment |
|---|---|
| One CPU too hot | `CPU 1 temperature is too high, …` *(unchanged)* |
| Both CPUs too hot | `CPU 1 and CPU 2 temperatures are too high, …` *(unchanged)* |
| One CPU unreadable | `CPU 1 temperature could not be read, …` |
| Both unreadable | `CPU 1 and CPU 2 temperatures could not be read, …` |
| Mixed | `CPU 1 temperature is too high and CPU 2 temperature could not be read, …` |

The two pre-existing sentences are reproduced byte for byte, so logs stay greppable.

## Implementation

- `is_temperature_reading_valid()` extracts the validity rule both overheating functions were duplicating, so the comment applies exactly the same rule as the decision it explains.
- `build_fan_control_fallback_comment()` takes name/reading pairs and sorts them into "too hot" and "could not be read".
- `join_with_and()` renders the enumeration (`CPU 1`, `CPU 1 and CPU 2`, `CPU 1, CPU 2 and CPU 3`…).

Both helpers take an arbitrary number of CPUs rather than assuming two, so they do not need revisiting when more CPUs are monitored.

Only the three comment assignments change in `Dell_iDRAC_fan_controller.sh`; the fan control decision itself is untouched.

## Testing

Unit coverage of the builder, every combination:

```
1 CPU too hot      : CPU 1 temperature is too high, …
1 CPU unreadable   : CPU 1 temperature could not be read, …
"-" placeholder    : CPU 2 temperature could not be read, …
2 CPUs too hot     : CPU 1 and CPU 2 temperatures are too high, …
2 CPUs unreadable  : CPU 1 and CPU 2 temperatures could not be read, …
mixed              : CPU 1 temperature is too high and CPU 2 temperature could not be read, …
4 CPUs too hot     : CPU 1, CPU 2, CPU 3 and CPU 4 temperatures are too high, …
```

End to end against a mocked `ipmitool`, driving the real script through a profile transition (the comment is only emitted when the active profile changes):

- R730 running cool, then reporting 100/101 °C → `CPU 1 and CPU 2 temperatures are too high`
- R730 running cool, then losing both CPU sensors → `CPU 1 and CPU 2 temperatures could not be read`
- T330 single CPU losing its sensor → `CPU 1 temperature could not be read`

`bash -n` on all four scripts.

## Note

This touches the same block as #144, which reworks CPU monitoring to an arbitrary number of CPUs. The helpers here are already N-CPU capable, but whichever lands second will need a rebase.

---
_Generated by [Claude Code](https://claude.ai/code/session_013UDjUCZwbWtWtUyHAjTKSG)_