### PR TITLE
Monitor every populated CPU socket instead of the first two

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,11 @@ CPU_TEMPERATURE_THRESHOLD=<decimal temperature threshold>
 CHECK_INTERVAL=<seconds between each check>
 DISABLE_THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE=<true or false>
 KEEP_THIRD_PARTY_PCIE_CARD_COOLING_RESPONSE_STATE_ON_EXIT=<true or false>
+MONITORING_ONLY_MODE=<true or false>
+
+# Intake air temperature limits. All four are optional: leave them out entirely to keep the
+# behavior unchanged. See the "Parameters" section of the README before setting them.
+# HIGH_INLET_TEMPERATURE_THRESHOLD=<decimal temperature above which Dell's profile is restored>
+# LOW_INLET_TEMPERATURE_THRESHOLD=<decimal temperature below which the fan speed is reduced>
+# LOW_CPU_TEMPERATURE_THRESHOLD=<decimal temperature below which the fan speed is reduced>
+# LOW_TEMPERATURE_FAN_SPEED=<reduced fan speed, required by the two thresholds above>

--- a/Dell_iDRAC_fan_controller.sh
+++ b/Dell_iDRAC_fan_controller.sh
@@ -204,17 +204,30 @@ readonly HEADER=$(build_header $NUMBER_OF_DETECTED_CPUS)
 # Start monitoring
 while true; do
   # In network mode, if the target server is powered off, skip this cycle entirely: don't read
-  # temperatures (they would be meaningless) and don't apply any fan control profile
-  if $NETWORK_MODE && ! is_server_powered_on; then
-    IS_TARGET_SERVER_POWERED_OFF=true
-    printf "%19s  Target server is powered off, no fan control profile applied.\n" "$(date +"%d-%m-%Y %T")"
+  # temperatures (they would be meaningless) and don't apply any fan control profile.
+  # A cycle is also skipped when the iDRAC can't be reached at all, but the two are reported
+  # separately: one is a machine that is legitimately off, the other is a server we may well be
+  # holding at a static fan speed with no way to see or change anything about it
+  if $NETWORK_MODE; then
+    get_server_power_state
+    TARGET_SERVER_POWER_STATE=$?
 
-    wait $SLEEP_PROCESS_PID
+    if [ $TARGET_SERVER_POWER_STATE -ne 0 ]; then
+      IS_TARGET_SERVER_POWERED_OFF=true
 
-    # Start timer in background for next cycle
-    sleep "$CHECK_INTERVAL" &
-    SLEEP_PROCESS_PID=$!
-    continue
+      if [ $TARGET_SERVER_POWER_STATE -eq 2 ]; then
+        printf "%19s  Cannot reach the iDRAC, target server state unknown and fan control profile left as-is. ipmitool said: %s\n" "$(date +"%d-%m-%Y %T")" "$IPMI_UNREACHABLE_REASON" >&2
+      else
+        printf "%19s  Target server is powered off, no fan control profile applied.\n" "$(date +"%d-%m-%Y %T")"
+      fi
+
+      wait $SLEEP_PROCESS_PID
+
+      # Start timer in background for next cycle
+      sleep "$CHECK_INTERVAL" &
+      SLEEP_PROCESS_PID=$!
+      continue
+    fi
   fi
 
   # The server just powered back on: refresh temperatures now instead of evaluating stale data read

--- a/Dell_iDRAC_fan_controller.sh
+++ b/Dell_iDRAC_fan_controller.sh
@@ -22,6 +22,14 @@ validate_fan_speed_parameter "FAN_SPEED" "$FAN_SPEED"
 validate_integer_parameter "CPU_TEMPERATURE_THRESHOLD" "$CPU_TEMPERATURE_THRESHOLD" -128 127
 validate_check_interval_parameter "CHECK_INTERVAL" "$CHECK_INTERVAL"
 
+# The booleans are validated for the same reason, their failure mode just being quieter still: they are
+# dispatched by running their value as a command, so anything that isn't literally "true" or "false" is
+# a command that doesn't exist, exits 127, and takes the branch as false. "True", "1" and "Yes" would
+# each give the user the exact opposite of what they configured, without a word about it
+validate_boolean_parameter "DISABLE_THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE" "$DISABLE_THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE"
+validate_boolean_parameter "KEEP_THIRD_PARTY_PCIE_CARD_COOLING_RESPONSE_STATE_ON_EXIT" "$KEEP_THIRD_PARTY_PCIE_CARD_COOLING_RESPONSE_STATE_ON_EXIT"
+validate_boolean_parameter "MONITORING_ONLY_MODE" "$MONITORING_ONLY_MODE"
+
 # Leading zeros are stripped so that the value used in comparisons is the one the user meant, "09"
 # being read as an invalid octal number everywhere else
 CPU_TEMPERATURE_THRESHOLD=$(normalize_decimal_value "$CPU_TEMPERATURE_THRESHOLD")
@@ -144,7 +152,7 @@ if $IS_LOW_TEMPERATURE_PROTECTION_ENABLED; then
 else
   echo "Low temperature protection: Disabled"
 fi
-if $MONITORING_ONLY_MODE; then
+if "$MONITORING_ONLY_MODE"; then
   echo "Monitoring only mode: Enabled (no fan control profile will be applied, temperatures will only be logged)"
 else
   echo "Monitoring only mode: Disabled"
@@ -291,7 +299,7 @@ while true; do
       THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE_STATUS="Enabled"
     fi
 
-    if $MONITORING_ONLY_MODE; then
+    if "$MONITORING_ONLY_MODE"; then
       THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE_STATUS+=" (not applied: monitoring only mode)"
     fi
   fi

--- a/Dell_iDRAC_fan_controller.sh
+++ b/Dell_iDRAC_fan_controller.sh
@@ -172,14 +172,14 @@ IS_TARGET_SERVER_POWERED_OFF=false
 
 # Check present sensors
 IS_EXHAUST_TEMPERATURE_SENSOR_PRESENT=true
-IS_CPU2_TEMPERATURE_SENSOR_PRESENT=true
 
 # Start timer in background
 sleep "$CHECK_INTERVAL" &
 SLEEP_PROCESS_PID=$!
 
-retrieve_temperatures $IS_EXHAUST_TEMPERATURE_SENSOR_PRESENT $IS_CPU2_TEMPERATURE_SENSOR_PRESENT
+retrieve_temperatures $IS_EXHAUST_TEMPERATURE_SENSOR_PRESENT
 
+echo "$NUMBER_OF_DETECTED_CPUS CPU temperature sensor(s) detected."
 if [ -z "$EXHAUST_TEMPERATURE" ]; then
   echo "No exhaust temperature sensor detected."
   IS_EXHAUST_TEMPERATURE_SENSOR_PRESENT=false
@@ -188,17 +188,8 @@ if [ -z "$EXHAUST_TEMPERATURE" ]; then
   # consistent with the rest, instead of leaving a blank under the "Exhaust" heading
   EXHAUST_TEMPERATURE="-"
 fi
-if [ -z "$CPU2_TEMPERATURE" ]; then
-  echo "No CPU2 temperature sensor detected."
-  IS_CPU2_TEMPERATURE_SENSOR_PRESENT=false
-fi
-# Output new line to beautify output if one of the previous conditions have echoed
-if ! $IS_EXHAUST_TEMPERATURE_SENSOR_PRESENT || ! $IS_CPU2_TEMPERATURE_SENSOR_PRESENT; then
-  echo ""
-fi
+echo ""
 
-#readonly NUMBER_OF_DETECTED_CPUS=(${CPUS_TEMPERATURES//;/ })
-# TODO : write "X CPU sensors detected." and remove previous ifs
 readonly HEADER=$(build_header $NUMBER_OF_DETECTED_CPUS)
 
 # Start monitoring
@@ -234,7 +225,7 @@ while true; do
   # before/during the outage (could be the initial pre-loop reading, or readings from before it powered off)
   if $IS_TARGET_SERVER_POWERED_OFF; then
     IS_TARGET_SERVER_POWERED_OFF=false
-    retrieve_temperatures $IS_EXHAUST_TEMPERATURE_SENSOR_PRESENT $IS_CPU2_TEMPERATURE_SENSOR_PRESENT
+    retrieve_temperatures $IS_EXHAUST_TEMPERATURE_SENSOR_PRESENT
   fi
 
   # Initialize a variable to store the comments displayed when the fan control profile changed
@@ -243,27 +234,15 @@ while true; do
   # the intake air is doing, a CPU past its threshold has to get the Dell default profile, and no
   # later branch may reduce the fan speed while that is the case
   #
-  # Check if CPU 1 is overheating then apply Dell default dynamic fan control profile if true
-  if CPU1_OVERHEATING; then
+  # Check if any CPU is overheating then apply Dell default dynamic fan control profile if true
+  if ANY_CPU_OVERHEATING; then
     # The state is only latched if the command actually reached the server: latching on a failure
     # would silence every later cycle through the "!= Dell" guard, leaving the log asserting that the
     # safety profile is active while the fans are still held at the user's speed
     if apply_Dell_default_fan_control_profile && [ "$ACTIVE_FAN_CONTROL_PROFILE" != "Dell" ]; then
       ACTIVE_FAN_CONTROL_PROFILE="Dell"
 
-      # If CPU 2 temperature sensor is present, check if it is overheating too.
-      # Do not apply Dell default dynamic fan control profile as it has already been applied before
-      if $IS_CPU2_TEMPERATURE_SENSOR_PRESENT && CPU2_OVERHEATING; then
-        COMMENT=$(build_fan_control_fallback_comment "CPU 1" "$CPU1_TEMPERATURE" "CPU 2" "$CPU2_TEMPERATURE")
-      else
-        COMMENT=$(build_fan_control_fallback_comment "CPU 1" "$CPU1_TEMPERATURE")
-      fi
-    fi
-  # If CPU 2 temperature sensor is present, check if it is overheating then apply Dell default dynamic fan control profile if true
-  elif $IS_CPU2_TEMPERATURE_SENSOR_PRESENT && CPU2_OVERHEATING; then
-    if apply_Dell_default_fan_control_profile && [ "$ACTIVE_FAN_CONTROL_PROFILE" != "Dell" ]; then
-      ACTIVE_FAN_CONTROL_PROFILE="Dell"
-      COMMENT=$(build_fan_control_fallback_comment "CPU 2" "$CPU2_TEMPERATURE")
+      COMMENT=$(build_fan_control_fallback_comment "${OVERHEATING_CPUS_AND_TEMPERATURES[@]}")
     fi
   # Intake air hotter than the server is rated for: a static fan speed is the wrong thing to be
   # holding, so hand control back to iDRAC, which knows the platform's own airflow requirements
