### PR TITLE
Show the exhaust placeholder on the first line too, instead of a blank

### DIFF
--- a/Dell_iDRAC_fan_controller.sh
+++ b/Dell_iDRAC_fan_controller.sh
@@ -84,6 +84,10 @@ retrieve_temperatures $IS_EXHAUST_TEMPERATURE_SENSOR_PRESENT $IS_CPU2_TEMPERATUR
 if [ -z "$EXHAUST_TEMPERATURE" ]; then
   echo "No exhaust temperature sensor detected."
   IS_EXHAUST_TEMPERATURE_SENSOR_PRESENT=false
+  # This reading was taken before the sensor was known to be absent, so it holds an empty string where
+  # every later cycle will hold the "-" placeholder. Backfilling it here keeps the first printed line
+  # consistent with the rest, instead of leaving a blank under the "Exhaust" heading
+  EXHAUST_TEMPERATURE="-"
 fi
 if [ -z "$CPU2_TEMPERATURE" ]; then
   echo "No CPU2 temperature sensor detected."


### PR DESCRIPTION
Closes #161.

## Summary

Sensor presence is decided from a reading taken before the presence flags exist, so on a server without an exhaust sensor `EXHAUST_TEMPERATURE` still holds the empty string that revealed the sensor was missing. `retrieve_temperatures()` only substitutes the `-` placeholder on its next call, at the end of the first loop iteration, so the first printed line shows a blank where every following one shows `-`.

Backfilling the placeholder where the flag is set keeps the value consistent with the flag that was just derived from it.

## Before / after

On a T330, replaying the `sdr` output posted in #117:

```
                                                             before                after
    Date & time      Inlet  CPU 1  Exhaust
08-08-2026 07:58:27   30°C   73°C       °C     ← blank        30°C   73°C      -°C
08-08-2026 07:58:28   30°C   73°C      -°C                    30°C   73°C      -°C
```

## Scope

One line plus its comment, in the exhaust branch only.

CPU 2 needs no equivalent: `CPUS_TEMPERATURES` is built inside `retrieve_temperatures()` before this check runs, and an absent CPU 2 is simply left out of it, so the first line already matches its header. Adding a placeholder there would be dead code.

This is cosmetic. `printf " %5s°C "` pads an empty string to the same width, so nothing was crashing and no column was shifting — but the blank reads as a missing value on the one line people tend to paste when reporting a problem.

## Testing

Against a mocked `ipmitool` replaying the raw `sdr` outputs from the issues, driving the real script:

| Dump | Exhaust sensor | First line before | First line after |
|---|---|---|---|
| R730 (#125) | present | `32°C` | `32°C` |
| R930 (#91) | present | `28°C` | `28°C` |
| Gen 14 | present | `35°C` | `35°C` |
| CPU at 100 °C | present | `32°C` | `32°C` |
| T330 (#117) | absent | blank | `-°C` |
| Gen 14 without exhaust | absent | blank | `-°C` |
| CPU sensors missing | present | `32°C` | `32°C` |

Servers that do have the sensor are untouched; only the two dumps without one change, and only on their first line. `bash -n` on all four scripts.

---
_Generated by [Claude Code](https://claude.ai/code/session_013UDjUCZwbWtWtUyHAjTKSG)_