### PR TITLE
Read the exhaust sensor on every cycle instead of writing it off once

### DIFF
--- a/Dell_iDRAC_fan_controller.sh
+++ b/Dell_iDRAC_fan_controller.sh
@@ -155,9 +155,6 @@ IS_FIRST_MONITORING_CYCLE=true
 # refreshed right when it powers back on instead of reusing data read before/during the outage
 IS_TARGET_SERVER_POWERED_OFF=false
 
-# Check present sensors
-IS_EXHAUST_TEMPERATURE_SENSOR_PRESENT=true
-
 # Start timer in background
 sleep "$CHECK_INTERVAL" &
 SLEEP_PROCESS_PID=$!
@@ -230,15 +227,15 @@ echo "$(format_detected_CPU_temperature_sensors)."
 
 warn_if_unexpected_number_of_CPUs
 
-retrieve_temperatures $IS_EXHAUST_TEMPERATURE_SENSOR_PRESENT "$SDR_TEMPERATURE_DATA"
+retrieve_temperatures "$SDR_TEMPERATURE_DATA"
 
+# Reported for information only. Most servers printing this line genuinely have no exhaust sensor --
+# blades and enclosure-housed sleds never do -- so the wording stays as it was ; what changed is that
+# the line no longer decides anything. The sensor is read again on every cycle, so a chassis whose
+# sensors were merely not readable at this instant starts showing its temperature as soon as they
+# answer, instead of being written off for the container's lifetime
 if [ -z "$EXHAUST_TEMPERATURE" ]; then
   echo "No exhaust temperature sensor detected."
-  IS_EXHAUST_TEMPERATURE_SENSOR_PRESENT=false
-  # This reading was taken before the sensor was known to be absent, so it holds an empty string where
-  # every later cycle will hold the "-" placeholder. Backfilling it here keeps the first printed line
-  # consistent with the rest, instead of leaving a blank under the "Exhaust" heading
-  EXHAUST_TEMPERATURE="-"
 fi
 # Output new line to beautify output
 echo ""
@@ -273,7 +270,7 @@ while true; do
     IS_CPU_REMOVAL_ALLOWED=true
     PENDING_CPU_REMOVAL_SIGNATURE=""
     PENDING_CPU_REMOVAL_READINGS=0
-    retrieve_temperatures $IS_EXHAUST_TEMPERATURE_SENSOR_PRESENT
+    retrieve_temperatures
   fi
 
   # Follow the CPUs the server exposes : one may have been added while it was powered off, one may have
@@ -320,7 +317,7 @@ while true; do
     # entity list rather than reused from before it changed. The same data is handed back rather than
     # fetched again : following the CPUs then costs no IPMI round-trip at all, and the readings keep
     # describing the very instant the set was detected on
-    retrieve_temperatures $IS_EXHAUST_TEMPERATURE_SENSOR_PRESENT "$SDR_TEMPERATURE_DATA"
+    retrieve_temperatures "$SDR_TEMPERATURE_DATA"
   fi
 
   # Initialize a variable to store the comments displayed when the fan control profile changed
@@ -390,5 +387,5 @@ while true; do
   sleep "$CHECK_INTERVAL" &
   SLEEP_PROCESS_PID=$!
 
-  retrieve_temperatures $IS_EXHAUST_TEMPERATURE_SENSOR_PRESENT
+  retrieve_temperatures
 done

--- a/functions.sh
+++ b/functions.sh
@@ -568,21 +568,20 @@ function compute_CPU_column_content_width() {
 }
 
 # Retrieve temperature sensors data using ipmitool