@@ -324,5 +303,5 @@ while true; do
   sleep "$CHECK_INTERVAL" &
   SLEEP_PROCESS_PID=$!
 
-  retrieve_temperatures $IS_EXHAUST_TEMPERATURE_SENSOR_PRESENT $IS_CPU2_TEMPERATURE_SENSOR_PRESENT
+  retrieve_temperatures $IS_EXHAUST_TEMPERATURE_SENSOR_PRESENT
 done

--- a/Dell_iDRAC_fan_controller.sh
+++ b/Dell_iDRAC_fan_controller.sh
@@ -14,14 +14,25 @@ trap 'graceful_exit' SIGINT SIGQUIT SIGTERM
 
 # readonly DELL_FRESH_AIR_COMPLIANCE=45
 
-# Check if FAN_SPEED variable is in hexadecimal format. If not, convert it to hexadecimal
-if [[ "$FAN_SPEED" == 0x* ]]; then
-  readonly DECIMAL_FAN_SPEED=$(convert_hexadecimal_value_to_decimal "$FAN_SPEED")
-  readonly HEXADECIMAL_FAN_SPEED="$FAN_SPEED"
-else
-  readonly DECIMAL_FAN_SPEED="$FAN_SPEED"
-  readonly HEXADECIMAL_FAN_SPEED=$(convert_decimal_value_to_hexadecimal "$FAN_SPEED")
-fi
+# Validate every user-supplied number before it reaches an arithmetic comparison or an ipmitool
+# command. All of them are unchecked text until here, and each one fails silently rather than loudly
+# when malformed: FAN_SPEED converts to 0x00 and stops the fans, CPU_TEMPERATURE_THRESHOLD makes the
+# overheating checks return "not overheating" and disables the safety fallback, and a CHECK_INTERVAL
+# sleep cannot parse makes it return at once, turning the monitoring loop into a busy loop
+validate_fan_speed_parameter "FAN_SPEED" "$FAN_SPEED"
+# IPMI reports temperatures as a signed byte, so no threshold outside that range can ever be crossed
+validate_integer_parameter "CPU_TEMPERATURE_THRESHOLD" "$CPU_TEMPERATURE_THRESHOLD" -128 127
+validate_check_interval_parameter "CHECK_INTERVAL" "$CHECK_INTERVAL"
+
+# Leading zeros are stripped so that the value used in comparisons is the one the user meant, "09"
+# being read as an invalid octal number everywhere else
+CPU_TEMPERATURE_THRESHOLD=$(normalize_decimal_value "$CPU_TEMPERATURE_THRESHOLD")
+readonly CPU_TEMPERATURE_THRESHOLD
+
+# Express FAN_SPEED in both notations, whichever one the user gave it in
+convert_fan_speed_parameter "$FAN_SPEED"
+readonly DECIMAL_FAN_SPEED="$DECIMAL_SPEED"
+readonly HEXADECIMAL_FAN_SPEED="$HEXADECIMAL_SPEED"
 
 set_iDRAC_login_string "$IDRAC_HOST" "$IDRAC_USERNAME" "$IDRAC_PASSWORD"
 
@@ -56,7 +67,12 @@ echo "iDRAC/IPMI host: $IDRAC_HOST"
 # Log the fan speed objective, CPU temperature threshold and check interval
 echo "Fan speed objective: $DECIMAL_FAN_SPEED%"
 echo "CPU temperature threshold: "$CPU_TEMPERATURE_THRESHOLD"°C"
-echo "Check interval: ${CHECK_INTERVAL}s"
+# The unit is only appended when the value doesn't already carry one, "60s" being an accepted form
+if [[ "$CHECK_INTERVAL" =~ ^[0-9.]+$ ]]; then
+  echo "Check interval: ${CHECK_INTERVAL}s"
+else
+  echo "Check interval: $CHECK_INTERVAL"
+fi
 if $MONITORING_ONLY_MODE; then
   echo "Monitoring only mode: Enabled (no fan control profile will be applied, temperatures will only be logged)"
 else

--- a/Dell_iDRAC_fan_controller.sh
+++ b/Dell_iDRAC_fan_controller.sh
@@ -12,8 +12,6 @@ trap 'graceful_exit' SIGINT SIGQUIT SIGTERM
 
 # Prepare, format and define initial variables
 
-# readonly DELL_FRESH_AIR_COMPLIANCE=45
-
 # Validate every user-supplied number before it reaches an arithmetic comparison or an ipmitool
 # command. All of them are unchecked text until here, and each one fails silently rather than loudly
 # when malformed: FAN_SPEED converts to 0x00 and stops the fans, CPU_TEMPERATURE_THRESHOLD makes the
@@ -33,6 +31,57 @@ readonly CPU_TEMPERATURE_THRESHOLD
 convert_fan_speed_parameter "$FAN_SPEED"
 readonly DECIMAL_FAN_SPEED="$DECIMAL_SPEED"
 readonly HEXADECIMAL_FAN_SPEED="$HEXADECIMAL_SPEED"
+
+# HIGH_INLET_TEMPERATURE_THRESHOLD defaults to 35°C, the ASHRAE A2 allowable ceiling. An empty value
+# still disables the check, which is how an ASHRAE A3/A4 (Dell Fresh Air) deployment or anyone who
+# prefers the previous CPU-only behaviour opts out. The low temperature protections below stay opt-in
+if [ -n "$HIGH_INLET_TEMPERATURE_THRESHOLD" ]; then
+  validate_integer_parameter "HIGH_INLET_TEMPERATURE_THRESHOLD" "$HIGH_INLET_TEMPERATURE_THRESHOLD" -128 127
+  HIGH_INLET_TEMPERATURE_THRESHOLD=$(normalize_decimal_value "$HIGH_INLET_TEMPERATURE_THRESHOLD")
+fi
+readonly HIGH_INLET_TEMPERATURE_THRESHOLD
+
+if [ -n "$LOW_INLET_TEMPERATURE_THRESHOLD" ]; then
+  validate_integer_parameter "LOW_INLET_TEMPERATURE_THRESHOLD" "$LOW_INLET_TEMPERATURE_THRESHOLD" -128 127
+  LOW_INLET_TEMPERATURE_THRESHOLD=$(normalize_decimal_value "$LOW_INLET_TEMPERATURE_THRESHOLD")
+
+  if [ -n "$HIGH_INLET_TEMPERATURE_THRESHOLD" ] && [ "$LOW_INLET_TEMPERATURE_THRESHOLD" -ge "$HIGH_INLET_TEMPERATURE_THRESHOLD" ]; then
+    print_configuration_error_and_exit "LOW_INLET_TEMPERATURE_THRESHOLD" "$LOW_INLET_TEMPERATURE_THRESHOLD" "a temperature below HIGH_INLET_TEMPERATURE_THRESHOLD (${HIGH_INLET_TEMPERATURE_THRESHOLD}°C), otherwise the two intake air limits would overlap"
+  fi
+fi
+readonly LOW_INLET_TEMPERATURE_THRESHOLD
+
+if [ -n "$LOW_CPU_TEMPERATURE_THRESHOLD" ]; then
+  validate_integer_parameter "LOW_CPU_TEMPERATURE_THRESHOLD" "$LOW_CPU_TEMPERATURE_THRESHOLD" -128 127
+  LOW_CPU_TEMPERATURE_THRESHOLD=$(normalize_decimal_value "$LOW_CPU_TEMPERATURE_THRESHOLD")
+
+  if [ "$LOW_CPU_TEMPERATURE_THRESHOLD" -ge "$CPU_TEMPERATURE_THRESHOLD" ]; then
+    print_configuration_error_and_exit "LOW_CPU_TEMPERATURE_THRESHOLD" "$LOW_CPU_TEMPERATURE_THRESHOLD" "a temperature below CPU_TEMPERATURE_THRESHOLD (${CPU_TEMPERATURE_THRESHOLD}°C), otherwise the same reading would be both too cold and too hot"
+  fi
+fi
+readonly LOW_CPU_TEMPERATURE_THRESHOLD
+
+# LOW_TEMPERATURE_FAN_SPEED is what the low temperature protection applies, so it becomes required as
+# soon as either of its triggers is configured, and it must not exceed FAN_SPEED : the protection
+# exists to reduce airflow when the chassis is too cold, never to increase it
+if [ -n "$LOW_INLET_TEMPERATURE_THRESHOLD" ] || [ -n "$LOW_CPU_TEMPERATURE_THRESHOLD" ]; then
+  if [ -z "$LOW_TEMPERATURE_FAN_SPEED" ]; then
+    print_configuration_error_and_exit "LOW_TEMPERATURE_FAN_SPEED" "" "a fan speed, because it is what the low temperature protection applies and you set LOW_INLET_TEMPERATURE_THRESHOLD or LOW_CPU_TEMPERATURE_THRESHOLD"
+  fi
+
+  validate_fan_speed_parameter "LOW_TEMPERATURE_FAN_SPEED" "$LOW_TEMPERATURE_FAN_SPEED"
+  convert_fan_speed_parameter "$LOW_TEMPERATURE_FAN_SPEED"
+
+  if [ "$DECIMAL_SPEED" -gt "$DECIMAL_FAN_SPEED" ]; then
+    print_configuration_error_and_exit "LOW_TEMPERATURE_FAN_SPEED" "$LOW_TEMPERATURE_FAN_SPEED" "a fan speed at or below FAN_SPEED (${DECIMAL_FAN_SPEED}%), the low temperature protection only ever reduces the fan speed"
+  fi
+
+  readonly DECIMAL_LOW_TEMPERATURE_FAN_SPEED="$DECIMAL_SPEED"
+  readonly HEXADECIMAL_LOW_TEMPERATURE_FAN_SPEED="$HEXADECIMAL_SPEED"
+  readonly IS_LOW_TEMPERATURE_PROTECTION_ENABLED=true
+else
+  readonly IS_LOW_TEMPERATURE_PROTECTION_ENABLED=false
+fi
 
 set_iDRAC_login_string "$IDRAC_HOST" "$IDRAC_USERNAME" "$IDRAC_PASSWORD"
 
