### PR TITLE
Validate boolean parameters instead of executing whatever they contain

### DIFF
--- a/Dell_iDRAC_fan_controller.sh
+++ b/Dell_iDRAC_fan_controller.sh
@@ -22,6 +22,14 @@ validate_fan_speed_parameter "FAN_SPEED" "$FAN_SPEED"
 validate_integer_parameter "CPU_TEMPERATURE_THRESHOLD" "$CPU_TEMPERATURE_THRESHOLD" -128 127
 validate_check_interval_parameter "CHECK_INTERVAL" "$CHECK_INTERVAL"
 
+# The booleans are validated for the same reason, their failure mode just being quieter still: they are
+# dispatched by running their value as a command, so anything that isn't literally "true" or "false" is
+# a command that doesn't exist, exits 127, and takes the branch as false. "True", "1" and "Yes" would
+# each give the user the exact opposite of what they configured, without a word about it
+validate_boolean_parameter "DISABLE_THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE" "$DISABLE_THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE"
+validate_boolean_parameter "KEEP_THIRD_PARTY_PCIE_CARD_COOLING_RESPONSE_STATE_ON_EXIT" "$KEEP_THIRD_PARTY_PCIE_CARD_COOLING_RESPONSE_STATE_ON_EXIT"
+validate_boolean_parameter "MONITORING_ONLY_MODE" "$MONITORING_ONLY_MODE"
+
 # Leading zeros are stripped so that the value used in comparisons is the one the user meant, "09"
 # being read as an invalid octal number everywhere else
 CPU_TEMPERATURE_THRESHOLD=$(normalize_decimal_value "$CPU_TEMPERATURE_THRESHOLD")
@@ -144,7 +152,7 @@ if $IS_LOW_TEMPERATURE_PROTECTION_ENABLED; then
 else
   echo "Low temperature protection: Disabled"
 fi
-if $MONITORING_ONLY_MODE; then
+if "$MONITORING_ONLY_MODE"; then
   echo "Monitoring only mode: Enabled (no fan control profile will be applied, temperatures will only be logged)"
 else
   echo "Monitoring only mode: Disabled"
@@ -291,7 +299,7 @@ while true; do
       THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE_STATUS="Enabled"
     fi
 
-    if $MONITORING_ONLY_MODE; then
+    if "$MONITORING_ONLY_MODE"; then
       THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE_STATUS+=" (not applied: monitoring only mode)"
     fi
   fi

