### PR TITLE
Tell an unreachable iDRAC apart from a powered-off server

### DIFF
--- a/Dell_iDRAC_fan_controller.sh
+++ b/Dell_iDRAC_fan_controller.sh
@@ -149,8 +149,12 @@ IS_DELL_DEFAULT_FAN_CONTROL_PROFILE_APPLIED=true
 # No starting value of that flag fixes it: setting it the other way just moves the
 # silence onto the healthy path
 IS_FIRST_MONITORING_CYCLE=true
-# Tracks whether the target server was powered off on the previous cycle, so temperatures can be
-# refreshed right when it powers back on instead of reusing data read before/during the outage
+# Tracks whether the previous cycle was skipped, so temperatures can be refreshed the moment the
+# server comes back instead of reusing data read before/during the outage. Set by both reasons a
+# cycle is skipped, the readings being equally stale either way
+IS_TARGET_SERVER_UNAVAILABLE=false
+# Tracks whether that outage was the server actually being powered off, as opposed to an iDRAC we
+# could not reach. Only the first can have changed the CPUs, and only it may open the removal window
 IS_TARGET_SERVER_POWERED_OFF=false
 
 # Start timer in background
@@ -166,9 +170,12 @@ SLEEP_PROCESS_PID=$!
 # A server that does answer is a different matter, and is handled inside the loop : it has CPUs, so
 # reporting none of them is a fault to report rather than a state to wait out
 while true; do
+  # Either outcome get_server_power_state reports as non-zero -- powered off, or an iDRAC that cannot be
+  # reached at all -- means no sensor can be read yet, which is what this loop waits on. They are only
+  # worth telling apart once the monitoring loop is running and a profile is actually being held
   IS_TARGET_SERVER_ANSWERING=true
-  if $NETWORK_MODE && ! is_server_powered_on; then
-    IS_TARGET_SERVER_ANSWERING=false
+  if $NETWORK_MODE; then
+    get_server_power_state || IS_TARGET_SERVER_ANSWERING=false
   fi
 
   if $IS_TARGET_SERVER_ANSWERING; then
@@ -238,29 +245,53 @@ fi
 # Start monitoring
 while true; do
   # In network mode, if the target server is powered off, skip this cycle entirely: don't read
-  # temperatures (they would be meaningless) and don't apply any fan control profile
-  if $NETWORK_MODE && ! is_server_powered_on; then
-    IS_TARGET_SERVER_POWERED_OFF=true
-    set_log_timestamp TIMESTAMP
-    printf "%19s  Target server is powered off, no fan control profile applied.\n" "$TIMESTAMP"
+  # temperatures (they would be meaningless) and don't apply any fan control profile.
+  # A cycle is also skipped when the iDRAC can't be reached at all, but the two are reported
+  # separately: one is a machine that is legitimately off, the other is a server we may well be
+  # holding at a static fan speed with no way to see or change anything about it
+  if $NETWORK_MODE; then
+    get_server_power_state
+    TARGET_SERVER_POWER_STATE=$?
 
-    wait $SLEEP_PROCESS_PID
+    if [ $TARGET_SERVER_POWER_STATE -ne 0 ]; then
+      IS_TARGET_SERVER_UNAVAILABLE=true
+      set_log_timestamp TIMESTAMP
 
-    # Start timer in background for next cycle
-    sleep "$CHECK_INTERVAL" &
-    SLEEP_PROCESS_PID=$!
-    continue
+      if [ $TARGET_SERVER_POWER_STATE -eq 2 ]; then
+        # Deliberately not flagged as powered off : we did not observe the server, we failed to ask.
+        # A dropped session or a LAN flap leaves it running, and its CPUs cannot have changed
+        printf "%19s  Cannot reach the iDRAC, target server state unknown and fan control profile left as-is. ipmitool said: %s\n" "$TIMESTAMP" "$IPMI_UNREACHABLE_REASON" >&2
+      else
+        IS_TARGET_SERVER_POWERED_OFF=true
+        printf "%19s  Target server is powered off, no fan control profile applied.\n" "$TIMESTAMP"
+      fi
+
+      wait $SLEEP_PROCESS_PID
+
+      # Start timer in background for next cycle
+      sleep "$CHECK_INTERVAL" &
+      SLEEP_PROCESS_PID=$!
+      continue
+    fi
   fi
 
   # The server just powered back on: refresh temperatures now instead of evaluating stale data read
   # before/during the outage (could be the initial pre-loop reading, or readings from before it powered off)