@@ -73,6 +122,28 @@ if [[ "$CHECK_INTERVAL" =~ ^[0-9.]+$ ]]; then
 else
   echo "Check interval: $CHECK_INTERVAL"
 fi
+if [ -n "$HIGH_INLET_TEMPERATURE_THRESHOLD" ]; then
+  echo "High inlet temperature threshold: ${HIGH_INLET_TEMPERATURE_THRESHOLD}°C (Dell default dynamic fan control profile applied above, set HIGH_INLET_TEMPERATURE_THRESHOLD empty to disable)"
+else
+  echo "High inlet temperature threshold: Disabled"
+fi
+if $IS_LOW_TEMPERATURE_PROTECTION_ENABLED; then
+  # Both triggers are listed so the log states the exact conjunction that has to hold, the protection
+  # engaging only once every configured one does
+  LOW_TEMPERATURE_CONDITIONS=""
+  if [ -n "$LOW_INLET_TEMPERATURE_THRESHOLD" ]; then
+    LOW_TEMPERATURE_CONDITIONS="inlet < ${LOW_INLET_TEMPERATURE_THRESHOLD}°C"
+  fi
+  if [ -n "$LOW_CPU_TEMPERATURE_THRESHOLD" ]; then
+    if [ -n "$LOW_TEMPERATURE_CONDITIONS" ]; then
+      LOW_TEMPERATURE_CONDITIONS+=" and "
+    fi
+    LOW_TEMPERATURE_CONDITIONS+="every CPU < ${LOW_CPU_TEMPERATURE_THRESHOLD}°C"
+  fi
+  echo "Low temperature protection: Enabled (${DECIMAL_LOW_TEMPERATURE_FAN_SPEED}% applied while $LOW_TEMPERATURE_CONDITIONS)"
+else
+  echo "Low temperature protection: Disabled"
+fi
 if $MONITORING_ONLY_MODE; then
   echo "Monitoring only mode: Enabled (no fan control profile will be applied, temperatures will only be logged)"
 else
@@ -81,8 +152,12 @@ fi
 echo ""
 
 TABLE_HEADER_PRINT_COUNTER=$TABLE_HEADER_PRINT_INTERVAL
-# Set the flag used to check if the active fan control profile has changed
-IS_DELL_DEFAULT_FAN_CONTROL_PROFILE_APPLIED=true
+# Tracks which fan control profile is currently applied, so that a change can be commented on the
+# cycle it happens rather than on every cycle. A boolean was enough while there were only two
+# profiles; the low temperature protection adds a third one to tell apart.
+# Values : "Dell", "user" or "low temperature". Starts at "Dell", the profile in force before the
+# container takes control
+ACTIVE_FAN_CONTROL_PROFILE="Dell"
 # Tracks whether the target server was powered off on the previous cycle, so temperatures can be
 # refreshed right when it powers back on instead of reusing data read before/during the outage
 IS_TARGET_SERVER_POWERED_OFF=false
@@ -143,12 +218,16 @@ while true; do
 
   # Initialize a variable to store the comments displayed when the fan control profile changed
   COMMENT=" -"
+  # The branches below are ordered by priority, and CPU overheating deliberately comes first: whatever
+  # the intake air is doing, a CPU past its threshold has to get the Dell default profile, and no
+  # later branch may reduce the fan speed while that is the case
+  #
   # Check if CPU 1 is overheating then apply Dell default dynamic fan control profile if true
   if CPU1_OVERHEATING; then
     apply_Dell_default_fan_control_profile
 
-    if ! $IS_DELL_DEFAULT_FAN_CONTROL_PROFILE_APPLIED; then
-      IS_DELL_DEFAULT_FAN_CONTROL_PROFILE_APPLIED=true
+    if [ "$ACTIVE_FAN_CONTROL_PROFILE" != "Dell" ]; then
+      ACTIVE_FAN_CONTROL_PROFILE="Dell"
 
       # If CPU 2 temperature sensor is present, check if it is overheating too.
       # Do not apply Dell default dynamic fan control profile as it has already been applied before
@@ -162,17 +241,41 @@ while true; do
   elif $IS_CPU2_TEMPERATURE_SENSOR_PRESENT && CPU2_OVERHEATING; then
     apply_Dell_default_fan_control_profile
 
-    if ! $IS_DELL_DEFAULT_FAN_CONTROL_PROFILE_APPLIED; then
-      IS_DELL_DEFAULT_FAN_CONTROL_PROFILE_APPLIED=true
+    if [ "$ACTIVE_FAN_CONTROL_PROFILE" != "Dell" ]; then
+      ACTIVE_FAN_CONTROL_PROFILE="Dell"
       COMMENT=$(build_fan_control_fallback_comment "CPU 2" "$CPU2_TEMPERATURE")
+    fi
+  # Intake air hotter than the server is rated for: a static fan speed is the wrong thing to be
+  # holding, so hand control back to iDRAC, which knows the platform's own airflow requirements
+  elif INLET_TEMPERATURE_TOO_HIGH; then
+    apply_Dell_default_fan_control_profile
+
+    if [ "$ACTIVE_FAN_CONTROL_PROFILE" != "Dell" ]; then
+      ACTIVE_FAN_CONTROL_PROFILE="Dell"
+      COMMENT="Inlet temperature is too high (> $HIGH_INLET_TEMPERATURE_THRESHOLD°C), Dell default dynamic fan control profile applied for safety"
+    fi
+  # Chassis colder than its components are rated for: reduce the airflow so their own waste heat can
+  # hold the inside of the server above the ambient temperature
+  elif SERVER_TOO_COLD; then
+    apply_low_temperature_fan_control_profile
+
+    if [ "$ACTIVE_FAN_CONTROL_PROFILE" != "low temperature" ]; then
+      ACTIVE_FAN_CONTROL_PROFILE="low temperature"
+      COMMENT="Server is too cold, fan speed reduced to $DECIMAL_LOW_TEMPERATURE_FAN_SPEED% to preserve a minimum internal temperature"
     fi
   else
     apply_user_fan_control_profile
 
     # Check if user fan control profile is applied then apply it if not
-    if $IS_DELL_DEFAULT_FAN_CONTROL_PROFILE_APPLIED; then
-      IS_DELL_DEFAULT_FAN_CONTROL_PROFILE_APPLIED=false
-      COMMENT="CPU temperature decreased and is now OK (<= $CPU_TEMPERATURE_THRESHOLD°C), user's fan control profile applied."
+    if [ "$ACTIVE_FAN_CONTROL_PROFILE" != "user" ]; then
+      # The profile being left says which condition cleared, the return to the user's profile meaning
+      # different things depending on it
+      if [ "$ACTIVE_FAN_CONTROL_PROFILE" == "low temperature" ]; then
+        COMMENT="Server warmed back up, user's fan control profile applied."
+      else
+        COMMENT="CPU temperature decreased and is now OK (<= $CPU_TEMPERATURE_THRESHOLD°C), user's fan control profile applied."
+      fi
+      ACTIVE_FAN_CONTROL_PROFILE="user"
     fi
   fi
 

--- a/Dell_iDRAC_fan_controller.sh
+++ b/Dell_iDRAC_fan_controller.sh
@@ -232,9 +232,10 @@ while true; do
   #
   # Check if CPU 1 is overheating then apply Dell default dynamic fan control profile if true
   if CPU1_OVERHEATING; then
-    apply_Dell_default_fan_control_profile
-
-    if [ "$ACTIVE_FAN_CONTROL_PROFILE" != "Dell" ]; then
+    # The state is only latched if the command actually reached the server: latching on a failure
+    # would silence every later cycle through the "!= Dell" guard, leaving the log asserting that the
+    # safety profile is active while the fans are still held at the user's speed
+    if apply_Dell_default_fan_control_profile && [ "$ACTIVE_FAN_CONTROL_PROFILE" != "Dell" ]; then
       ACTIVE_FAN_CONTROL_PROFILE="Dell"
 
       # If CPU 2 temperature sensor is present, check if it is overheating too.
@@ -247,35 +248,27 @@ while true; do
     fi
   # If CPU 2 temperature sensor is present, check if it is overheating then apply Dell default dynamic fan control profile if true
   elif $IS_CPU2_TEMPERATURE_SENSOR_PRESENT && CPU2_OVERHEATING; then
-    apply_Dell_default_fan_control_profile
-
-    if [ "$ACTIVE_FAN_CONTROL_PROFILE" != "Dell" ]; then
+    if apply_Dell_default_fan_control_profile && [ "$ACTIVE_FAN_CONTROL_PROFILE" != "Dell" ]; then
       ACTIVE_FAN_CONTROL_PROFILE="Dell"
       COMMENT=$(build_fan_control_fallback_comment "CPU 2" "$CPU2_TEMPERATURE")
     fi
   # Intake air hotter than the server is rated for: a static fan speed is the wrong thing to be
   # holding, so hand control back to iDRAC, which knows the platform's own airflow requirements
   elif INLET_TEMPERATURE_TOO_HIGH; then
-    apply_Dell_default_fan_control_profile
-
-    if [ "$ACTIVE_FAN_CONTROL_PROFILE" != "Dell" ]; then
+    if apply_Dell_default_fan_control_profile && [ "$ACTIVE_FAN_CONTROL_PROFILE" != "Dell" ]; then
       ACTIVE_FAN_CONTROL_PROFILE="Dell"
       COMMENT="Inlet temperature is too high (> $HIGH_INLET_TEMPERATURE_THRESHOLD°C), Dell default dynamic fan control profile applied for safety"
     fi
   # Chassis colder than its components are rated for: reduce the airflow so their own waste heat can
   # hold the inside of the server above the ambient temperature
   elif SERVER_TOO_COLD; then
