### PR TITLE
Declare build_header and print_temperature_array_line locals

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -518,8 +518,11 @@ function build_header() {
 
   local header="                     ----" # Width ready for 1 CPU
 
-  # Calculate the number of dashes to add on each side of the title
-  number_of_dashes=$(((number_of_CPUs-1)*CPU_column_width/2))
+  # Calculate the number of dashes to add on each side of the title.
+  # Declared local like its neighbours: functions.sh is sourced into the entry point, so anything left
+  # undeclared here lands in the container's main shell
+  local -r number_of_dashes=$(((number_of_CPUs-1)*CPU_column_width/2))
+  local i
 
   # Loop to add dashes
   for ((i=1; i<=number_of_dashes; i++)); do
@@ -562,6 +565,9 @@ function print_temperature_array_line() {
 
   # Creating an array from the string
   local -r CPUs_temperatures_array=(${LOCAL_CPUS_TEMPERATURES//;/ })
+  # The loop variable below is the one that actually escapes: unlike build_header(), which the caller
+  # runs in a command substitution, this function is called directly on every cycle
+  local temperature
 
   printf "%19s  %s°C " "$(date +"%d-%m-%Y %T")" "$(format_temperature_for_display "$LOCAL_INLET_TEMPERATURE")"
   # Itération sur les températures dans le tableau


### PR DESCRIPTION
Closes #171. **11th and last in the stack** — based on #180.

`functions.sh` is sourced into the entry point, so anything a function leaves undeclared lands in the container's main shell.

```
before: temperature=[42]
after:  temperature=[<unset>]
```

`print_temperature_array_line()`'s `for temperature in …` counter is the one that actually escapes, and it is called on every cycle of the monitoring loop.

`build_header()`'s `number_of_dashes` and its three loop counters are undeclared too, but they **cannot reach a running shell today**: the function returns its result on stdout, so its only call site is a command substitution and both names die with that subshell. That is a correction to how this was originally reported.

## Why fix it anyway

Neither has a user-visible effect right now — nothing else reads a variable by those names. They are fixed because #178 removed the `readonly` from `HEADER` and made `build_header` callable from inside the loop, which is exactly the change that turns a confined subshell leak into one that can clobber a caller's loop counter.

No output changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CbNSVDuGxXfPf9qyKnsNbh)_