-  if $IS_TARGET_SERVER_POWERED_OFF; then
-    IS_TARGET_SERVER_POWERED_OFF=false
-    # It has just been switched off and on again, which is the only way its CPUs can have changed : open
-    # the window during which one is allowed to leave the monitored set
-    IS_CPU_REMOVAL_ALLOWED=true
-    PENDING_CPU_REMOVAL_SIGNATURE=""
-    PENDING_CPU_REMOVAL_READINGS=0
+  if $IS_TARGET_SERVER_UNAVAILABLE; then
+    IS_TARGET_SERVER_UNAVAILABLE=false
+
+    # Only a server that was really switched off and on again can have changed CPUs, so only that opens
+    # the window during which one is allowed to leave the monitored set. An iDRAC we merely could not
+    # reach says nothing about the machine : it kept running, and treating the outage as a power cycle
+    # would let five unreadable readings after a LAN flap drop a socket that never went anywhere
+    if $IS_TARGET_SERVER_POWERED_OFF; then
+      IS_TARGET_SERVER_POWERED_OFF=false
+      IS_CPU_REMOVAL_ALLOWED=true
+      PENDING_CPU_REMOVAL_SIGNATURE=""
+      PENDING_CPU_REMOVAL_READINGS=0
+    fi
+
+    # Refreshed after either outage : the readings taken before or during it are equally stale
     retrieve_temperatures
   fi
 

--- a/functions.sh
+++ b/functions.sh
@@ -650,11 +650,26 @@ function retrieve_temperatures() {
   EXHAUST_TEMPERATURE=$(retrieve_temperature_by_sensor_name "$DATA" "Exhaust")
 }
 
-# Returns 0 (true) if the target server is currently powered on, 1 (false) otherwise
+# Report the target server's power state
+# Returns : 0 if it is powered on, 1 if it is powered off, 2 if the iDRAC could not be reached
+#
 # Only meaningful in network mode: in local mode the container runs on the target server itself,
 # so it cannot be observed powered off while the container is running