-    apply_low_temperature_fan_control_profile
-
-    if [ "$ACTIVE_FAN_CONTROL_PROFILE" != "low temperature" ]; then
+    if apply_low_temperature_fan_control_profile && [ "$ACTIVE_FAN_CONTROL_PROFILE" != "low temperature" ]; then
       ACTIVE_FAN_CONTROL_PROFILE="low temperature"
       COMMENT="Server is too cold, fan speed reduced to $DECIMAL_LOW_TEMPERATURE_FAN_SPEED% to preserve a minimum internal temperature"
     fi
   else
-    apply_user_fan_control_profile
-
     # Check if user fan control profile is applied then apply it if not
-    if [ "$ACTIVE_FAN_CONTROL_PROFILE" != "user" ]; then
+    if apply_user_fan_control_profile && [ "$ACTIVE_FAN_CONTROL_PROFILE" != "user" ]; then
       # The profile being left says which condition cleared, the return to the user's profile meaning
       # different things depending on it
       if [ "$ACTIVE_FAN_CONTROL_PROFILE" == "low temperature" ]; then

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,16 @@ ENV IDRAC_HOST=local
 ENV FAN_SPEED=5
 ENV CPU_TEMPERATURE_THRESHOLD=50
 ENV CHECK_INTERVAL=5
+# Hand control back to iDRAC above this intake air temperature. 35°C is the ASHRAE A2 allowable
+# ceiling, the class the volume PowerEdge line is rated to, so above it a standard server is outside
+# its rated envelope while this container holds its fans at a fixed speed.
+# Raise it to 40 or 45 on an ASHRAE A3/A4 (Dell Fresh Air) machine, or set it empty to disable the
+# check entirely and keep the previous CPU-only behaviour
+ENV HIGH_INLET_TEMPERATURE_THRESHOLD=35
+# Low temperature protection, opt-in: left empty, its checks stay disabled
+ENV LOW_INLET_TEMPERATURE_THRESHOLD=
+ENV LOW_CPU_TEMPERATURE_THRESHOLD=
+ENV LOW_TEMPERATURE_FAN_SPEED=
 ENV DISABLE_THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE=false
 ENV KEEP_THIRD_PARTY_PCIE_CARD_COOLING_RESPONSE_STATE_ON_EXIT=false
 ENV MONITORING_ONLY_MODE=false

