### PR TITLE
Preserve the sign of sub-zero temperature readings

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -97,10 +97,37 @@ function set_iDRAC_login_string() {
 # The value is matched on its "degrees" suffix rather than on a fixed two-digit width, so that its
 # width stops mattering : "100 degrees C" used to be truncated to 10°C, and "9 degrees C" used to
 # match nothing at all, which callers cannot tell apart from a missing sensor
+#
+# The sign is part of the match : "\d+" alone silently returned sub-zero readings as their absolute
+# value, turning a -40°C CPU sensor (what a disconnected sensor reports on some iDRACs) into a 40°C
+# one hot enough to trip the overheating branch, and making the sub-zero inlet temperatures this
+# container is expected to react to indistinguishable from mild ones
 function extract_temperature_from_sdr_line() {
   local -r SDR_LINE="$1"
 
-  echo "$SDR_LINE" | cut -d'|' -f5 | grep -Po '\d+(?=[[:space:]]*degrees)'
+  # The sign is written as a character class rather than as a bare "-?" so the pattern doesn't start
+  # with a dash, which grep would otherwise try to parse as one of its own options
+  echo "$SDR_LINE" | cut -d'|' -f5 | grep -Po '[-]?\d+(?=[[:space:]]*degrees)'
+}
+
+# Convert a temperature reading into a plain base 10 integer, usable in arithmetic and comparisons
+# Usage : normalize_decimal_value "$VALUE"
+# Returns : the value as a base 10 integer
+#
+# Readings reach us as text and carry two traps that have to be defused together. A leading zero makes
+# bash read the value as octal, where "09" is not a valid number, which is what the "10#" prefix is
+# for. But "10#" cannot itself accept a sign : "10#-5" is an "invalid integer constant" and aborts the
+# arithmetic. The sign is therefore split off, the digits forced to base 10, and the sign re-applied
+function normalize_decimal_value() {
+  local VALUE="$1"
+  local SIGN=1
+
+  if [[ "$VALUE" == -* ]]; then
+    SIGN=-1
+    VALUE="${VALUE#-}"
+  fi
+
+  echo $((SIGN * 10#$VALUE))
 }
 
 # Extract a single temperature reading from ipmitool sdr output, located by its IPMI entity ID
@@ -352,26 +379,32 @@ function print_temperature_array_line() {
     printf " %s°C " "$(format_temperature_for_display "$temperature")"
   done
 
-  printf " %5s°C  %40s  %51s  %s\n" "$LOCAL_EXHAUST_TEMPERATURE" "$LOCAL_CURRENT_FAN_CONTROL_PROFILE" "$LOCAL_THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE_STATUS" "$LOCAL_COMMENT"
+  # Exhaust goes through the same formatter as the other three temperature columns, so that a reading
+  # that failed on this cycle shows the "-" placeholder rather than an empty column reading as "°C"
+  printf " %5s°C  %40s  %51s  %s\n" "$(format_temperature_for_display "$LOCAL_EXHAUST_TEMPERATURE")" "$LOCAL_CURRENT_FAN_CONTROL_PROFILE" "$LOCAL_THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE_STATUS" "$LOCAL_COMMENT"
 }
 
 # Formats a temperature reading as a right-aligned, 3-character-wide decimal number for display.
 # Falls back to "  -" instead of letting printf %d crash when the reading is empty, a placeholder ("-"),
-# or has a leading zero that would otherwise be misinterpreted as an invalid octal number (e.g. "09")
+# or has a leading zero that would otherwise be misinterpreted as an invalid octal number (e.g. "09").
+# Sub-zero readings are values in their own right, not invalid ones, so they keep their sign
 function format_temperature_for_display() {
   local -r VALUE="$1"
-  if [[ "$VALUE" =~ ^[0-9]+$ ]]; then
-    printf '%3d' "$((10#$VALUE))"
+  if is_temperature_reading_valid "$VALUE"; then
+    printf '%3d' "$(normalize_decimal_value "$VALUE")"
   else
     printf '%3s' "-"
   fi
 }
 
-# Returns 0 (true) if the given temperature reading is usable, i.e. a plain non-negative integer.
+# Returns 0 (true) if the given temperature reading is usable, i.e. an integer.
 # A missing sensor, a transient IPMI parsing glitch or an "ns"/"Disabled" sensor all yield something
-# that isn't
+# that isn't.
+#
+# A sub-zero reading is a value in its own right rather than an unusable one : Dell rates the PowerEdge
+# line down to -5°C, so an unheated room produces one in normal operation
 function is_temperature_reading_valid() {
-  [[ "$1" =~ ^[0-9]+$ ]]
+  [[ "$1" =~ ^-?[0-9]+$ ]]
 }
 
 # Define functions to check if CPU 1 and CPU 2 temperatures are above the threshold.
@@ -380,11 +413,11 @@ function is_temperature_reading_valid() {
 # input) or silently running the low user fan speed on unverified data
 function CPU1_OVERHEATING() {
   is_temperature_reading_valid "$CPU1_TEMPERATURE" || return 0
-  [ "$((10#$CPU1_TEMPERATURE))" -gt "$CPU_TEMPERATURE_THRESHOLD" ]
+  [ "$(normalize_decimal_value "$CPU1_TEMPERATURE")" -gt "$CPU_TEMPERATURE_THRESHOLD" ]
 }
 function CPU2_OVERHEATING() {
   is_temperature_reading_valid "$CPU2_TEMPERATURE" || return 0
-  [ "$((10#$CPU2_TEMPERATURE))" -gt "$CPU_TEMPERATURE_THRESHOLD" ]
+  [ "$(normalize_decimal_value "$CPU2_TEMPERATURE")" -gt "$CPU_TEMPERATURE_THRESHOLD" ]
 }
 
 # Join the given items into an enumeration : "CPU 1", "CPU 1 and CPU 2", "CPU 1, CPU 2 and CPU 3"...


### PR DESCRIPTION
Closes #147. Follow-up to #146, which made inlet and exhaust readings width-independent but left them, and the CPU readings, unsigned.

**First in a stack of three. Merge this one first** — #164 (#148/#149/#172) and #165 (#49) build on `normalize_decimal_value()` introduced here.

## The defect

`extract_temperature_from_sdr_line()` matched `\d+`, which cannot match a leading minus, so every sub-zero reading came back as its absolute value:

| iDRAC reports | parsed as (before) | parsed as (after) |
|---|---|---|
| `-1 degrees C` | `1` | `-1` |
| `-5 degrees C` | `5` | `-5` |
| `-12 degrees C` | `12` | `-12` |
| `-40 degrees C` | `40` | `-40` |

On the display columns that only made a cold room look mild. On the CPU path it inverted a safety decision: a sensor reporting −40 °C — what a disconnected CPU sensor reports on some iDRACs — was read as +40 °C and tripped the overheating branch against any threshold below it, forcing the Dell default profile and its full fan ramp on a machine that was not hot.

It also blocked #49, which reacts to inlet temperatures below 10 °C. Negative ones are in-spec rather than anomalous there: Dell rates the PowerEdge line down to −5 °C for up to 1 % of annual operating hours, and the servers this container targets are often in unheated rooms.

## What changed

The extraction pattern now matches an optional sign. It is written as a character class (`[-]?`) rather than a bare `-?` so the pattern does not start with a dash, which `grep` parses as one of its own options — the naive form fails with `grep: invalid option -- '?'`.

Preserving the sign then had to reach the guards that consume these readings, which rejected or crashed on it:

- **`is_temperature_reading_valid()`** tested `^[0-9]+$`. Widening it to `^-?[0-9]+$` is now the whole change on that side, #162 having centralised the test into this one function — the CPU overheating checks and the fallback-comment classifier pick it up for free.
- **`format_temperature_for_display()`** kept an inline copy of the same predicate, which would have printed the `-` placeholder in place of a real sub-zero measurement. It now calls `is_temperature_reading_valid()` too, so the rule for what counts as a reading lives in exactly one place instead of two that have to be widened in step.
- **`$((10#$VALUE))`** throws `invalid integer constant` on `-5`. The `10#` prefix defuses the leading-zero octal trap and cannot just be dropped, so the new `normalize_decimal_value()` splits the sign off, forces the digits to base 10, and re-applies it.

Exhaust also joins the other three columns in going through `format_temperature_for_display()`. #162 already backfills `EXHAUST_TEMPERATURE="-"` for the first printed line; this covers the other case, a reading that fails on a later cycle and would otherwise render as a bare `°C` over an empty column. Output is unchanged for every readable value.

## Interaction with #162's fallback comment

`build_fan_control_fallback_comment()` uses `is_temperature_reading_valid()` to tell "too hot" from "could not be read". Widening the predicate makes a −40 °C reading *valid*, which is the point: with its sign preserved it is no longer greater than the threshold, `CPU1_OVERHEATING()` returns false, and no fallback is triggered at all. The unreadable-reading path is untouched — empty and non-numeric input still fail safe to "assume overheating".

## Verification

Exercised against a stubbed `ipmitool` covering inlet, exhaust and CPU across `-40`, `-12`, `-5`, `-1`, `0`, `5`, `9`, `09`, `21`, `100` and `105`, the `-`/empty/garbage placeholders, and end-to-end runs of the real entrypoint confirming that:

- a CPU reporting −40 °C against a 30 °C threshold no longer trips the overheating branch;
- an unreadable CPU still does, and still prints #162's "temperature could not be read" wording on the transition.

**Rebased onto `master`** (was based on 814d799, before #160/#162). The conflict was the `is_temperature_reading_valid()` centralisation described above.