--- a/functions.sh
+++ b/functions.sh
@@ -2,7 +2,7 @@
 # This function applies Dell's default dynamic fan control profile
 # In monitoring only mode, the profile is only logged, not actually applied
 function apply_Dell_default_fan_control_profile() {
-  if $MONITORING_ONLY_MODE; then
+  if "$MONITORING_ONLY_MODE"; then
     CURRENT_FAN_CONTROL_PROFILE="Dell default dynamic fan control profile (monitoring only, not applied)"
     return
   fi
@@ -35,7 +35,7 @@ function apply_static_fan_control_profile() {
   local -r HEXADECIMAL_SPEED="$2"
   local -r PROFILE_NAME="$3"
 
-  if $MONITORING_ONLY_MODE; then
+  if "$MONITORING_ONLY_MODE"; then
     CURRENT_FAN_CONTROL_PROFILE="$PROFILE_NAME ($DECIMAL_SPEED%) (monitoring only, not applied)"
     return
   fi
@@ -164,6 +164,27 @@ function validate_check_interval_parameter() {
   # take a fractional value at all
   if [[ "$DURATION" =~ ^0*\.?0*$ ]]; then
     print_configuration_error_and_exit "$PARAMETER_NAME" "$VALUE" "a duration greater than zero, otherwise the monitoring loop would never pause between two readings"
+  fi
+}
+
+# Stop the container unless the given parameter is one of the two documented boolean values
+# Usage : validate_boolean_parameter "$PARAMETER_NAME" "$VALUE"
+#
+# Booleans are dispatched by running their value as a command, "true" and "false" being real programs.
+# Anything else is a command that doesn't exist : it exits 127 and the branch is silently taken as
+# false, so "True", "TRUE", "1", "on" and "Yes" all give the user the opposite of what they asked for.
+# MONITORING_ONLY_MODE=True is the dangerous one, the container reporting the mode as disabled and then
+# taking real control of the fans on a server the operator asked it not to touch.
+#
+# "yes" is worse still, being a command that DOES exist and never returns : the container blocks on the
+# first test, floods stdout at hundreds of MB per second, and cannot be stopped by "docker stop", the
+# graceful_exit trap being deferred while yes holds the foreground
+function validate_boolean_parameter() {
+  local -r PARAMETER_NAME="$1"
+  local -r VALUE="$2"
+
+  if [ "$VALUE" != "true" ] && [ "$VALUE" != "false" ]; then
+    print_configuration_error_and_exit "$PARAMETER_NAME" "$VALUE" "exactly \"true\" or \"false\", in lower case ; \"True\", \"1\", \"yes\" and \"on\" are not accepted because they would silently be taken as false"
   fi
 }
 
@@ -359,7 +380,7 @@ function is_server_powered_on() {
 # /!\ Use this function only for Gen 13 and older generation servers /!\
 # In monitoring only mode, this is a no-op
 function enable_third_party_PCIe_card_Dell_default_cooling_response() {
-  if $MONITORING_ONLY_MODE; then
+  if "$MONITORING_ONLY_MODE"; then
     return
   fi
   # We could check the current cooling response before applying but it's not very useful so let's skip the test and apply directly
@@ -374,7 +395,7 @@ function enable_third_party_PCIe_card_Dell_default_cooling_response() {
 # /!\ Use this function only for Gen 13 and older generation servers /!\
 # In monitoring only mode, this is a no-op
 function disable_third_party_PCIe_card_Dell_default_cooling_response() {
-  if $MONITORING_ONLY_MODE; then
+  if "$MONITORING_ONLY_MODE"; then
     return
   fi
   # We could check the current cooling response before applying but it's not very useful so let's skip the test and apply directly
@@ -405,7 +426,7 @@ function disable_third_party_PCIe_card_Dell_default_cooling_response() {
 
 # Prepare traps in case of container exit
 function graceful_exit() {
-  if $MONITORING_ONLY_MODE; then
+  if "$MONITORING_ONLY_MODE"; then
     print_warning_and_exit "Container stopped (monitoring only mode, no fan control profile was ever applied)"
   fi
 


### PR DESCRIPTION
Closes #166. **4th in the stack** — based on #165.

Booleans are dispatched by running their value as a command. Anything that isn't literally `true` or `false` is a command that doesn't exist: it exits 127 and the branch is silently taken as false.

## `MONITORING_ONLY_MODE=True` broke the mode's core promise

Measured against a stubbed `ipmitool` that logs every call:

```
Monitoring only mode: Disabled
  commands actually sent:
    raw 0x30 0x30 0x01 0x00       <- enable manual fan control
    raw 0x30 0x30 0x02 0xff 0x05  <- pin fans to 5%
```

The container seized manual fan control and pinned the fans on a server the operator had explicitly asked it not to touch — the exact opposite of what the README promises for this mode, and the mode it recommends running first.

## `MONITORING_ONLY_MODE=yes` made the container unkillable

`yes` is a command that *does* exist and never returns.

```
>> still alive 2s after SIGTERM (docker stop fails)
   log written in ~4s: 674828288 bytes
```

**675 MB in four seconds**, and `docker stop` could not end it — the `graceful_exit` trap stays deferred while `yes` holds the foreground, so only SIGKILL works. The monitoring loop was never entered, so no fan profile was ever applied either. A host disk fills in minutes. It now exits in **15 ms** with an error.

## The exit-time booleans inverted intent too

`KEEP_THIRD_PARTY_PCIE_CARD_COOLING_RESPONSE_STATE_ON_EXIT=True` made the container **reset** the cooling response on exit — the opposite of what its name asks.

## What changed

All three booleans are checked at startup next to the numeric parameters, and a value that isn't literally `true` or `false` stops the container. Once the value is known to be one of two literals, running it as a command is sound, so the existing idiom stays.

The `MONITORING_ONLY_MODE` call sites are also quoted, which they alone weren't — unquoted, the value was word-split into a command plus arguments, and `MONITORING_ONLY_MODE="touch /tmp/pwned"` really did create the file. Not a privilege boundary (whoever sets the environment already controls the container), but it made a typo behave unpredictably rather than fail. Validation makes it unreachable; the quoting makes it impossible.

## Verification

`True`, `TRUE`, `1`, `yes`, `on`, `Yes` and empty all rejected at startup; `true` and `false` behave exactly as before.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CbNSVDuGxXfPf9qyKnsNbh)_