--- a/README.md
+++ b/README.md
@@ -199,6 +199,61 @@ All parameters are optional as they have default values (including default iDRAC
 - `KEEP_THIRD_PARTY_PCIE_CARD_COOLING_RESPONSE_STATE_ON_EXIT` parameter is a boolean that allows to keep the third-party PCIe card Dell default cooling response state upon exit. **Default** value is false, so that it resets the third-party PCIe card Dell default cooling response to Dell default.
 - `MONITORING_ONLY_MODE` parameter is a boolean that allows to run the container in a read-only, monitoring-only mode: temperatures are still read and logged at each `CHECK_INTERVAL`, but no fan control profile (neither the user-defined one nor Dell's default) and no third-party PCIe card cooling response change is ever sent to the server. Useful to observe temperatures and validate your `FAN_SPEED`/`CPU_TEMPERATURE_THRESHOLD` values before letting the container actually take control of the fans. **Default** value is false.
 
+All parameters are validated at startup. A malformed value stops the container instead of being silently misinterpreted, and says why:
+
+```
+/!\ Error /!\ Invalid configuration, the container will not start.
+
+  Parameter : FAN_SPEED
+  Value     : "abc"
+  Expected  : a percentage from 0 to 100, or the same value in hexadecimal from 0x00 to 0x64
+
+  Fix it in the "-e" arguments of your "docker run" command, or in the "environment"
+  section of your docker-compose.yml, then start the container again.
+```
+
+This matters most for `FAN_SPEED`: an unvalidated malformed value converted to `0x00`, which is the documented Dell command for **0% fan duty**, and the container then reported the user's profile as applied every cycle with the fans stopped.
+
+### Intake air temperature limits
+
+These four parameters are **optional and disabled by default**. Leaving them unset keeps the behavior described above unchanged.
+
+- `HIGH_INLET_TEMPERATURE_THRESHOLD` is the intake air temperature above which the Dell default dynamic fan control profile is restored. Past its rated intake temperature, a server's fans are the only mitigation left and a fixed fan speed is the wrong thing to be holding, so control is handed back to iDRAC, which knows the platform's own airflow requirements. The volume PowerEdge line is rated to ASHRAE class A2, whose allowable inlet ceiling is 35°C; Dell Fresh Air models add A3 (40°C) and A4 (45°C), both restricted to a share of annual operating hours rather than continuous use. **Default** value is 35(°C).
+
+  > **This is the one default that changed.** It is enabled out of the box because the failure mode is asymmetric: a threshold set too low costs you louder fans in hot weather — the server behaves exactly as it would if this container had never been installed — while a threshold not set at all leaves a server running above its rated intake with its fans pinned at a fixed speed. If your rack legitimately runs above 35°C (an ASHRAE A3/A4 Dell Fresh Air deployment), raise it to `40` or `45`. To restore the previous CPU-only behaviour entirely, set it empty: `-e HIGH_INLET_TEMPERATURE_THRESHOLD=`. The startup log always states which of the two is in effect.
+- `LOW_INLET_TEMPERATURE_THRESHOLD` is the intake air temperature below which the fan speed is reduced to `LOW_TEMPERATURE_FAN_SPEED`. Negative values are accepted. **Default** value is empty (trigger disabled).
+- `LOW_CPU_TEMPERATURE_THRESHOLD` is the CPU temperature below which the fan speed is reduced to `LOW_TEMPERATURE_FAN_SPEED`. Every detected CPU has to be below it. Must be lower than `CPU_TEMPERATURE_THRESHOLD`. **Default** value is empty (trigger disabled).
+- `LOW_TEMPERATURE_FAN_SPEED` is the reduced fan speed applied while the low temperature protection is engaged, in the same decimal or hexadecimal notation as `FAN_SPEED`. It becomes **required** as soon as either low temperature threshold is set, and it must not exceed `FAN_SPEED`: this protection only ever reduces the fan speed, never increases it. **Default** value is empty.
+
+#### What the low temperature protection is for
+
+Cold intake air does not damage silicon. What it does is drag the components that *do* have a lower limit down with it, and a high fixed fan speed in a cold room is what makes that happen:
+
+- enterprise hard drives are rated from 5°C (0°C on some ranges) and their spindle lubricant stiffens below it;
+- PERC battery backup units are lithium-ion, and charging lithium-ion below 0°C plates metallic lithium on the anode, which is permanent;
+- Dell's own operating envelope stops at 10°C, or 5°C continuously and −5°C for up to 1% of annual operating hours.
+
+Reducing the airflow lets the machine's own waste heat hold the inside of the chassis above the ambient temperature. It is a mitigation, not a guarantee: fans cannot be stopped, and on an idle server in a genuinely freezing room it may not be enough on its own.
+
+#### How the conditions combine
+
+The two low temperature triggers are combined with **AND**, not OR: the protection engages only once *every* configured condition holds. The goal is a minimum temperature *inside* the chassis, and a cold room with a busy server in it is not a situation to reduce airflow in. Setting `LOW_CPU_TEMPERATURE_THRESHOLD` alongside `LOW_INLET_TEMPERATURE_THRESHOLD` is what keeps cold intake air from throttling the fans over a CPU that is working.
+
+CPU overheating always wins. Whatever the intake air is doing, a CPU above `CPU_TEMPERATURE_THRESHOLD` gets the Dell default profile, and the low temperature protection can never reduce the fan speed while that is the case. A sensor reading that cannot be parsed never engages the protection either — it stays disengaged rather than reducing airflow on unverified data.
+
+Example, for a server in an unheated room:
+
+```bash
+  -e FAN_SPEED=30 \
+  -e CPU_TEMPERATURE_THRESHOLD=60 \
+  -e LOW_INLET_TEMPERATURE_THRESHOLD=5 \
+  -e LOW_CPU_TEMPERATURE_THRESHOLD=30 \
+  -e LOW_TEMPERATURE_FAN_SPEED=10 \
+  -e HIGH_INLET_TEMPERATURE_THRESHOLD=35 \
+```
+
+Fans run at 30%, drop to 10% while the intake is below 5°C *and* every CPU is below 30°C, return to 30% as soon as either warms back up, and hand over to Dell's profile if any CPU passes 60°C or the intake passes 35°C.
+
 <p align="right">(<a href="#top">back to top</a>)</p>
 
 <!-- TROUBLESHOOTING -->

--- a/constants.sh
+++ b/constants.sh
@@ -2,3 +2,4 @@
 
 # Define the interval for printing temperature table header
 readonly TABLE_HEADER_PRINT_INTERVAL=10
+readonly MAXIMUM_NUMBER_OF_CPUS=4

--- a/functions.sh
+++ b/functions.sh
@@ -2,7 +2,7 @@
 # This function applies Dell's default dynamic fan control profile
 # In monitoring only mode, the profile is only logged, not actually applied
 function apply_Dell_default_fan_control_profile() {
-  if $MONITORING_ONLY_MODE; then
+  if "$MONITORING_ONLY_MODE"; then
     CURRENT_FAN_CONTROL_PROFILE="Dell default dynamic fan control profile (monitoring only, not applied)"
     return
   fi
@@ -35,7 +35,7 @@ function apply_static_fan_control_profile() {
   local -r HEXADECIMAL_SPEED="$2"
   local -r PROFILE_NAME="$3"
 
-  if $MONITORING_ONLY_MODE; then
+  if "$MONITORING_ONLY_MODE"; then
     CURRENT_FAN_CONTROL_PROFILE="$PROFILE_NAME ($DECIMAL_SPEED%) (monitoring only, not applied)"
     return
   fi
@@ -164,6 +164,27 @@ function validate_check_interval_parameter() {
   # take a fractional value at all
   if [[ "$DURATION" =~ ^0*\.?0*$ ]]; then
     print_configuration_error_and_exit "$PARAMETER_NAME" "$VALUE" "a duration greater than zero, otherwise the monitoring loop would never pause between two readings"
+  fi
+}
+
+# Stop the container unless the given parameter is one of the two documented boolean values
+# Usage : validate_boolean_parameter "$PARAMETER_NAME" "$VALUE"
+#
+# Booleans are dispatched by running their value as a command, "true" and "false" being real programs.
+# Anything else is a command that doesn't exist : it exits 127 and the branch is silently taken as
+# false, so "True", "TRUE", "1", "on" and "Yes" all give the user the opposite of what they asked for.
+# MONITORING_ONLY_MODE=True is the dangerous one, the container reporting the mode as disabled and then
+# taking real control of the fans on a server the operator asked it not to touch.
+#
+# "yes" is worse still, being a command that DOES exist and never returns : the container blocks on the
+# first test, floods stdout at hundreds of MB per second, and cannot be stopped by "docker stop", the
+# graceful_exit trap being deferred while yes holds the foreground
+function validate_boolean_parameter() {
+  local -r PARAMETER_NAME="$1"
+  local -r VALUE="$2"
+
+  if [ "$VALUE" != "true" ] && [ "$VALUE" != "false" ]; then
+    print_configuration_error_and_exit "$PARAMETER_NAME" "$VALUE" "exactly \"true\" or \"false\", in lower case ; \"True\", \"1\", \"yes\" and \"on\" are not accepted because they would silently be taken as false"
   fi
 }
 
@@ -359,7 +380,7 @@ function is_server_powered_on() {
 # /!\ Use this function only for Gen 13 and older generation servers /!\
 # In monitoring only mode, this is a no-op
 function enable_third_party_PCIe_card_Dell_default_cooling_response() {
-  if $MONITORING_ONLY_MODE; then
+  if "$MONITORING_ONLY_MODE"; then
     return
   fi
   # We could check the current cooling response before applying but it's not very useful so let's skip the test and apply directly
@@ -374,7 +395,7 @@ function enable_third_party_PCIe_card_Dell_default_cooling_response() {
 # /!\ Use this function only for Gen 13 and older generation servers /!\
 # In monitoring only mode, this is a no-op
 function disable_third_party_PCIe_card_Dell_default_cooling_response() {
-  if $MONITORING_ONLY_MODE; then
+  if "$MONITORING_ONLY_MODE"; then
     return
   fi
   # We could check the current cooling response before applying but it's not very useful so let's skip the test and apply directly
@@ -405,7 +426,7 @@ function disable_third_party_PCIe_card_Dell_default_cooling_response() {
 
 # Prepare traps in case of container exit
 function graceful_exit() {
-  if $MONITORING_ONLY_MODE; then
+  if "$MONITORING_ONLY_MODE"; then
     print_warning_and_exit "Container stopped (monitoring only mode, no fan control profile was ever applied)"
   fi
 

--- a/functions.sh
+++ b/functions.sh
@@ -15,6 +15,11 @@ function apply_Dell_default_fan_control_profile() {
   ipmitool_stderr=$(ipmitool -I $IDRAC_LOGIN_STRING raw 0x30 0x30 0x01 0x01 2>&1 >/dev/null)
   if [ $? -ne 0 ]; then
     print_error "Failed to apply Dell default fan control profile. ipmitool said: $ipmitool_stderr"
+    # The command never reached the server, so the table must not claim the profile is active : this is
+    # the safety fallback, and an operator reading "applied for safety" on a cooking server would have
+    # no reason to look further
+    CURRENT_FAN_CONTROL_PROFILE="Dell default profile FAILED TO APPLY"
+    return 1
   fi
   CURRENT_FAN_CONTROL_PROFILE="Dell default dynamic fan control profile"
 }
@@ -46,10 +51,19 @@ function apply_static_fan_control_profile() {
   ipmitool_stderr=$(ipmitool -I $IDRAC_LOGIN_STRING raw 0x30 0x30 0x01 0x00 2>&1 >/dev/null)
   if [ $? -ne 0 ]; then
     print_error "Failed to enable manual fan control. ipmitool said: $ipmitool_stderr"
+    # Returning early rather than sending a speed anyway : without manual control the speed command is
+    # meaningless, and iDRAC is still managing the fans, which is the safe state to leave the server in
+    CURRENT_FAN_CONTROL_PROFILE="Manual fan control FAILED TO ENABLE"
+    return 1
   fi
   ipmitool_stderr=$(ipmitool -I $IDRAC_LOGIN_STRING raw 0x30 0x30 0x02 0xff $HEXADECIMAL_SPEED 2>&1 >/dev/null)
   if [ $? -ne 0 ]; then
     print_error "Failed to set fan speed to $DECIMAL_SPEED%. ipmitool said: $ipmitool_stderr"
+    # The worst of the three states and the one that most needs naming: manual control is now ON, so
+    # iDRAC has stopped managing the fans, and the speed that was supposed to replace it never arrived.
+    # The fans are sitting at whatever value was last set, under nobody's control
+    CURRENT_FAN_CONTROL_PROFILE="Fan speed FAILED TO APPLY ($DECIMAL_SPEED% requested)"
+    return 1
   fi
   CURRENT_FAN_CONTROL_PROFILE="$PROFILE_NAME ($DECIMAL_SPEED%)"
 }
@@ -430,11 +444,19 @@ function graceful_exit() {
     print_warning_and_exit "Container stopped (monitoring only mode, no fan control profile was ever applied)"
   fi
 
-  apply_Dell_default_fan_control_profile
+  local restored=true
+  apply_Dell_default_fan_control_profile || restored=false
 
   # Reset third-party PCIe card cooling response to Dell default depending on the user's choice at startup
   if ! "$KEEP_THIRD_PARTY_PCIE_CARD_COOLING_RESPONSE_STATE_ON_EXIT"; then
     enable_third_party_PCIe_card_Dell_default_cooling_response
+  fi
+
+  # The goodbye message is the last thing an operator sees, and it used to assert the fans were safe
+  # whether or not the command had actually reached the server. On failure the container is exiting and
+  # leaving the fans under nobody's control, which is worth a non-zero exit code as well as a mention
+  if ! $restored; then
+    print_error_and_exit "Container stopped but the Dell default dynamic fan control profile could NOT be restored, the fans are still under this container's last setting"
   fi
 
   print_warning_and_exit "Container stopped, Dell default dynamic fan control profile applied for safety"

--- a/functions.sh
+++ b/functions.sh
@@ -59,6 +59,108 @@ function convert_hexadecimal_value_to_decimal() {
   echo $DECIMAL_NUMBER
 }
 
+# Stop the container unless the given parameter is an integer within an inclusive range
+# Usage : validate_integer_parameter "$PARAMETER_NAME" "$VALUE" $MINIMUM $MAXIMUM
+#
+# User-supplied parameters reach us as unchecked text and are then used in arithmetic, where a
+# malformed one fails quietly instead of loudly. A non-integer CPU_TEMPERATURE_THRESHOLD makes bash's
+# "-gt" return 2, which every caller reads as "not overheating", disabling the safety fallback the
+# container exists to provide. Refusing to start is the only outcome that can't be mistaken for
+# normal operation.
+#
+# This function must be called as a statement, never through a command substitution : the exit inside
+# print_error_and_exit would otherwise only leave the subshell and the container would keep running
+function validate_integer_parameter() {
+  local -r PARAMETER_NAME="$1"
+  local -r VALUE="$2"
+  local -r MINIMUM="$3"
+  local -r MAXIMUM="$4"
+
+  if [[ ! "$VALUE" =~ ^-?[0-9]+$ ]]; then
+    print_configuration_error_and_exit "$PARAMETER_NAME" "$VALUE" "a whole number between $MINIMUM and $MAXIMUM"
+  fi
+
+  local -r NORMALIZED_VALUE=$(normalize_decimal_value "$VALUE")
+  if [ "$NORMALIZED_VALUE" -lt "$MINIMUM" ] || [ "$NORMALIZED_VALUE" -gt "$MAXIMUM" ]; then
+    print_configuration_error_and_exit "$PARAMETER_NAME" "$VALUE" "a whole number between $MINIMUM and $MAXIMUM"
+  fi
+}
+
+# Stop the container unless the given parameter is a usable fan speed, in either accepted notation
+# Usage : validate_fan_speed_parameter "$PARAMETER_NAME" "$VALUE"
+#
+# bash's printf applies base detection, so an unchecked value never fails visibly : "09" is an invalid
+# octal number, "abc" an invalid number, an empty value produces no diagnostic at all, and all three
+# convert to 0x00 -- the documented Dell command for 0% fan duty. The container would then report the
+# user's profile as applied every cycle with the fans stopped, and only recover once a CPU crossed
+# CPU_TEMPERATURE_THRESHOLD, i.e. after it had already heated up
+function validate_fan_speed_parameter() {
+  local -r PARAMETER_NAME="$1"
+  local -r VALUE="$2"
+  local DECIMAL_VALUE
+
+  if [[ "$VALUE" =~ ^0[xX][0-9A-Fa-f]{1,2}$ ]]; then
+    DECIMAL_VALUE=$(convert_hexadecimal_value_to_decimal "$VALUE")
+  elif [[ "$VALUE" =~ ^[0-9]+$ ]]; then
+    DECIMAL_VALUE=$(normalize_decimal_value "$VALUE")
+  else
+    print_configuration_error_and_exit "$PARAMETER_NAME" "$VALUE" "a percentage from 0 to 100, or the same value in hexadecimal from 0x00 to 0x64"
+  fi
+
+  if [ "$DECIMAL_VALUE" -gt 100 ]; then
+    print_configuration_error_and_exit "$PARAMETER_NAME" "$VALUE" "a percentage from 0 to 100, or the same value in hexadecimal from 0x00 to 0x64 (this is ${DECIMAL_VALUE}%)"
+  fi
+}
+
+# Stop the container unless the given parameter is a duration sleep can actually wait for
+# Usage : validate_check_interval_parameter "$PARAMETER_NAME" "$VALUE"
+#
+# The value is passed straight to sleep, whose exit status the loop discards, so an unusable one
+# doesn't stop anything : sleep returns in a few milliseconds and the monitoring loop starts spinning
+# at full speed, opening an IPMI session per iteration and flooding the logs.
+#
+# The accepted set is what sleep itself accepts, not what the README documents, because the point is to
+# reject only the values that don't wait. GNU sleep takes a unit suffix and a fractional part, so "60s",
+# "5m" and "0.5" have all been working configurations all along : rejecting a value that has been
+# waiting correctly would break a working container for no benefit.
+#
+# One deliberate narrowing : sleep also takes scientific notation ("1e2" waits 100 seconds) and this
+# rejects it. Supporting it would mean a noticeably hairier pattern and a zero test that has to cope
+# with "0e5", for a spelling nobody puts in an environment variable
+function validate_check_interval_parameter() {
+  local -r PARAMETER_NAME="$1"
+  local -r VALUE="$2"
+  local -r DURATION="${VALUE%[smhd]}"
+
+  if [[ ! "$DURATION" =~ ^([0-9]+\.?[0-9]*|\.[0-9]+)$ ]]; then
+    print_configuration_error_and_exit "$PARAMETER_NAME" "$VALUE" "a duration sleep can wait for : a number, optionally fractional, optionally suffixed with s, m, h or d (for example 60, 0.5, 60s, 5m or 1h)"
+  fi
+
+  # A zero interval is syntactically valid for sleep and still spins the loop, so it's rejected on its
+  # own terms rather than on its format. Tested on the digits rather than with arithmetic, which cannot
+  # take a fractional value at all
+  if [[ "$DURATION" =~ ^0*\.?0*$ ]]; then
+    print_configuration_error_and_exit "$PARAMETER_NAME" "$VALUE" "a duration greater than zero, otherwise the monitoring loop would never pause between two readings"
+  fi
+}
+
+# Express an already validated fan speed parameter in both notations at once
+# Usage : convert_fan_speed_parameter "$VALUE"
+# Returns : DECIMAL_SPEED, HEXADECIMAL_SPEED
+function convert_fan_speed_parameter() {
+  local -r VALUE="$1"
+
+  if [[ "$VALUE" == 0[xX]* ]]; then
+    DECIMAL_SPEED=$(convert_hexadecimal_value_to_decimal "$VALUE")
+    HEXADECIMAL_SPEED="$VALUE"
+  else
+    # Leading zeros are stripped before the conversion, printf would otherwise read "09" as an invalid
+    # octal number and hand back 0x00
+    DECIMAL_SPEED=$(normalize_decimal_value "$VALUE")
+    HEXADECIMAL_SPEED=$(convert_decimal_value_to_hexadecimal "$DECIMAL_SPEED")
+  fi
+}
+
 # Set the IDRAC_LOGIN_STRING variable based on connection type
 # Usage : set_iDRAC_login_string $IDRAC_HOST $IDRAC_USERNAME $IDRAC_PASSWORD
 # Returns : IDRAC_LOGIN_STRING
@@ -302,7 +404,7 @@ function get_Dell_server_model() {
   local -r ipmitool_exit_code=$?
 
   if [ $ipmitool_exit_code -ne 0 ]; then
-    print_error_and_exit "Could not establish IPMI connection to iDRAC/IPMI host \"$IDRAC_HOST\". Check that IDRAC_HOST, IDRAC_USERNAME and IDRAC_PASSWORD are correct. ipmitool said: $IPMI_FRU_content"
+    print_configuration_error_and_exit "IDRAC_HOST / IDRAC_USERNAME / IDRAC_PASSWORD" "$IDRAC_HOST" "credentials that can open an IPMI session. ipmitool said: $IPMI_FRU_content"
   fi
 
   SERVER_MANUFACTURER=$(echo "$IPMI_FRU_content" | grep "Product Manufacturer" | awk -F ': ' '{print $2}')
@@ -473,6 +575,29 @@ function build_fan_control_fallback_comment() {
   fi
 
   echo "$(join_with_and "${reasons[@]}"), Dell default dynamic fan control profile applied for safety"
+}
+
+# Stop the container on an invalid configuration parameter, with everything needed to fix it
+# Usage : print_configuration_error_and_exit "$PARAMETER_NAME" "$VALUE" "$EXPECTED"
+#
+# Refusing to start is the point : a malformed parameter fails silently once the container is running,
+# so the only outcome that can't be mistaken for normal operation is not running at all. But refusing
+# to start is only useful if the reason survives a "docker logs" scroll, hence the block form rather
+# than one line among the startup output -- the user has to be able to see, without reading the source,
+# which parameter is wrong, what it currently is, what is accepted, and where to change it
+function print_configuration_error_and_exit() {
+  local -r PARAMETER_NAME="$1"
+  local -r VALUE="$2"
+  local -r EXPECTED="$3"
+
+  printf "\n/!\\ Error /!\\ Invalid configuration, the container will not start.\n\n" >&2
+  printf "  Parameter : %s\n" "$PARAMETER_NAME" >&2
+  printf "  Value     : \"%s\"\n" "$VALUE" >&2
+  printf "  Expected  : %s\n\n" "$EXPECTED" >&2
+  printf "  Fix it in the \"-e\" arguments of your \"docker run\" command, or in the \"environment\"\n" >&2
+  printf "  section of your docker-compose.yml, then start the container again.\n\n" >&2
+
+  exit 1
 }
 
 function print_error() {

--- a/functions.sh
+++ b/functions.sh
@@ -383,11 +383,26 @@ function retrieve_temperatures() {
   fi
 }
 
-# Returns 0 (true) if the target server is currently powered on, 1 (false) otherwise
+# Report the target server's power state
+# Returns : 0 if it is powered on, 1 if it is powered off, 2 if the iDRAC could not be reached
+#
 # Only meaningful in network mode: in local mode the container runs on the target server itself,
 # so it cannot be observed powered off while the container is running
-function is_server_powered_on() {
-  local -r POWER_STATUS=$(ipmitool -I $IDRAC_LOGIN_STRING chassis power status 2>/dev/null)
+#
+# The three outcomes used to be two. stderr and the exit code were both discarded and the verdict came
+# from a substring, so a failed call produced empty output, didn't contain "is on", and was reported as
+# a powered-off chassis -- indistinguishable from the real thing. A dropped session, rotated
+# credentials, an iDRAC reboot and a LAN flap all landed in the same branch, and the caller skipped the
+# cycle without reading temperatures or applying any profile, leaving the fans frozen at the user's
+# static speed on a running, loaded server while the log called it benign
+function get_server_power_state() {
+  local POWER_STATUS
+  POWER_STATUS=$(ipmitool -I $IDRAC_LOGIN_STRING chassis power status 2>&1)
+  if [ $? -ne 0 ]; then
+    IPMI_UNREACHABLE_REASON="$POWER_STATUS"
+    return 2
+  fi
+
   [[ "$POWER_STATUS" == *"is on"* ]]
 }
 

--- a/functions.sh
+++ b/functions.sh
@@ -19,14 +19,27 @@ function apply_Dell_default_fan_control_profile() {
   CURRENT_FAN_CONTROL_PROFILE="Dell default dynamic fan control profile"
 }
 
-# This function applies a user-specified static fan control profile
+# This function applies a static fan control profile at the given speed
+# Usage : apply_static_fan_control_profile $DECIMAL_SPEED $HEXADECIMAL_SPEED "$PROFILE_NAME"
+#
+# The speed is a parameter rather than the FAN_SPEED global because two different profiles use this
+# same command: the user's normal one, and the reduced one the low temperature protection applies
+#
 # In monitoring only mode, the profile is only logged, not actually applied
-function apply_user_fan_control_profile() {
+function apply_static_fan_control_profile() {
+  if (( $# != 3 )); then
+    print_error "Illegal number of parameters.\nUsage: apply_static_fan_control_profile \$DECIMAL_SPEED \$HEXADECIMAL_SPEED \"\$PROFILE_NAME\""
+    return 1
+  fi
+  local -r DECIMAL_SPEED="$1"
+  local -r HEXADECIMAL_SPEED="$2"
+  local -r PROFILE_NAME="$3"
+
   if $MONITORING_ONLY_MODE; then
-    CURRENT_FAN_CONTROL_PROFILE="User static fan control profile ($DECIMAL_FAN_SPEED%) (monitoring only, not applied)"
+    CURRENT_FAN_CONTROL_PROFILE="$PROFILE_NAME ($DECIMAL_SPEED%) (monitoring only, not applied)"
     return
   fi
-  # Use ipmitool to send the raw command to set fan control to user-specified value.
+  # Use ipmitool to send the raw command to set fan control to the given value.
   # Same reasoning as apply_Dell_default_fan_control_profile: only surface stderr if the command
   # actually failed, instead of always discarding it (this profile changes real fan speed)
   local ipmitool_stderr
@@ -34,11 +47,21 @@ function apply_user_fan_control_profile() {
   if [ $? -ne 0 ]; then
     print_error "Failed to enable manual fan control. ipmitool said: $ipmitool_stderr"
   fi
-  ipmitool_stderr=$(ipmitool -I $IDRAC_LOGIN_STRING raw 0x30 0x30 0x02 0xff $HEXADECIMAL_FAN_SPEED 2>&1 >/dev/null)
+  ipmitool_stderr=$(ipmitool -I $IDRAC_LOGIN_STRING raw 0x30 0x30 0x02 0xff $HEXADECIMAL_SPEED 2>&1 >/dev/null)
   if [ $? -ne 0 ]; then
-    print_error "Failed to set fan speed to $DECIMAL_FAN_SPEED%. ipmitool said: $ipmitool_stderr"
+    print_error "Failed to set fan speed to $DECIMAL_SPEED%. ipmitool said: $ipmitool_stderr"
   fi
-  CURRENT_FAN_CONTROL_PROFILE="User static fan control profile ($DECIMAL_FAN_SPEED%)"
+  CURRENT_FAN_CONTROL_PROFILE="$PROFILE_NAME ($DECIMAL_SPEED%)"
+}
+
+# This function applies the user-specified static fan control profile
+function apply_user_fan_control_profile() {
+  apply_static_fan_control_profile "$DECIMAL_FAN_SPEED" "$HEXADECIMAL_FAN_SPEED" "User static fan control profile"
+}
+
+# This function applies the reduced static fan control profile that the low temperature protection uses
+function apply_low_temperature_fan_control_profile() {
+  apply_static_fan_control_profile "$DECIMAL_LOW_TEMPERATURE_FAN_SPEED" "$HEXADECIMAL_LOW_TEMPERATURE_FAN_SPEED" "Low temperature fan profile"
 }
 
 # Convert first parameter given ($DECIMAL_NUMBER) to hexadecimal
@@ -575,6 +598,69 @@ function build_fan_control_fallback_comment() {
   fi
 
   echo "$(join_with_and "${reasons[@]}"), Dell default dynamic fan control profile applied for safety"
+}
+
+# Returns 0 (true) if intake air is hotter than HIGH_INLET_TEMPERATURE_THRESHOLD, 1 (false) otherwise
+#
+# Above its rated intake temperature a server's fans are the only mitigation left, and a static low
+# fan speed is exactly the wrong thing to be holding. The volume PowerEdge line is rated to ASHRAE
+# class A2, whose allowable inlet ceiling is 35°C; Dell Fresh Air models add A3 (40°C) and A4 (45°C),
+# both restricted to a share of annual operating hours rather than continuous use. Past the configured
+# limit, iDRAC's own profile knows the platform's airflow requirements better than a fixed percentage.
+#
+# The default is 35°C, so the check is on unless it is turned off. A false trigger is deliberately the
+# cheap direction: handing control back to iDRAC makes the server behave exactly as it would if this
+# container had never been installed -- louder, but never less safe. Leaving the threshold empty
+# disables the check, which then never fires.
+#
+# An unreadable inlet reading also returns false. That is the opposite of how the CPU checks treat bad
+# data, and deliberately so: an intake temperature that was not measured says nothing about whether
+# the server is in danger, and the CPU checks already cover the case that actually endangers it
+function INLET_TEMPERATURE_TOO_HIGH() {
+  [ -n "$HIGH_INLET_TEMPERATURE_THRESHOLD" ] || return 1
+  [[ "$INLET_TEMPERATURE" =~ ^-?[0-9]+$ ]] || return 1
+  [ "$(normalize_decimal_value "$INLET_TEMPERATURE")" -gt "$HIGH_INLET_TEMPERATURE_THRESHOLD" ]
+}
+
+# Returns 0 (true) if every configured low temperature condition is met, 1 (false) otherwise
+#
+# Cold intake air doesn't damage silicon, but a chassis held at a sub-zero ambient by a high static
+# fan speed drags the components that do have a lower limit down with it: enterprise disks are rated
+# from 5°C (0°C on some ranges) and stiffen their spindle lubricant below it, PERC battery backup
+# units are lithium-ion and plate metallic lithium if charged below 0°C, and Dell's own operating
+# envelope stops at 10°C, or 5°C continuously and -5°C for up to 1% of annual operating hours.
+# Reducing airflow lets the machine's own waste heat hold the inside above ambient.
+#
+# The conditions are combined with AND rather than OR. The point of the protection is a minimum
+# temperature *inside* the chassis, and a cold room with a busy server in it is not a situation to
+# reduce airflow in: configuring LOW_CPU_TEMPERATURE_THRESHOLD next to LOW_INLET_TEMPERATURE_THRESHOLD
+# is what keeps cold intake air from throttling the fans over a CPU that is working.
+#
+# An unreadable sensor never satisfies its condition, so the protection stays disengaged rather than
+# reducing airflow on data it could not verify
+function SERVER_TOO_COLD() {
+  local IS_ANY_CONDITION_CONFIGURED=false
+
+  if [ -n "$LOW_INLET_TEMPERATURE_THRESHOLD" ]; then
+    IS_ANY_CONDITION_CONFIGURED=true
+    [[ "$INLET_TEMPERATURE" =~ ^-?[0-9]+$ ]] || return 1
+    [ "$(normalize_decimal_value "$INLET_TEMPERATURE")" -lt "$LOW_INLET_TEMPERATURE_THRESHOLD" ] || return 1
+  fi
+
+  if [ -n "$LOW_CPU_TEMPERATURE_THRESHOLD" ]; then
+    IS_ANY_CONDITION_CONFIGURED=true
+    # Every detected CPU has to be cold : one busy CPU is enough to mean the chassis isn't
+    [[ "$CPU1_TEMPERATURE" =~ ^-?[0-9]+$ ]] || return 1
+    [ "$(normalize_decimal_value "$CPU1_TEMPERATURE")" -lt "$LOW_CPU_TEMPERATURE_THRESHOLD" ] || return 1
+
+    if $IS_CPU2_TEMPERATURE_SENSOR_PRESENT; then
+      [[ "$CPU2_TEMPERATURE" =~ ^-?[0-9]+$ ]] || return 1
+      [ "$(normalize_decimal_value "$CPU2_TEMPERATURE")" -lt "$LOW_CPU_TEMPERATURE_THRESHOLD" ] || return 1
+    fi
+  fi
+
+  # Neither threshold configured means the protection is off, not that every condition trivially held
+  $IS_ANY_CONDITION_CONFIGURED
 }
 
 # Stop the container on an invalid configuration parameter, with everything needed to fix it

--- a/functions.sh
+++ b/functions.sh
@@ -335,42 +335,57 @@ function retrieve_temperature_by_sensor_name() {
 }
 
 # Retrieve temperature sensors data using ipmitool
-# Usage : retrieve_temperatures $IS_EXHAUST_TEMPERATURE_SENSOR_PRESENT $IS_CPU2_TEMPERATURE_SENSOR_PRESENT
+# Usage : retrieve_temperatures $IS_EXHAUST_TEMPERATURE_SENSOR_PRESENT
+# Returns : CPU_TEMPERATURES (indexed array), NUMBER_OF_DETECTED_CPUS, CPUS_TEMPERATURES,
+#           INLET_TEMPERATURE, EXHAUST_TEMPERATURE
+#
+# The CPU 2 presence flag is gone: the CPUs are discovered on every reading, so their count is an
+# output of this function rather than something the caller has to tell it
 function retrieve_temperatures() {
-  if (( $# != 2 )); then
-    print_error "Illegal number of parameters.\nUsage: retrieve_temperatures \$IS_EXHAUST_TEMPERATURE_SENSOR_PRESENT \$IS_CPU2_TEMPERATURE_SENSOR_PRESENT"
+  if (( $# != 1 )); then
+    print_error "Illegal number of parameters. Usage: retrieve_temperatures \$IS_EXHAUST_TEMPERATURE_SENSOR_PRESENT"
     return 1
   fi
   local -r IS_EXHAUST_TEMPERATURE_SENSOR_PRESENT=$1
-  local -r IS_CPU2_TEMPERATURE_SENSOR_PRESENT=$2
 
   # stderr is discarded here: this is a read-only diagnostic call (it never changes fan behavior) and some
   # iDRAC/BMC firmwares print a harmless protocol warning on every call even though the reading succeeds
   local -r DATA=$(ipmitool -I $IDRAC_LOGIN_STRING sdr type temperature 2>/dev/null | grep degrees)
 
-  # Parse CPU data, each CPU being located by its IPMI entity ID (3.1 is CPU 1, 3.2 is CPU 2)
-  CPU1_TEMPERATURE=$(retrieve_temperature_by_entity_id "$DATA" "3.1")
-  if $IS_CPU2_TEMPERATURE_SENSOR_PRESENT; then
-    CPU2_TEMPERATURE=$(retrieve_temperature_by_entity_id "$DATA" "3.2")
-  else
-    CPU2_TEMPERATURE="-"
-  fi
+  # Discover the CPUs rather than assuming two of them. Entity 3 is the processor, so 3.1 is CPU 1,
+  # 3.2 is CPU 2, and so on: the lookup was already generation-independent, but the enumerated set was
+  # hardcoded to the first two, so a 4-socket R810/R815/R910/R930 ran with half its sockets never
+  # sampled and never checked for overheating -- on a machine whose own thermal management this
+  # container had just disabled
+  local i
+  CPU_TEMPERATURES=()
+  NUMBER_OF_DETECTED_CPUS=0
+  # The bound is defaulted rather than assumed: functions.sh is sourced on its own by healthcheck.sh,
+  # and an unset constant would silently make this loop detect no CPU at all
+  for ((i = 1; i <= ${MAXIMUM_NUMBER_OF_CPUS:-4}; i++)); do
+    local CPU_TEMPERATURE=$(retrieve_temperature_by_entity_id "$DATA" "3.$i")
 
-  # Initialize CPUS_TEMPERATURES. An unreadable CPU 1 reading falls back to the "-" placeholder so that it
-  # still takes up its column when the line is printed : CPUS_TEMPERATURES is split on whitespace to build
-  # the display array, so an empty value would be dropped and shift every following column to the left.
-  # CPU1_TEMPERATURE itself is left untouched, CPU1_OVERHEATING() must still see the invalid reading
-  CPUS_TEMPERATURES="${CPU1_TEMPERATURE:--}"
-  NUMBER_OF_DETECTED_CPUS=1
+    # Dell populates sockets contiguously, so the first entity with no reading at all marks the end of
+    # the populated ones rather than a failed read to be skipped over
+    if [ -z "$CPU_TEMPERATURE" ] && [ $i -gt 1 ]; then
+      break
+    fi
 
-  # If CPU2 is present, parse its temperature data and add it to CPUS_TEMPERATURES.
-  # "-" is the placeholder set above when the sensor is known to be absent, so it must not be counted as a
-  # detected CPU: otherwise servers without a CPU2 sensor get an extra column that the header, built once
-  # from the first reading (when the placeholder isn't set yet), doesn't account for
-  if [ -n "$CPU2_TEMPERATURE" ] && [ "$CPU2_TEMPERATURE" != "-" ]; then
-    CPUS_TEMPERATURES+=";$CPU2_TEMPERATURE"
+    CPU_TEMPERATURES+=("$CPU_TEMPERATURE")
     ((NUMBER_OF_DETECTED_CPUS++))
-  fi
+  done
+
+  # Build the display string. An unreadable reading falls back to the "-" placeholder so that it still
+  # takes up its column when the line is printed : CPUS_TEMPERATURES is split to build the display
+  # array, so an empty value would be dropped and shift every following column to the left.
+  # CPU_TEMPERATURES itself is left untouched, the overheating checks must still see the invalid reading
+  CPUS_TEMPERATURES=""
+  for ((i = 0; i < NUMBER_OF_DETECTED_CPUS; i++)); do
+    if [ -n "$CPUS_TEMPERATURES" ]; then
+      CPUS_TEMPERATURES+=";"
+    fi
+    CPUS_TEMPERATURES+="${CPU_TEMPERATURES[$i]:--}"
+  done
 
   # Parse inlet temperature data, the sensor being located by its name
   INLET_TEMPERATURE=$(retrieve_temperature_by_sensor_name "$DATA" "Inlet")
@@ -590,17 +605,42 @@ function is_temperature_reading_valid() {
   [[ "$1" =~ ^-?[0-9]+$ ]]
 }
 
-# Define functions to check if CPU 1 and CPU 2 temperatures are above the threshold.
-# If a reading isn't valid, fail safe and report overheating so the Dell default fan control profile
-# kicks in, instead of crashing (bash's "-gt" throws "unary operator expected" on empty/non-numeric
-# input) or silently running the low user fan speed on unverified data
-function CPU1_OVERHEATING() {
-  is_temperature_reading_valid "$CPU1_TEMPERATURE" || return 0
-  [ "$(normalize_decimal_value "$CPU1_TEMPERATURE")" -gt "$CPU_TEMPERATURE_THRESHOLD" ]
+# Check whether a detected CPU is above the threshold, by its 0-based index in CPU_TEMPERATURES.
+# If a reading isn't a valid number (missing sensor, transient IPMI parsing glitch, etc.), fail safe and
+# report overheating so the Dell default fan control profile kicks in, instead of crashing (bash's "-gt"
+# throws "unary operator expected" on empty/non-numeric input) or silently running the low user fan speed
+# on unverified data
+function CPU_OVERHEATING() {
+  local -r TEMPERATURE="${CPU_TEMPERATURES[$1]}"
+
+  is_temperature_reading_valid "$TEMPERATURE" || return 0
+  [ "$(normalize_decimal_value "$TEMPERATURE")" -gt "$CPU_TEMPERATURE_THRESHOLD" ]
 }
-function CPU2_OVERHEATING() {
-  is_temperature_reading_valid "$CPU2_TEMPERATURE" || return 0
-  [ "$(normalize_decimal_value "$CPU2_TEMPERATURE")" -gt "$CPU_TEMPERATURE_THRESHOLD" ]
+
+# Returns 0 (true) if any detected CPU is overheating, 1 (false) otherwise
+# Returns : OVERHEATING_CPUS_AND_TEMPERATURES, alternating "CPU <n>" labels and their readings, in the
+#           pair form build_fan_control_fallback_comment() takes, so it can be passed straight through
+#
+# Every detected CPU is checked rather than the first two: on a 4-socket server the container has just
+# disabled iDRAC's own thermal management, so a CPU it doesn't look at is a CPU nothing is looking at
+function ANY_CPU_OVERHEATING() {
+  local i
+  OVERHEATING_CPUS_AND_TEMPERATURES=()
+
+  # No readable CPU at all is not "nothing is too hot", it means the container is flying blind. An
+  # empty loop below would return false and hold the user's static speed on an unmonitored machine,
+  # so this fails safe the same way an unreadable individual reading does
+  if [ "${NUMBER_OF_DETECTED_CPUS:-0}" -eq 0 ]; then
+    return 0
+  fi
+
+  for ((i = 0; i < NUMBER_OF_DETECTED_CPUS; i++)); do
+    if CPU_OVERHEATING $i; then
+      OVERHEATING_CPUS_AND_TEMPERATURES+=("CPU $((i + 1))" "${CPU_TEMPERATURES[$i]}")
+    fi
+  done
+
+  [ ${#OVERHEATING_CPUS_AND_TEMPERATURES[@]} -gt 0 ]
 }
 
 # Join the given items into an enumeration : "CPU 1", "CPU 1 and CPU 2", "CPU 1, CPU 2 and CPU 3"...
@@ -625,8 +665,8 @@ function join_with_and() {
 # Build the comment explaining why the Dell default fan control profile was applied.
 # Usage : build_fan_control_fallback_comment $CPU_NAME $CPU_TEMPERATURE [$CPU_NAME $CPU_TEMPERATURE]...
 #
-# CPU1_OVERHEATING()/CPU2_OVERHEATING() deliberately return true both when a CPU is genuinely too hot
-# and when its reading is unusable, so an unverifiable temperature still falls back to Dell's profile.
+# CPU_OVERHEATING() deliberately returns true both when a CPU is genuinely too hot and when its reading
+# is unusable, so an unverifiable temperature still falls back to Dell's profile.
 # The comment has to tell the two apart : reporting "temperature is too high" on a reading that was
 # never obtained sends the user chasing a cooling problem instead of the sensor problem they have
 function build_fan_control_fallback_comment() {
@@ -708,13 +748,11 @@ function SERVER_TOO_COLD() {
   if [ -n "$LOW_CPU_TEMPERATURE_THRESHOLD" ]; then
     IS_ANY_CONDITION_CONFIGURED=true
     # Every detected CPU has to be cold : one busy CPU is enough to mean the chassis isn't
-    [[ "$CPU1_TEMPERATURE" =~ ^-?[0-9]+$ ]] || return 1
-    [ "$(normalize_decimal_value "$CPU1_TEMPERATURE")" -lt "$LOW_CPU_TEMPERATURE_THRESHOLD" ] || return 1
-
-    if $IS_CPU2_TEMPERATURE_SENSOR_PRESENT; then
-      [[ "$CPU2_TEMPERATURE" =~ ^-?[0-9]+$ ]] || return 1
-      [ "$(normalize_decimal_value "$CPU2_TEMPERATURE")" -lt "$LOW_CPU_TEMPERATURE_THRESHOLD" ] || return 1
-    fi
+    local i
+    for ((i = 0; i < NUMBER_OF_DETECTED_CPUS; i++)); do
+      [[ "${CPU_TEMPERATURES[$i]}" =~ ^-?[0-9]+$ ]] || return 1
+      [ "$(normalize_decimal_value "${CPU_TEMPERATURES[$i]}")" -lt "$LOW_CPU_TEMPERATURE_THRESHOLD" ] || return 1
+    done
   fi
 
   # Neither threshold configured means the protection is off, not that every condition trivially held


### PR DESCRIPTION
Closes #168, and the "4 CPUs servers support" half of #91 — whose octal half was fixed by #134 and whose parsing half by #146. **6th in the stack** — based on #176.

`retrieve_temperatures()` hardcoded two entity lookups, `3.1` and `3.2`. The lookup was already generation-independent, as its own comments argue, but the enumerated set was not.

## Why it matters

On a 4-socket PowerEdge (R810, R815, R910, R930 — all in this container's target range) CPUs 3 and 4 were never sampled and never checked. The container had just put the machine into manual fan control at a static speed, so it had **disabled iDRAC's own thermal management** and then supervised half the sockets. A CPU 3 at 91 °C against a 50 °C threshold produced no verdict, the fans stayed at 5 %, and the table showed two healthy columns with nothing to suggest the rest of the machine was unwatched.

That is worse than not running the container at all — iDRAC would otherwise have ramped the fans.

## What changed

CPUs are discovered by walking entities `3.1` upward, stopping at the first unpopulated socket, and held in an indexed array. The two per-CPU functions collapse into `CPU_OVERHEATING(index)` and `ANY_CPU_OVERHEATING()`.

**This composes with #162's fallback comment rather than replacing it.** `build_fan_control_fallback_comment()` was already variadic and already distinguishes "too hot" from "could not be read", so `ANY_CPU_OVERHEATING()` returns its results in exactly the pair form that function takes and passes them straight through. `CPU_OVERHEATING()` also uses #162's centralised `is_temperature_reading_valid()` rather than carrying its own copy of the predicate. Result on a 4-socket machine:

```
CPU 3 hot        : CPU 3 temperature is too high, Dell default dynamic fan control profile applied for safety
CPU 1 + CPU 3    : CPU 1 and CPU 3 temperatures are too high, Dell default dynamic fan control profile applied for safety
CPU 3 hot, 2 n/a : CPU 3 temperature is too high and CPU 2 temperature could not be read, Dell default dynamic fan control profile applied for safety
```

The low temperature protection from #49 gets the same treatment — it required only CPUs 1 and 2 to be cold, so it would have reduced airflow over a busy CPU 3.

## Two fail-safes come with it

- **Zero detected CPUs now reports overheating.** An empty loop would otherwise return "nothing is too hot" and hold a static speed on a completely unmonitored machine.
- **The socket-count bound is defaulted, not assumed.** `functions.sh` is sourced on its own by `healthcheck.sh`, where an unset constant would have silently detected no CPU at all.

## The display layer needed nothing

`build_header` already handled arbitrary N. The startup probe now reports `N CPU temperature sensor(s) detected.` in place of the CPU 2 presence flag, which discovery makes redundant — closing the `TODO` left in the entrypoint.

## Verification

Stubbed 1, 2, 3 and 4 socket servers give correct column counts. On a stubbed R910:

```
    Date & time      Inlet  CPU 1  CPU 2  CPU 3  CPU 4  Exhaust          Active fan speed profile
08-08-2026 09:17:12   21°C   40°C   41°C   91°C   43°C     33°C  Dell default dynamic fan control profile
```

CPU 3 at 91 °C now trips the Dell default profile and is named in the comment. Before this change it was invisible.

## Overlap note

#144 targets the same issue. This PR additionally keeps #162's readable-vs-unreadable comment distinction and adds the two fail-safes above; whichever lands first, the other will need rebasing.