-function is_server_powered_on() {
-  local -r POWER_STATUS=$(ipmitool -I $IDRAC_LOGIN_STRING chassis power status 2>/dev/null)
+#
+# The three outcomes used to be two. stderr and the exit code were both discarded and the verdict came
+# from a substring, so a failed call produced empty output, didn't contain "is on", and was reported as
+# a powered-off chassis -- indistinguishable from the real thing. A dropped session, rotated
+# credentials, an iDRAC reboot and a LAN flap all landed in the same branch, and the caller skipped the
+# cycle without reading temperatures or applying any profile, leaving the fans frozen at the user's
+# static speed on a running, loaded server while the log called it benign
+function get_server_power_state() {
+  local POWER_STATUS
+  POWER_STATUS=$(ipmitool -I $IDRAC_LOGIN_STRING chassis power status 2>&1)
+  if [ $? -ne 0 ]; then
+    IPMI_UNREACHABLE_REASON="$POWER_STATUS"
+    return 2
+  fi
+
   [[ "$POWER_STATUS" == *"is on"* ]]
 }
 

--- a/tests/cases/85_power_state.sh
+++ b/tests/cases/85_power_state.sh
@@ -3,40 +3,63 @@
 # In network mode the container keeps running while the server it cools is
 # powered off. Reading temperatures then would be meaningless, and applying a fan
 # control profile would either fail or wake the fans of a sleeping chassis, so
-# the whole cycle is skipped. Anything that is not a clear "powered on" answer
-# must therefore be treated as powered off.
+# the whole cycle is skipped.
+#
+# A chassis that is genuinely off and an iDRAC that cannot be reached at all both
+# skip the cycle, but they are not the same event and must not be reported as
+# one: the first is a machine legitimately at rest, the second is a server we may
+# well be holding at a static fan speed with no way to see or change anything
+# about it. get_server_power_state therefore has three outcomes rather than two.
 
 function test_a_powered_on_server_is_detected() {
   export MOCK_IPMITOOL_POWER_STATUS="Chassis Power is on"
 
-  assert_command_succeeds "a server answering \"Chassis Power is on\" is powered on" is_server_powered_on
+  assert_command_succeeds "a server answering \"Chassis Power is on\" is powered on" get_server_power_state
 }
 
 function test_a_powered_off_server_is_detected() {
   export MOCK_IPMITOOL_POWER_STATUS="Chassis Power is off"
 
-  assert_command_fails "a server answering \"Chassis Power is off\" is powered off" is_server_powered_on
+  get_server_power_state
+  assert_equals "1" "$?" "a server answering \"Chassis Power is off\" is powered off, not unreachable"
 }
 
-function test_an_empty_power_status_is_treated_as_powered_off() {
+function test_an_empty_power_status_is_not_read_as_powered_on() {
+  # The query succeeded and simply didn't say "is on". That is not an unreachable
+  # iDRAC, so it stays in the powered-off branch rather than being escalated
   export MOCK_IPMITOOL_POWER_STATUS=""
 
-  assert_command_fails "no answer at all must not be read as powered on" is_server_powered_on
+  get_server_power_state
+  assert_equals "1" "$?" "no answer at all must not be read as powered on"
 }
 
-function test_a_failing_power_status_query_is_treated_as_powered_off() {
-  # An iDRAC that stopped answering, a wrong password, a network outage : none of
-  # them is a reason to start sending fan control commands into the void
+function test_an_unreachable_idrac_is_told_apart_from_a_powered_off_server() {
+  # An iDRAC that stopped answering, a wrong password, a network outage: none of
+  # them is a powered-off chassis, and reporting them as one is what used to
+  # freeze fan control indefinitely while the log called it benign
   export MOCK_IPMITOOL_POWER_EXIT_CODE=1
   export MOCK_IPMITOOL_POWER_STATUS="Error: Unable to establish IPMI v2 / RMCP+ session"
 
-  assert_command_fails "a failing query must not be read as powered on" is_server_powered_on
+  get_server_power_state
+  assert_equals "2" "$?" "a failing query must be reported as unreachable, not as powered off"
+}
+
+function test_an_unreachable_idrac_keeps_the_reason_it_gave() {
+  # The caller prints this, so a user can tell a rotated password from a LAN flap
+  # instead of being told the server is off
+  export MOCK_IPMITOOL_POWER_EXIT_CODE=1
+  export MOCK_IPMITOOL_POWER_STATUS="Error: Unable to establish IPMI v2 / RMCP+ session"
+
+  get_server_power_state
+
+  assert_contains "$IPMI_UNREACHABLE_REASON" "Unable to establish IPMI v2 / RMCP+ session" \
+    "the reason ipmitool gave must survive for the caller to report"
 }
 
 function test_the_power_status_is_queried_through_the_idrac_login_string() {
   IDRAC_LOGIN_STRING="lanplus -H 10.0.0.42 -U administrator -E"
 
-  is_server_powered_on
+  get_server_power_state
 
   assert_equals "1" "$(count_ipmitool_calls_matching "chassis power status")"
   assert_contains "$(recorded_ipmitool_calls)" "-H 10.0.0.42 -U administrator -E" \

--- a/tests/cases/90_integration.sh
+++ b/tests/cases/90_integration.sh
@@ -426,3 +426,33 @@ function test_a_removed_cpu_is_reported_as_removed_and_not_merely_as_silent() {
     "and the entities, so the line can be matched against an ipmitool output"
   assert_contains "$OUTPUT" "2 CPU temperature sensors detected (entities 3.1 3.2)."
 }
+
+function test_an_unreachable_idrac_does_not_open_the_cpu_removal_window() {
+  # A CPU can only be added or removed while the server is off, which is why a
+  # confirmed power cycle is what allows one to leave the monitored set. An iDRAC
+  # we merely failed to reach is not that event : the machine kept running, so its
+  # sockets cannot have changed. Treating the outage as a power cycle would let a
+  # socket that goes quiet afterwards be dropped, and a dropped column is a heat
+  # source nobody is watching.
+  simulate_server "PowerEdge R930" --cpus 4 --cpu-temperatures "41 40 39 38"
+
+  # Reachable, then an unreachable iDRAC for two cycles, then answering again --
+  # the same shape as the power cycle in the test above, but without the server
+  # ever reporting itself off
+  export MOCK_IPMITOOL_POWER_EXIT_CODE_SEQUENCE MOCK_IPMITOOL_SDR_SECOND_OUTPUT MOCK_IPMITOOL_SDR_SWITCH_AFTER_CALLS
+  MOCK_IPMITOOL_POWER_EXIT_CODE_SEQUENCE="0 1 1 0"
+  # Two sockets go quiet from the moment the iDRAC answers again, and keep quiet,
+  # so a wrongly opened window has every reading it needs to confirm a removal
+  MOCK_IPMITOOL_SDR_SECOND_OUTPUT=$(make_sdr_output --cpus 2 --cpu-temperatures "41 40")
+  MOCK_IPMITOOL_SDR_SWITCH_AFTER_CALLS=1
+
+  # Far more cycles than CPU_REMOVAL_CONFIRMING_READINGS, so absence is a verdict
+  local -r OUTPUT=$(run_controller "$CONTROLLER_TEMPERATURE_LINE_PATTERN" 12)
+
+  assert_contains "$OUTPUT" "Cannot reach the iDRAC" \
+    "the unreachable iDRAC must be reported as such"
+  assert_not_contains "$OUTPUT" "Target server is powered off" \
+    "a query that failed is not an observation that the server is off"
+  assert_not_contains "$OUTPUT" "considered removed" \
+    "no CPU may be dropped : the server never powered off, so none can have left"
+}

--- a/tests/mocks/ipmitool
+++ b/tests/mocks/ipmitool
@@ -33,6 +33,14 @@
 #                                            see its target server switched off
 #                                            and back on ("on on off on on")
 #   MOCK_IPMITOOL_POWER_EXIT_CODE  its exit code (default 0)
+#   MOCK_IPMITOOL_POWER_EXIT_CODE_SEQUENCE   exit codes returned one per call, the
+#                                            last one repeating, so that a running
+#                                            controller can be made to see its
+#                                            iDRAC become unreachable and then
+#                                            answer again ("0 1 1 0"). A non-zero
+#                                            entry is an unreachable iDRAC, which
+#                                            is not the same event as a chassis
+#                                            reporting itself powered off
 #   MOCK_IPMITOOL_RAW_STDERR       stderr printed by every "ipmitool raw" call
 #   MOCK_IPMITOOL_RAW_EXIT_CODE    exit code of every "ipmitool raw" call
 #   MOCK_IPMITOOL_RAW_FAIL_ONLY_ONCE  when "true", only the FIRST command matching
@@ -105,6 +113,23 @@ case "$SUB_COMMAND" in
     ;;
 
   chassis)
+    # An unreachable iDRAC answers on stderr and exits non-zero, so the sequence drives both together
+    if [ -n "${MOCK_IPMITOOL_POWER_EXIT_CODE_SEQUENCE:-}" ] && [ -n "${MOCK_IPMITOOL_CALL_LOG:-}" ]; then
+      POWER_CALL_NUMBER=$(grep -c ' chassis ' "$MOCK_IPMITOOL_CALL_LOG")
+      read -r -a POWER_EXIT_CODES <<< "$MOCK_IPMITOOL_POWER_EXIT_CODE_SEQUENCE"
+      if [ "$POWER_CALL_NUMBER" -gt "${#POWER_EXIT_CODES[@]}" ]; then
+        POWER_CALL_NUMBER=${#POWER_EXIT_CODES[@]}
+      fi
+      POWER_EXIT_CODE="${POWER_EXIT_CODES[POWER_CALL_NUMBER - 1]}"
+
+      if [ "$POWER_EXIT_CODE" -ne 0 ]; then
+        printf 'Error: Unable to establish IPMI v2 / RMCP+ session\n' >&2
+      else
+        printf '%s\n' "${MOCK_IPMITOOL_POWER_STATUS-Chassis Power is on}"
+      fi
+      exit "$POWER_EXIT_CODE"
+    fi
+
     if [ -n "${MOCK_IPMITOOL_POWER_STATUS_SEQUENCE:-}" ] && [ -n "${MOCK_IPMITOOL_CALL_LOG:-}" ]; then
       # The current call is already in the log, so this counts it too
       POWER_CALL_NUMBER=$(grep -c ' chassis ' "$MOCK_IPMITOOL_CALL_LOG")


### PR DESCRIPTION
Closes #151. Rebased onto current `master`.

## The defect

`is_server_powered_on()` discarded both stderr and the exit code and decided on a substring:

```bash
local -r POWER_STATUS=$(ipmitool -I $IDRAC_LOGIN_STRING chassis power status 2>/dev/null)
[[ "$POWER_STATUS" == *"is on"* ]]
```

A failed call produces empty output, which does not contain `is on`, so it was indistinguishable from a genuinely powered-off chassis. A dropped session, rotated credentials, an iDRAC reboot and a LAN flap all landed in the same branch: the loop skipped the cycle without reading temperatures and **without applying any profile**, so whatever profile was applied last stayed in force on the hardware — typically the user's static low speed, on a running, loaded server, while the log calmly reported a benign powered-off machine.

## The fix

`get_server_power_state()` replaces it with three outcomes:

| return | meaning |
|---|---|
| 0 | powered on |
| 1 | powered off |
| 2 | the iDRAC could not be reached |

The reason `ipmitool` gave is kept in `IPMI_UNREACHABLE_REASON` so the caller can print it — a rotated password and a LAN flap are different problems for whoever reads the log. Only the genuine power-off keeps its old wording; the unreachable case says so explicitly and goes to stderr.

## The part that is not just renaming

That distinction has to reach the **CPU removal window**, and this is where getting it wrong would cost something real.

A CPU can only be added or removed while the server is off, which is why `refresh_CPU_temperature_sensors()` (from #144) only lets a socket leave the monitored set across a power cycle, confirmed over `CPU_REMOVAL_CONFIRMING_READINGS` agreeing readings. An iDRAC we merely failed to reach **is not that event**: the machine kept running, so its sockets cannot have changed.

Flagging the outage as a power-off would open that window anyway, and a socket going quiet afterwards would then be dropped — a heat source silently unmonitored, which is the very thing the gate exists to prevent. So the two conditions are tracked apart:

- `IS_TARGET_SERVER_UNAVAILABLE` — set by both, and refreshes temperatures on recovery, the readings being equally stale either way;
- `IS_TARGET_SERVER_POWERED_OFF` — set only by a real power-off, and is the only one that opens the removal window.

This was found by reading the merged `master` rather than the branch in isolation, and it is **demonstrated by a test rather than argued**: reintroducing the single-flag version makes the new integration case fail, with CPU 3 and CPU 4 losing their columns after nothing worse than a network incident.

## The pre-loop wait

The wait that detects the CPU sensors before the monitoring loop calls the new function too. Both non-zero outcomes mean no sensor can be read yet, which is all that loop waits on, so it treats them alike — they are only worth telling apart once a profile is actually being held.

## Verification

**199 test cases pass**, 1 skipped (1254 assertions).

`tests/cases/85_power_state.sh` was rewritten for the three-state contract — it previously encoded the premise this change overturns ("anything that is not a clear powered-on answer must be treated as powered off"). It now covers powered on, powered off, an empty answer that still means off, an unreachable iDRAC returning 2, and the reason surviving for the caller.

`tests/cases/90_integration.sh` gains `test_an_unreachable_idrac_does_not_open_the_cpu_removal_window`, driving a full reachable → unreachable → recovered sequence with two sockets going quiet. Verified to fail on the regression, not merely to pass.

The `ipmitool` mock gains `MOCK_IPMITOOL_POWER_EXIT_CODE_SEQUENCE`, without which an iDRAC that becomes unreachable and then answers again could not be simulated at all.