### PR TITLE
Keep the table aligned in monitoring only mode

### DIFF
--- a/Dell_iDRAC_fan_controller.sh
+++ b/Dell_iDRAC_fan_controller.sh
@@ -328,6 +328,10 @@ fi
 # Output new line to beautify output
 echo ""
 
+# Settled here, once, and read by both the header and every row : the profile column is too tight to hold
+# the monitoring only mode badge, so its width follows the mode rather than being a literal in two places
+resolve_fan_control_profile_column_width
+
 CPU_COLUMN_CONTENT_WIDTH=$(compute_CPU_column_content_width "${DETECTED_CPU_LABELS[@]}")
 if ! HEADER=$(build_header "$CPU_COLUMN_CONTENT_WIDTH" "${DETECTED_CPU_LABELS[@]}"); then
   print_error_and_exit "Could not build the temperatures table header"

--- a/constants.sh
+++ b/constants.sh
@@ -44,6 +44,22 @@ readonly MINIMUM_CPU_COLUMN_CONTENT_WIDTH=5
 # slow to become readable after POST, and monitoring one heat source less until it shows up again
 readonly CPU_REMOVAL_CONFIRMING_READINGS=5
 
+# Widths of the two right-hand columns of the temperatures table. The header and the rows are both laid out
+# from these, rather than each repeating a literal of its own, which is how the profile column came to
+# reserve less in the header than the rows were printing into it.
+#
+# That column has zero slack by construction : "Dell default dynamic fan control profile" is exactly 40
+# characters, so the " (monitoring only, not applied)" badge -- 31 more -- cannot be made to fit by
+# shortening anything, and the column has to widen with the mode instead. MONITORING_ONLY_MODE is fixed for
+# the container's lifetime, so which of the two applies is settled once at startup
+readonly FAN_CONTROL_PROFILE_COLUMN_WIDTH=40
+readonly MONITORING_ONLY_MODE_FAN_CONTROL_PROFILE_COLUMN_WIDTH=71
+
+# The cooling response column is sized by its own heading, "Third-party PCIe card Dell default cooling
+# response", which is longer than anything that column ever holds : its widest value is "Disabled (not
+# applied: monitoring only mode)" at 44. So, unlike the profile column, it does not move with the mode
+readonly COOLING_RESPONSE_COLUMN_WIDTH=51
+
 # How long the supervisor gives the monitoring process to stop on its own after forwarding it the signal,
 # before killing it outright. Docker's own grace period is 10 seconds by default, so this has to stay
 # comfortably inside it or the container is SIGKILLed as a whole before the supervisor gets to act

--- a/functions.sh
+++ b/functions.sh
@@ -1253,6 +1253,39 @@ function get_Dell_server_model() {
   fi
 }
 
