### PR TITLE
Stop running the whole test workflow twice per push

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,11 @@ name: Tests
 
 on:
   push:
+    # Branches are covered by their pull request. Without this, every push to a
+    # branch that has one runs the whole workflow twice, publishes the results
+    # twice, and leaves a skipped "event file" check behind. Keeping master is
+    # what gives the published results a baseline to compare against
+    branches: [master]
     paths-ignore:
       - "**/README.md"
   pull_request:


### PR DESCRIPTION
Closes #186.

A branch of this repository with an open pull request got **both** a `push` run and a `pull_request` run of the entire workflow on the same commit. Measured on the branch of #158:

| Commit | `push` run | `pull_request` run |
| --- | --- | --- |
| `ea80069` | #3 | #4 |
| `64eaf48` | #5 | #6 |
| `c931266` | #7 | #8 |

That is two test suites, **two Docker builds**, the results published twice into the same comment — so two notifications per commit — and a permanently skipped `Tests / Upload the event file (push)` check sitting in the list, which is what the "2 skipped checks" line on a green pull request refers to.

## The change

```yaml
on:
  push:
    branches: [master]
```

Branches are covered by their pull request. Keeping `master` is deliberate: its run is what gives `EnricoMi/publish-unit-test-result-action` the baseline behind the `± Comparison against base commit` line, and what makes a broken default branch visible straight away.

Verified on the branch this was first written on: the commit carrying the change produced a `pull_request` run and **no** `push` run, while the commit before it produced both.

The trade is that a branch pushed without a pull request no longer gets CI. For a repository that merges through pull requests, that is the intended behaviour; `workflow_dispatch` is still declared for the exceptions.

## Note for review

⚠️ **CI on this pull request will be red, and not because of this change.** `master` is currently red — #185 fixes it. This branch is based on `master`, so it inherits those two failing test cases:

```
80_temperature_thresholds.sh — a non numeric reading fails safe and reports overheating
80_temperature_thresholds.sh — an unreadable temperature is printed as a placeholder
```

Merge #185 first, then this branch just needs updating and will go green. This pull request touches nothing but `.github/workflows/tests.yml`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q2kZqrbw7hzFtytvWAT5yJ)_