-# Usage : retrieve_temperatures $IS_EXHAUST_TEMPERATURE_SENSOR_PRESENT ["$SDR_DATA"]
+# Usage : retrieve_temperatures ["$SDR_DATA"]
 #
 # The sensor data can be handed over by a caller that has just read it, so that detecting the CPUs and
 # taking their first readings cost a single IPMI round-trip and describe the very same instant
 function retrieve_temperatures() {
-  if (( $# < 1 || $# > 2 )); then
-    print_error "Illegal number of parameters. Usage: retrieve_temperatures \$IS_EXHAUST_TEMPERATURE_SENSOR_PRESENT [\"\$SDR_DATA\"]"
+  if (( $# > 1 )); then
+    print_error "Illegal number of parameters. Usage: retrieve_temperatures [\"\$SDR_DATA\"]"
     return 1
   fi
-  local -r IS_EXHAUST_TEMPERATURE_SENSOR_PRESENT=$1
 
   # Kept in a global so that refresh_CPU_temperature_sensors() can look for a newly readable CPU in the
   # very same data, without spending another IPMI round-trip on it
-  if (( $# == 2 )); then
-    SDR_TEMPERATURE_DATA="$2"
+  if (( $# == 1 )); then
+    SDR_TEMPERATURE_DATA="$1"
   else
     SDR_TEMPERATURE_DATA=$(retrieve_sdr_temperature_data)
   fi
@@ -611,12 +610,15 @@ function retrieve_temperatures() {
   # Parse inlet temperature data, the sensor being located by its name
   INLET_TEMPERATURE=$(retrieve_temperature_by_sensor_name "$DATA" "Inlet")
 
-  # If exhaust temperature sensor is present, parse its temperature data
-  if $IS_EXHAUST_TEMPERATURE_SENSOR_PRESENT; then
-    EXHAUST_TEMPERATURE=$(retrieve_temperature_by_sensor_name "$DATA" "Exhaust")
-  else
-    EXHAUST_TEMPERATURE="-"
-  fi
+  # Parse exhaust temperature data, the sensor being located by its name like the inlet one.
+  # It is read on every cycle rather than once, an empty value meaning "nothing on this cycle" rather
+  # than "no such sensor" : the presence flag this used to consult was decided from a single pre-loop
+  # reading and only ever set to false, so one partial SDR response -- or chassis sensors not yet
+  # initialised while the CPU entities already were -- dropped the column for the container's lifetime
+  # even though the sensor answered a second later. The display layer already renders an unreadable
+  # value as the "-" placeholder, so a server that genuinely has no exhaust sensor still shows the
+  # same column it did before, on every line
+  EXHAUST_TEMPERATURE=$(retrieve_temperature_by_sensor_name "$DATA" "Exhaust")
 }
 
 # Returns 0 (true) if the target server is currently powered on, 1 (false) otherwise

--- a/tests/README.md
+++ b/tests/README.md
@@ -87,7 +87,7 @@ function test_a_single_cpu_server_reports_one_cpu() {
   export MOCK_IPMITOOL_SDR_OUTPUT
   MOCK_IPMITOOL_SDR_OUTPUT=$(make_sdr_output --cpus 1 --cpu-temperatures "44")
 
-  retrieve_temperatures true true
+  retrieve_temperatures "$SDR_DATA"
 
   assert_equals "1" "$NUMBER_OF_DETECTED_CPUS"
 }

--- a/tests/cases/40_temperature_parsing.sh
+++ b/tests/cases/40_temperature_parsing.sh
@@ -59,7 +59,7 @@ function test_the_sign_survives_the_whole_read_not_just_the_extraction() {
   MOCK_IPMITOOL_SDR_OUTPUT=$(make_sdr_output --cpus 2 --cpu-temperatures "-40 -5" --inlet -3 --exhaust 12)
 
   detect_CPU_temperature_sensors "$(retrieve_sdr_temperature_data)"
-  retrieve_temperatures true
+  retrieve_temperatures
 
   assert_equals "-40" "${DETECTED_CPU_TEMPERATURES[0]}"
   assert_equals "-5" "${DETECTED_CPU_TEMPERATURES[1]}"

--- a/tests/cases/55_enclosure_housed_servers.sh
+++ b/tests/cases/55_enclosure_housed_servers.sh
@@ -77,7 +77,7 @@ function test_a_blade_reports_no_exhaust_temperature_sensor() {
   MOCK_IPMITOOL_SDR_OUTPUT=$(make_sdr_output --cpus 2 --cpu-temperatures "43 45" --inlet 24 --no-exhaust)
 
   detect_CPU_temperature_sensors "$(retrieve_sdr_temperature_data)"
-  retrieve_temperatures true
+  retrieve_temperatures
 
   assert_equals "2" "${#DETECTED_CPU_ENTITY_IDS[@]}"
   assert_equals "24" "$INLET_TEMPERATURE"
@@ -92,7 +92,7 @@ function test_a_sled_whose_enclosure_owns_the_airflow_reports_no_temperature_aro
   MOCK_IPMITOOL_SDR_OUTPUT=$(make_sdr_output --cpus 2 --cpu-temperatures "47 48" --no-inlet --no-exhaust)
 
   detect_CPU_temperature_sensors "$(retrieve_sdr_temperature_data)"
-  retrieve_temperatures true
+  retrieve_temperatures
 
   assert_equals "47" "${DETECTED_CPU_TEMPERATURES[0]}"
   assert_equals "48" "${DETECTED_CPU_TEMPERATURES[1]}"

--- a/tests/cases/60_cpu_topologies.sh
+++ b/tests/cases/60_cpu_topologies.sh
@@ -12,10 +12,8 @@
 # come from, so a test drives the pair the way the controller does.
 
 function detect_then_retrieve_temperatures() {
-  local -r IS_EXHAUST_TEMPERATURE_SENSOR_PRESENT="${1:-true}"
-
   detect_CPU_temperature_sensors "$(retrieve_sdr_temperature_data)"
-  retrieve_temperatures "$IS_EXHAUST_TEMPERATURE_SENSOR_PRESENT"
+  retrieve_temperatures
 }
 
 function test_a_single_cpu_server_reports_one_cpu() {
@@ -96,17 +94,38 @@ function test_a_gap_between_two_readable_sockets_does_not_truncate_the_list() {
   assert_equals "41;39;38" "$CPUS_TEMPERATURES"
 }
 
-function test_the_sensors_known_to_be_absent_are_replaced_by_placeholders() {
+function test_an_exhaust_sensor_missing_from_one_reading_comes_back_on_the_next() {
+  # The exhaust sensor used to be probed once before the loop, and a single reading
+  # without it settled the question for the container's whole life : one partial sdr
+  # response, or chassis sensors not yet initialised while the CPU entities already
+  # were, dropped the column until the container was restarted. It is read every
+  # cycle now, so a sensor that answers a second later is picked back up
   export MOCK_IPMITOOL_SDR_OUTPUT
-  MOCK_IPMITOOL_SDR_OUTPUT=$(make_sdr_output --cpus 2 --cpu-temperatures "44 46" --exhaust 36)
+  MOCK_IPMITOOL_SDR_OUTPUT=$(make_sdr_output --cpus 2 --cpu-temperatures "44 46" --no-exhaust)
 
-  # Once the controller has detected that the exhaust sensor is missing, it stops
-  # reading it and prints a placeholder in its place
-  detect_then_retrieve_temperatures false
+  detect_then_retrieve_temperatures
 
-  assert_equals "-" "$EXHAUST_TEMPERATURE"
+  assert_empty "$EXHAUST_TEMPERATURE" "a reading without the exhaust sensor yields no value"
   assert_equals "2" "${#DETECTED_CPU_ENTITY_IDS[@]}" "a missing exhaust sensor must not change the CPU count"
   assert_equals "44;46" "$CPUS_TEMPERATURES"
+
+  MOCK_IPMITOOL_SDR_OUTPUT=$(make_sdr_output --cpus 2 --cpu-temperatures "44 46" --exhaust 36)
+
+  retrieve_temperatures
+
+  assert_equals "36" "$EXHAUST_TEMPERATURE" "the exhaust sensor must be read again rather than written off"
+}
+
+function test_a_server_genuinely_without_an_exhaust_sensor_keeps_its_column() {
+  # Reading it every cycle must not cost the column on hardware that has none :
+  # the display layer renders an unreadable value as the "-" placeholder, so the
+  # line keeps the same shape it had when absence was a settled verdict
+  export MOCK_IPMITOOL_SDR_OUTPUT
+  MOCK_IPMITOOL_SDR_OUTPUT=$(make_sdr_output --cpus 2 --cpu-temperatures "44 46" --no-exhaust)
+
+  detect_then_retrieve_temperatures
+
+  assert_equals "  -" "$(format_temperature_for_display "$EXHAUST_TEMPERATURE")"
 }
 
 function test_a_server_without_an_inlet_or_exhaust_sensor_reports_no_reading() {
@@ -131,7 +150,7 @@ function test_an_unreadable_cpu1_temperature_keeps_its_column() {
   assert_equals "2" "${#DETECTED_CPU_ENTITY_IDS[@]}"
 
   MOCK_IPMITOOL_SDR_OUTPUT=$(printf '%s\n' "$MOCK_IPMITOOL_SDR_OUTPUT" | grep -v ' 3\.2 ')
-  retrieve_temperatures true
+  retrieve_temperatures
 
   assert_empty "${DETECTED_CPU_TEMPERATURES[1]}" "the raw reading stays empty for the overheating check"
   assert_equals "44;-" "$CPUS_TEMPERATURES" "the printed value falls back on a placeholder"
@@ -140,7 +159,7 @@ function test_an_unreadable_cpu1_temperature_keeps_its_column() {
 function test_the_internal_functions_reject_a_wrong_number_of_parameters() {
   local RETRIEVE_OUTPUT BUILD_HEADER_OUTPUT
 
-  RETRIEVE_OUTPUT=$(retrieve_temperatures true true true 2>&1)
+  RETRIEVE_OUTPUT=$(retrieve_temperatures extra1 extra2 2>&1)
   local -r RETRIEVE_EXIT_CODE=$?
   BUILD_HEADER_OUTPUT=$(build_header 5 2>&1)
   local -r BUILD_HEADER_EXIT_CODE=$?
@@ -263,7 +282,7 @@ function test_a_cpu_going_silent_on_a_running_server_keeps_its_column() {
   for ((READING = 1; READING <= CPU_REMOVAL_CONFIRMING_READINGS + 2; READING++)); do
     refresh_CPU_temperature_sensors "$SDR_DATA"
   done
-  retrieve_temperatures true "$SDR_DATA"
+  retrieve_temperatures "$SDR_DATA"
 
   assert_equals "3.1 3.2 3.3 3.4" "${DETECTED_CPU_ENTITY_IDS[*]}" "no power cycle, no removal"
   assert_equals "40;41;-;-" "$CPUS_TEMPERATURES" "the silent CPUs keep their column, reading as a placeholder"


### PR DESCRIPTION
Closes the remaining half of #150. **Rebased onto `master` and narrowed to the exhaust sensor** — the CPU half this branch also carried is superseded by #144.

## What is still broken on `master`

#144 fixed the CPU half of #150. It deliberately left the exhaust sensor alone, and that one is still decided from a single pre-loop reading:

```bash
IS_EXHAUST_TEMPERATURE_SENSOR_PRESENT=true      # before the loop
IS_EXHAUST_TEMPERATURE_SENSOR_PRESENT=false     # once, if that reading came back empty
```

Nothing ever sets it back to `true`. One sdr response without the exhaust row — a partial answer, or chassis sensors not yet initialised while the CPU entities already were — drops the Exhaust column for the container's whole life, even though the sensor answers a second later. The pre-loop wait narrows the window, since it only breaks once a **CPU** sensor is readable, but it does not close it: the two are not guaranteed to become readable on the same reading.

## Why the flag goes away entirely

A CPU can only be added or removed while the server is off, which is why #144 gates removal behind a power cycle and confirms it over several readings. A chassis exhaust sensor is not like that: **it is never added or removed at all**. There is nothing to remember about it.

So the flag is removed rather than reset. The sensor is read like the inlet one, every cycle, and an empty value means "nothing on this cycle" rather than "no such sensor". Nothing can be poisoned by a single reading because nothing is remembered.

`retrieve_temperatures()` loses its first parameter, that flag having been its only consumer.

## No extra IPMI traffic — measured

The exhaust reading is parsed out of the same sdr output the inlet and CPU readings already come from. A cycle still costs exactly one `sdr type temperature` call, and none at all when the caller hands the data over:

```
one cycle costs exactly one sdr call ....... ok
and the exhaust reading comes out of it .... ok
handing the data over costs no call at all . ok
```

## Nothing changes for a server without the sensor

The display layer already renders an unreadable value as the `-` placeholder, so the column keeps exactly the shape it had when absence was a settled verdict. Blades and enclosure-housed sleds print the same line as before.

The startup message keeps its wording, `No exhaust temperature sensor detected.` — most servers printing it really do lack the sensor, and saying anything about a future reading would be wrong on exactly that hardware. What changed is that the line no longer decides anything.

## Verification

**201 test cases pass** (1421 assertions), up from 196. Two new cases replace the one that asserted the old settled-verdict behavior:

- `test_an_exhaust_sensor_missing_from_one_reading_comes_back_on_the_next` — the regression this PR exists to prevent.
- `test_a_server_genuinely_without_an_exhaust_sensor_keeps_its_column` — no column lost on hardware that has none.

The blade and enclosure-sled cases in `55_enclosure_housed_servers.sh` and the integration case in `90_integration.sh` are unchanged and still pass.