+# Settle the width of the "Active fan speed profile" column, which the header and the rows both lay
+# themselves out from. It depends only on MONITORING_ONLY_MODE, fixed for the container's lifetime, so it
+# is resolved once at startup rather than per row -- and, coming from one place, the header and the rows
+# cannot end up reserving different widths for the same column, which is the defect this exists to close
+# Usage : resolve_fan_control_profile_column_width
+# Returns : TABLE_FAN_CONTROL_PROFILE_COLUMN_WIDTH
+function resolve_fan_control_profile_column_width() {
+  if "$MONITORING_ONLY_MODE"; then
+    TABLE_FAN_CONTROL_PROFILE_COLUMN_WIDTH=$MONITORING_ONLY_MODE_FAN_CONTROL_PROFILE_COLUMN_WIDTH
+  else
+    TABLE_FAN_CONTROL_PROFILE_COLUMN_WIDTH=$FAN_CONTROL_PROFILE_COLUMN_WIDTH
+  fi
+}
+
+# Centre a column heading in a column of the given width, the odd character going to the left, which is the
+# convention the "Temperatures" banner already follows. Written into a named variable like
+# set_log_timestamp() does, rather than echoed, so that no subshell is paid for a string this short.
+#
+# Centred rather than right-aligned : the values below are right-aligned, but the monitoring only mode
+# profile column is 71 characters wide, and a heading flush against its right edge would drift away from
+# the heading on its left. This is also what the table has always displayed
+# Usage : center_column_heading HEADING_VARIABLE "Heading" $COLUMN_WIDTH
+function center_column_heading() {
+  local -r TARGET_VARIABLE_NAME="$1"
+  local -r HEADING="$2"
+  local -r COLUMN_WIDTH="$3"
+
+  local -r LEFT_PADDING_WIDTH=$(( (COLUMN_WIDTH - ${#HEADING} + 1) / 2 ))
+  local -r RIGHT_PADDING_WIDTH=$(( COLUMN_WIDTH - ${#HEADING} - LEFT_PADDING_WIDTH ))
+
+  printf -v "$TARGET_VARIABLE_NAME" '%*s%s%*s' "$LEFT_PADDING_WIDTH" '' "$HEADING" "$RIGHT_PADDING_WIDTH" ''
+}
+
 # Builds the two header lines of the temperatures table, sized for the CPUs actually detected
 # Usage : build_header $CPU_COLUMN_CONTENT_WIDTH ["CPU 1" "CPU 2" ...]
 #
@@ -1263,6 +1296,15 @@ function get_Dell_server_model() {
 function build_header() {
   if (( $# < 1 )); then
     print_error "build_header() requires a column content width"
+    return 1
+  fi
+
+  # The one width that does not arrive as an argument : the rows read it too, and threading it through the
+  # seven parameters print_temperature_array_line() already takes would be worse than naming it once. Left
+  # unresolved it would pad to nothing and misalign every row silently, so it is refused here instead --
+  # this runs once, at startup, and the caller turns a refusal into a container that stops
+  if [ -z "$TABLE_FAN_CONTROL_PROFILE_COLUMN_WIDTH" ]; then
+    print_error "build_header() needs the fan control profile column width, resolve_fan_control_profile_column_width() has not run"
     return 1
   fi
 
@@ -1297,7 +1339,13 @@ function build_header() {
     header+=$(printf ' %*s ' "$LOCAL_CPU_COLUMN_CONTENT_WIDTH" "$CPU_LABEL")
   done
 
-  header+=' Exhaust          Active fan speed profile          Third-party PCIe card Dell default cooling response  Comment'
+  # Padded to the very widths the rows print into, so that a heading keeps sitting above its own values
+  # instead of the rows overflowing a header that reserved less
+  local FAN_CONTROL_PROFILE_HEADING COOLING_RESPONSE_HEADING
+  center_column_heading FAN_CONTROL_PROFILE_HEADING 'Active fan speed profile' "$TABLE_FAN_CONTROL_PROFILE_COLUMN_WIDTH"
+  center_column_heading COOLING_RESPONSE_HEADING 'Third-party PCIe card Dell default cooling response' "$COOLING_RESPONSE_COLUMN_WIDTH"
+
+  header+=" Exhaust  ${FAN_CONTROL_PROFILE_HEADING}  ${COOLING_RESPONSE_HEADING}  Comment"
   printf "%s" "$header"
 }
 
@@ -1327,7 +1375,7 @@ function print_temperature_array_line() {
 
   # Exhaust goes through the same formatter as the other three temperature columns, so that a reading
   # that failed on this cycle shows the "-" placeholder rather than an empty column reading as "°C"
-  printf " %5s°C  %40s  %51s  %s\n" "$(format_temperature_for_display "$LOCAL_EXHAUST_TEMPERATURE")" "$LOCAL_CURRENT_FAN_CONTROL_PROFILE" "$LOCAL_THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE_STATUS" "$LOCAL_COMMENT"
+  printf " %5s°C  %*s  %*s  %s\n" "$(format_temperature_for_display "$LOCAL_EXHAUST_TEMPERATURE")" "$TABLE_FAN_CONTROL_PROFILE_COLUMN_WIDTH" "$LOCAL_CURRENT_FAN_CONTROL_PROFILE" "$COOLING_RESPONSE_COLUMN_WIDTH" "$LOCAL_THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE_STATUS" "$LOCAL_COMMENT"
 }
 
 # Stamp the current local time into the named variable, in the format every logged line starts with.

--- a/functions.sh
+++ b/functions.sh
@@ -1360,6 +1360,9 @@ function print_temperature_array_line() {
 
   # Creating an array from the string
   local -r CPUs_temperatures_array=(${LOCAL_CPUS_TEMPERATURES//;/ })
+  # Declared like its neighbours : functions.sh is sourced into the entry point, so a loop counter left
+  # undeclared here lands in the container's main shell, and this function runs on every cycle
+  local temperature
 
   local TIMESTAMP FORMATTED_TEMPERATURE
   set_log_timestamp TIMESTAMP

--- a/tests/cases/60_cpu_topologies.sh
+++ b/tests/cases/60_cpu_topologies.sh
@@ -544,3 +544,21 @@ function test_the_header_is_refused_when_the_profile_column_width_is_unresolved(
   assert_equals 1 "$EXIT_CODE" "a header that cannot be sized must not be printed"
   assert_contains "$OUTPUT" "resolve_fan_control_profile_column_width" "the refusal names what has not run"
 }
+
+function test_printing_a_row_leaks_no_variable_into_the_calling_shell() {
+  # functions.sh is sourced by the entry point, so anything a function leaves undeclared lands in the
+  # container's main shell -- and this one runs on every cycle of the monitoring loop. Nothing reads a
+  # variable by these names today, which is exactly why the leak could sit there unnoticed (#171)
+  local LEAKED_NAME
+  for LEAKED_NAME in temperature i number_of_dashes; do
+    unset "$LEAKED_NAME"
+  done
+
+  print_temperature_array_line 5 "21" "45;46" "34" "Dell default dynamic fan control profile" "Enabled" "-" > /dev/null
+  build_header 5 "CPU 1" "CPU 2" > /dev/null
+
+  for LEAKED_NAME in temperature i number_of_dashes; do
+    assert_equals "unset" "${!LEAKED_NAME+set}${!LEAKED_NAME-unset}" \
+      "\"$LEAKED_NAME\" must not escape into the shell that sourced functions.sh"
+  done
+}

--- a/tests/cases/60_cpu_topologies.sh
+++ b/tests/cases/60_cpu_topologies.sh
@@ -427,3 +427,120 @@ function test_every_cpu_going_silent_at_once_never_empties_the_table() {
       "reading $READING left the table intact"
   done
 }
+
+# The two right-hand columns of the table, whose widths the header and the rows have to agree on.
+#
+# The "°C" of a reading is one character on screen but two bytes in UTF-8, and the container runs in the
+# POSIX locale (the Dockerfile sets no LANG), where "${#STRING}" counts bytes. A row therefore measures
+# longer than it looks while a header, which carries no "°", does not. Every measurement below replaces the
+# degree sign with a one-byte stand-in first, so what is compared is what the reader sees, in any locale
+function display_width() {
+  local -r LINE="${1//°/o}"
+  printf '%s' "${#LINE}"
+}
+
+# Where the "Comment" column starts, which is the position everything to its left adds up to : it moves as
+# soon as a value overflows the field reserved for it, and it is the last column, so nothing hides the shift
+function comment_column_start_in_header() {
+  local -r HEADER_COLUMNS_LINE="$1"
+  printf '%s' "$(( $(display_width "$HEADER_COLUMNS_LINE") - ${#COMMENT_HEADING} ))"
+}
+
+readonly COMMENT_HEADING="Comment"
+readonly COMMENT_MARKER="COMMENT-MARKER"
+
+function assert_the_table_columns_line_up() {
+  local -r IS_MONITORING_ONLY_MODE="$1"
+  local -r FAN_CONTROL_PROFILE="$2"
+  local -r COOLING_RESPONSE_STATUS="$3"
+
+  export MONITORING_ONLY_MODE="$IS_MONITORING_ONLY_MODE"
+  resolve_fan_control_profile_column_width
+
+  local -r HEADER_COLUMNS_LINE=$(build_header 5 "CPU 1" "CPU 2" | tail -1)
+  local -r ROW=$(print_temperature_array_line 5 "21" "45;46" "34" "$FAN_CONTROL_PROFILE" "$COOLING_RESPONSE_STATUS" "$COMMENT_MARKER")
+
+  local -r ROW_BEFORE_COMMENT="${ROW%%"$COMMENT_MARKER"*}"
+
+  assert_equals "$(comment_column_start_in_header "$HEADER_COLUMNS_LINE")" "$(display_width "$ROW_BEFORE_COMMENT")" \
+    "MONITORING_ONLY_MODE=$IS_MONITORING_ONLY_MODE, \"$FAN_CONTROL_PROFILE\" : the comment column must start where the header says it does"
+}
+
+function test_the_table_columns_line_up_whatever_the_profile_and_the_mode() {
+  # The defect of #170 : the profile column had zero slack -- "Dell default dynamic fan control profile" is
+  # exactly the 40 characters it reserved -- so the monitoring only mode badge simply widened the field and
+  # pushed the cooling response and comment columns 27 to 31 characters right of their headings. The shift
+  # was not even constant, it followed the active profile and the configured percentage, so the columns
+  # jittered from row to row and the header reprinted every TABLE_HEADER_PRINT_INTERVAL cycles never lined
+  # up with a single data row
+  assert_the_table_columns_line_up false "Dell default dynamic fan control profile" "Enabled"
+  assert_the_table_columns_line_up false "User static fan control profile (5%)" "Could not be applied on this cycle"
+  assert_the_table_columns_line_up false "User static fan control profile (100%)" "Not supported by this server"
+
+  assert_the_table_columns_line_up true "Dell default dynamic fan control profile (monitoring only, not applied)" \
+    "Enabled (not applied: monitoring only mode)"
+  assert_the_table_columns_line_up true "User static fan control profile (5%) (monitoring only, not applied)" \
+    "Disabled (not applied: monitoring only mode)"
+  assert_the_table_columns_line_up true "User static fan control profile (100%) (monitoring only, not applied)" \
+    "Enabled (not applied: monitoring only mode)"
+}
+
+function test_no_fan_control_profile_can_outgrow_the_column_reserved_for_it() {
+  # The widths are constants, so they can only stay right for as long as the strings do. This walks every
+  # profile the code can actually produce -- both modes, every fan speed a user can configure -- and every
+  # cooling response status, against the width its column reserves. A string longer than its column is what
+  # #170 was, so a new profile wording has to be caught here rather than in somebody's docker logs
+  local -r MONITORING_ONLY_MODE_BADGE=" (monitoring only, not applied)"
+  local SPEED PROFILE
+  local IS_MONITORING_ONLY_MODE
+
+  for IS_MONITORING_ONLY_MODE in false true; do
+    export MONITORING_ONLY_MODE="$IS_MONITORING_ONLY_MODE"
+    resolve_fan_control_profile_column_width
+
+    local -a PROFILES=("Dell default dynamic fan control profile")
+    for SPEED in 1 5 10 50 100; do
+      PROFILES+=("User static fan control profile ($SPEED%)")
+    done
+
+    local WIDEST_PROFILE_WIDTH=0
+    for PROFILE in "${PROFILES[@]}"; do
+      if [ "$IS_MONITORING_ONLY_MODE" == "true" ]; then
+        PROFILE+="$MONITORING_ONLY_MODE_BADGE"
+      fi
+      (( ${#PROFILE} > WIDEST_PROFILE_WIDTH )) && WIDEST_PROFILE_WIDTH=${#PROFILE}
+      assert_equals "true" "$([ "${#PROFILE}" -le "$TABLE_FAN_CONTROL_PROFILE_COLUMN_WIDTH" ] && echo true || echo false)" \
+        "MONITORING_ONLY_MODE=$IS_MONITORING_ONLY_MODE : \"$PROFILE\" (${#PROFILE}) must fit in $TABLE_FAN_CONTROL_PROFILE_COLUMN_WIDTH"
+    done
+
+    # Reserving far more than the widest string would push the comment column right for nothing, so the
+    # width is also asserted not to be generous
+    assert_equals "$WIDEST_PROFILE_WIDTH" "$TABLE_FAN_CONTROL_PROFILE_COLUMN_WIDTH" \
+      "MONITORING_ONLY_MODE=$IS_MONITORING_ONLY_MODE : the column is exactly as wide as its widest profile"
+  done
+
+  local COOLING_RESPONSE_STATUS
+  for COOLING_RESPONSE_STATUS in "Enabled" "Disabled" "Not supported by this server" \
+    "Could not be applied on this cycle" "Enabled (not applied: monitoring only mode)" \
+    "Disabled (not applied: monitoring only mode)"; do
+    assert_equals "true" "$([ "${#COOLING_RESPONSE_STATUS}" -le "$COOLING_RESPONSE_COLUMN_WIDTH" ] && echo true || echo false)" \
+      "\"$COOLING_RESPONSE_STATUS\" (${#COOLING_RESPONSE_STATUS}) must fit in $COOLING_RESPONSE_COLUMN_WIDTH"
+  done
+}
+
+function test_the_header_is_refused_when_the_profile_column_width_is_unresolved() {
+  # That width is the one build_header() does not receive as an argument, the rows reading it too. Left
+  # unresolved, printf pads to nothing and every row comes out misaligned without a word -- which is the
+  # defect of #170 all over again, so it is refused rather than rendered
+  local -r RESOLVED_WIDTH="$TABLE_FAN_CONTROL_PROFILE_COLUMN_WIDTH"
+  unset TABLE_FAN_CONTROL_PROFILE_COLUMN_WIDTH
+
+  local OUTPUT
+  OUTPUT=$(build_header 5 "CPU 1" 2>&1)
+  local -r EXIT_CODE=$?
+
+  TABLE_FAN_CONTROL_PROFILE_COLUMN_WIDTH="$RESOLVED_WIDTH"
+
+  assert_equals 1 "$EXIT_CODE" "a header that cannot be sized must not be printed"
+  assert_contains "$OUTPUT" "resolve_fan_control_profile_column_width" "the refusal names what has not run"
+}

--- a/tests/lib/harness.sh
+++ b/tests/lib/harness.sh
@@ -35,6 +35,8 @@ function setup_test_context() {
   CONTROLLER_WORKING_DIRECTORY="$REPO_ROOT"
   # Set before the trap by the controller, so graceful_exit can read it whenever a signal lands
   IS_THIRD_PARTY_PCIE_CARD_COOLING_RESPONSE_SUPPORTED=true
+  # Settled once at startup by the controller, and read by build_header() and by every row it prints
+  resolve_fan_control_profile_column_width
 
   # Mock defaults : a healthy, powered-on dual CPU Gen 13 server
   export MOCK_IPMITOOL_CALL_LOG="$TEST_TEMPORARY_DIRECTORY/ipmitool_calls.log"


### PR DESCRIPTION
Closes #170 and #171. Rebased onto `master`: this branch used to be the 10th of a stack and carried seven commits belonging to other pull requests, four of which have since landed on `master` under different SHAs. It now holds only its own two.

## The alignment defect (#170)

The "Active fan speed profile" column is printed with a fixed `%40s`, and the header reserves a matching slot by hand. `Dell default dynamic fan control profile` is **exactly** 40 characters, so the column has zero slack, and the monitoring-only variants blow straight past it:

| profile string (monitoring only mode) | length |
|---|---|
| `Dell default dynamic fan control profile (monitoring only, not applied)` | 71 |
| `User static fan control profile (N%) (monitoring only, not applied)` | 67 – 69 |

The second is not a fixed length: it interpolates `$DECIMAL_FAN_SPEED`, so it is 67 for a one-digit percentage, 68 for two and 69 for `100`.

`printf` does not truncate, so the field widens and pushes the "Third-party PCIe card…" and "Comment" columns **27 to 31 characters** right of their headings. The shift is not even constant — it follows the active profile and the number of digits in the configured percentage — so the columns jitter from row to row, and the header reprinting every `TABLE_HEADER_PRINT_INTERVAL` cycles never lines up with a single data row.

Being a whole-run mode, this affects every row for the container's lifetime, in precisely the mode the README recommends running first to validate one's settings.

## What changed

No amount of shortening the badge can fix a column with no slack, so the width becomes a constant instead of a literal repeated in two places. `MONITORING_ONLY_MODE` is fixed for the container's lifetime, so it is resolved once at startup and read by both the header and every row, which can no longer reserve different widths for the same column.

It is **read rather than passed**: `print_temperature_array_line()` already takes seven positional parameters, and threading two more through it would cost more than it buys. What that leaves is a width that could go unresolved — `printf "%*s"` pads to nothing on an empty width, silently — so `build_header()` refuses to build a header it cannot size, next to the argument check it already makes. That runs once, at startup, and the caller turns the refusal into a container that stops. Happy to thread it through instead if you would rather.

The **cooling response column is left as it is**, contrary to what #170 supposes at the end. Its widest value is `Disabled (not applied: monitoring only mode)` at 44 characters and its own heading is 51, so it never overflowed and does not move with the mode. Its width is still named rather than repeated as a literal in two places — that duplication being how the profile column came to disagree with itself.

## The leaked loop counter (#171)

The branch also carries the fix for #171, which came in through #229 and was never mentioned in this description.

`functions.sh` is sourced into the entry point, so anything a function leaves undeclared lands in the container's main shell. `print_temperature_array_line()`'s `for temperature in ...` counter is one of those, and it runs on every cycle: the shell ends up holding the last CPU temperature of the last row under a name nothing chose. Nothing reads that name today, which is exactly why it could sit there unnoticed.

The other two names #171 and #229 report — `build_header()`'s `number_of_dashes` and its `for ((i=...))` counters — **no longer exist**: master's rewrite replaced the dash loops with `printf` padding and declares the label counter. The test asserts all three anyway, the point being the shell staying clean rather than those particular names.

## Verification

Normal mode output is **byte-identical** to `master`, checked by rendering the header and a row from both trees and diffing them. The heading stays centred over its column — 8 spaces either side of the 24-character text in a 40-wide field, which is what the table has always shown — rather than becoming flush with the values below it.

Where the "Comment" column starts, in display characters, on a dual-CPU table:

```
                             master        this branch
MONITORING_ONLY_MODE=false   146 / 146     146 / 146     (header / row)
MONITORING_ONLY_MODE=true    146 / 177     177 / 177
                                   ^^^ 31 characters past the header
```

The measurements count what the reader sees rather than what bash counts: the container runs in the POSIX locale, where `${#STRING}` counts **bytes** and the `°` of a reading is two of them, so a row measures longer than it looks while a header, carrying no `°`, does not. The new cases normalise that before comparing, so they hold in any locale.

Checked in both directions — against `master`'s layout the alignment case fails with exactly the 27-to-31 character jitter #170 reports, and the leak case comes back holding `46`, the last CPU temperature of the row it just printed.

One case walks every profile string the code can produce, both modes and every fan speed, against the width its column reserves — and asserts the column is no wider than its widest string, so neither a new profile wording nor a generous constant can drift past unnoticed.

```
master      : 306 test cases passed
this branch : 310 test cases passed (1774 assertions)
```