### PR TITLE
Make the test suite able to fail, and put it between master and the published image

### DIFF
--- a/.github/workflows/build_and_publish_docker_image.yml
+++ b/.github/workflows/build_and_publish_docker_image.yml
@@ -10,9 +10,29 @@ on:
   workflow_dispatch:
 
 jobs:
+  # The Tests workflow runs on push and pull_request, neither of which fires on
+  # a version tag : without this job a release would be built and published
+  # without a single test having run on the commit being released
+  test:
+    name: Run the test suite before publishing
+    runs-on: ubuntu-latest
+    # Reading the repository is all this job does ; publishing keeps the
+    # workflow's default token
+    permissions:
+      contents: read
+    if: startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run the test suite
+        run: ./tests/run_tests.sh --summary "$GITHUB_STEP_SUMMARY"
+
   build:
     name: Build and publish Docker image to Docker Hub and GitHub Containers Repository
     runs-on: ubuntu-latest
+    # Nothing is published unless the suite passed on the tagged commit
+    needs: [test]
     # The workflow_dispatch ref dropdown offers branches too. Publishing an image
     # built from a branch would move "latest" onto unreleased code, so only run
     # when the ref is a version tag

--- a/tests/cases/15_test_runner.sh
+++ b/tests/cases/15_test_runner.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+
+# Checks on the runner itself. Every other case file trusts it to turn a broken
+# controller into a red run ; these pin the four ways it used to stay green
+# while nothing had been verified. A suite that guards master has to be able to
+# fail, and that is what is tested here.
+
+# The runner reads its case files as text to list them in declaration order, so
+# a case file that merely quotes a definition would have it discovered too. That
+# is exactly what this file does, so the probes below name their test cases
+# through this prefix : nothing here reads as a definition to the outer run
+readonly PROBE_PREFIX="test"
+
+# Run the real runner against a throwaway case file, inside a repository of
+# symbolic links to the real scripts. The probe therefore exercises the real
+# controller, and never joins the suite that is currently running
+function run_the_runner_on_a_probe_case_file() {
+  local -r PROBE_CONTENT="$1"
+
+  local -r PROBE_REPOSITORY="$TEST_TEMPORARY_DIRECTORY/runner_probe"
+  rm -rf "$PROBE_REPOSITORY"
+  mkdir -p "$PROBE_REPOSITORY/tests/cases"
+
+  # The runner derives the repository root from its own path
+  local REPOSITORY_FILE
+  for REPOSITORY_FILE in "$REPO_ROOT"/*.sh "$REPO_ROOT/Dockerfile"; do
+    [ -e "$REPOSITORY_FILE" ] && ln -s "$REPOSITORY_FILE" "$PROBE_REPOSITORY/"
+  done
+  cp "$TESTS_DIRECTORY/run_tests.sh" "$PROBE_REPOSITORY/tests/"
+  cp -r "$TESTS_DIRECTORY/lib" "$TESTS_DIRECTORY/mocks" "$PROBE_REPOSITORY/tests/"
+  printf '%s\n' "$PROBE_CONTENT" > "$PROBE_REPOSITORY/tests/cases/50_probe.sh"
+
+  PROBE_OUTPUT=$(bash "$PROBE_REPOSITORY/tests/run_tests.sh" --no-color 2>&1)
+  PROBE_EXIT_CODE=$?
+}
+
+function test_a_test_case_that_asserts_nothing_is_reported_as_a_failure() {
+  # A case returning early on a condition that no longer holds asserts nothing
+  # and used to be counted among the passing ones
+  run_the_runner_on_a_probe_case_file "function ${PROBE_PREFIX}_verifies_nothing() { : ; }"
+
+  assert_equals 1 "$PROBE_EXIT_CODE" "a case that asserted nothing should fail the run"
+  assert_contains "$PROBE_OUTPUT" "recorded no assertion" \
+    "the report should say the case verified nothing"
+}
+
+function test_a_case_file_that_exits_while_being_sourced_fails_the_run() {
+  # Case files are sourced into the runner's own shell, so an exit reached at
+  # their top level ended the run with nothing printed and a zero exit code
+  run_the_runner_on_a_probe_case_file "exit 0
+function ${PROBE_PREFIX}_never_reached() { fail 'this case should never run'; }"
+
+  assert_equals 1 "$PROBE_EXIT_CODE" "a case file exiting while sourced should fail the run"
+  assert_contains "$PROBE_OUTPUT" "while it was being sourced" \
+    "the report should name what happened"
+}
+
+function test_skipping_a_test_case_does_not_hide_a_failure_it_also_recorded() {
+  # skip_test() only records a reason, it does not return from the case, so a
+  # failing assertion written after it used to disappear behind the skip
+  run_the_runner_on_a_probe_case_file "function ${PROBE_PREFIX}_skips_then_fails() {
+  skip_test 'not applicable here'
+  fail 'this failure must stay visible'
+}"
+
+  assert_equals 1 "$PROBE_EXIT_CODE" "a skipped case that also failed should fail the run"
+  assert_contains "$PROBE_OUTPUT" "this failure must stay visible" \
+    "the failure should be reported, not swallowed by the skip"
+}
+
+function test_a_test_case_skipped_without_failing_is_still_a_skip() {
+  # The counterpart of the case above : a genuine skip must stay a skip, or
+  # every environment-dependent case would turn red
+  run_the_runner_on_a_probe_case_file "function ${PROBE_PREFIX}_only_skips() {
+  skip_test 'nothing to check here'
+  return 0
+}"
+
+  assert_equals 0 "$PROBE_EXIT_CODE" "a case that only skipped should not fail the run"
+  assert_contains "$PROBE_OUTPUT" "nothing to check here" "the skip reason should be reported"
+}
+
+function test_every_form_bash_accepts_for_a_test_case_is_discovered() {
+  # Discovery reads the files as text. These three declarations are all valid
+  # bash, and the two indented or spaced ones used to be silently ignored
+  run_the_runner_on_a_probe_case_file "function ${PROBE_PREFIX}_with_a_space_before_the_parens () { pass; }
+  function ${PROBE_PREFIX}_indented() { pass; }
+${PROBE_PREFIX}_without_the_function_keyword() { pass; }"
+
+  assert_equals 0 "$PROBE_EXIT_CODE" "the probe cases should all pass"
+  assert_contains "$PROBE_OUTPUT" "with a space before the parens" "the spaced form should run"
+  assert_contains "$PROBE_OUTPUT" "indented" "the indented form should run"
+  assert_contains "$PROBE_OUTPUT" "without the function keyword" "the bare form should run"
+}
+
+function test_a_test_case_the_runner_cannot_discover_fails_the_run() {
+  # The safety net behind the discovery pattern : whatever form escapes it, a
+  # test case that exists and would never run has to be loud
+  run_the_runner_on_a_probe_case_file "eval 'function ${PROBE_PREFIX}_defined_through_eval() { pass; }'"
+
+  assert_equals 1 "$PROBE_EXIT_CODE" "an undiscoverable test case should fail the run"
+  assert_contains "$PROBE_OUTPUT" "${PROBE_PREFIX}_defined_through_eval" \
+    "the report should name the test case that would never run"
+}

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -130,16 +130,16 @@ if [ "${#TEST_FILES[@]}" -eq 0 ]; then
   exit 1
 fi
 
-# A case file is sourced into this shell, so an "exit" reached while it is read
-# - a stray one, or a guard clause written at the top level by mistake - ends
-# the runner right here, with that file's own exit code and nothing printed. It
-# would look exactly like a successful run that happened to be quiet. The trap
-# is what turns that silence into a failure
 # The runner and the libraries have helpers of their own whose name starts with
 # "test_" ; only the functions the case files add count as test cases
 TEST_CASE_FUNCTIONS_BEFORE_SOURCING="$(declare -F | sed -n 's/^declare -f \(test_[A-Za-z0-9_]*\)$/\1/p')"
 readonly TEST_CASE_FUNCTIONS_BEFORE_SOURCING
 
+# A case file is sourced into this shell, so an "exit" reached while it is read
+# - a stray one, or a guard clause written at the top level by mistake - ends
+# the runner right here, with that file's own exit code and nothing printed. It
+# would look exactly like a successful run that happened to be quiet. The trap
+# is what turns that silence into a failure
 SOURCING_TEST_FILE=""
 function report_interrupted_sourcing() {
   [ -n "$SOURCING_TEST_FILE" ] || return 0

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -98,9 +98,12 @@ if [ -z "$GENERATION_14_OR_NEWER_REGEX" ]; then
 fi
 
 # Collect the test case names of a file, in declaration order (declare -F would
-# sort them alphabetically, which would scramble the story each file tells)
+# sort them alphabetically, which would scramble the story each file tells).
+# Every form bash accepts for a top-level definition is matched : with or
+# without the "function" keyword, indented, and with spaces around the parens
 function test_case_names_of_file() {
-  grep -oE '^(function )?test_[A-Za-z0-9_]+\(\)' "$1" | sed -E 's/^function //; s/\(\)$//'
+  grep -oE '^[[:space:]]*(function[[:space:]]+)?test_[A-Za-z0-9_]+[[:space:]]*\(\)' "$1" |
+    sed -E 's/^[[:space:]]*//; s/^function[[:space:]]+//; s/[[:space:]]*\(\)$//'
 }
 
 # "test_the_fan_speed_is_applied" -> "the fan speed is applied"
@@ -127,21 +130,72 @@ if [ "${#TEST_FILES[@]}" -eq 0 ]; then
   exit 1
 fi
 
+# A case file is sourced into this shell, so an "exit" reached while it is read
+# - a stray one, or a guard clause written at the top level by mistake - ends
+# the runner right here, with that file's own exit code and nothing printed. It
+# would look exactly like a successful run that happened to be quiet. The trap
+# is what turns that silence into a failure
+# The runner and the libraries have helpers of their own whose name starts with
+# "test_" ; only the functions the case files add count as test cases
+TEST_CASE_FUNCTIONS_BEFORE_SOURCING="$(declare -F | sed -n 's/^declare -f \(test_[A-Za-z0-9_]*\)$/\1/p')"
+readonly TEST_CASE_FUNCTIONS_BEFORE_SOURCING
+
+SOURCING_TEST_FILE=""
+function report_interrupted_sourcing() {
+  [ -n "$SOURCING_TEST_FILE" ] || return 0
+  printf '%s stopped the run while it was being sourced, so no test case ran.\n' \
+    "${SOURCING_TEST_FILE#"$REPO_ROOT"/}" >&2
+  printf 'A case file must only declare functions and constants at its top level.\n' >&2
+  exit 1
+}
+trap report_interrupted_sourcing EXIT
+
 for TEST_FILE in "${TEST_FILES[@]}"; do
+  SOURCING_TEST_FILE="$TEST_FILE"
   source "$TEST_FILE"
 done
 
+SOURCING_TEST_FILE=""
+trap - EXIT
+
 # Build the ordered list of test cases to run, as "file<tab>function" pairs
 declare -a SELECTED_TEST_CASES=()
+declare -a DISCOVERED_TEST_CASES=()
 for TEST_FILE in "${TEST_FILES[@]}"; do
   while IFS= read -r TEST_CASE_NAME; do
     [ -n "$TEST_CASE_NAME" ] || continue
+    DISCOVERED_TEST_CASES+=("$TEST_CASE_NAME")
     if [ -n "$FILTER" ] && [[ ! "$TEST_CASE_NAME" =~ $FILTER ]] && [[ ! "$TEST_FILE" =~ $FILTER ]]; then
       continue
     fi
     SELECTED_TEST_CASES+=("$TEST_FILE"$'\t'"$TEST_CASE_NAME")
   done < <(test_case_names_of_file "$TEST_FILE")
 done
+
+# Discovery reads the files as text, execution runs what bash actually defined.
+# When the two disagree, a test case exists and never runs - the failure mode
+# that costs the most, because the suite stays green while covering less than
+# it says. Comparing the two lists is what keeps them honest
+declare -a UNDISCOVERED_TEST_CASES=()
+while IFS= read -r DEFINED_TEST_CASE; do
+  [ -n "$DEFINED_TEST_CASE" ] || continue
+  FOUND=false
+  for TEST_CASE_NAME in "${DISCOVERED_TEST_CASES[@]}"; do
+    if [ "$TEST_CASE_NAME" == "$DEFINED_TEST_CASE" ]; then
+      FOUND=true
+      break
+    fi
+  done
+  $FOUND || UNDISCOVERED_TEST_CASES+=("$DEFINED_TEST_CASE")
+done < <(declare -F | sed -n 's/^declare -f \(test_[A-Za-z0-9_]*\)$/\1/p' |
+  grep -Fxv -f <(printf '%s\n' "$TEST_CASE_FUNCTIONS_BEFORE_SOURCING") || true)
+
+if [ "${#UNDISCOVERED_TEST_CASES[@]}" -ne 0 ]; then
+  printf 'These test cases are defined but were not found by the runner, so they would never run :\n' >&2
+  printf '  %s\n' "${UNDISCOVERED_TEST_CASES[@]}" >&2
+  printf 'Declare them at the top level of their file, as "function test_name() {".\n' >&2
+  exit 1
+fi
 
 readonly TOTAL_TEST_CASES="${#SELECTED_TEST_CASES[@]}"
 
@@ -225,7 +279,10 @@ for TEST_CASE in "${SELECTED_TEST_CASES[@]}"; do
   TEST_SUITE_NAME="$(humanize_test_file_name "$TEST_FILE")"
   TEST_FILE_PATH="${TEST_FILE#"$REPO_ROOT"/}"
 
-  if [ -f "$TEST_SKIPPED_FILE" ]; then
+  # skip_test() only records a reason, it does not return from the test case.
+  # Anything that failed before or after that call still counts : a skip is a
+  # statement that nothing was verified, so it cannot also hide a failure
+  if [ -f "$TEST_SKIPPED_FILE" ] && [ ! -s "$TEST_DIAGNOSTICS_FILE" ] && [ "$TEST_CASE_EXIT_CODE" -eq 0 ]; then
     ((SKIPPED_TEST_CASES++))
     SKIP_REASON="$(cat "$TEST_SKIPPED_FILE")"
     record_test_result "$TEST_SUITE_NAME" "$TEST_FILE_PATH" "$TEST_CASE_NAME" "$HUMAN_READABLE_NAME" \
@@ -236,6 +293,15 @@ for TEST_CASE in "${SELECTED_TEST_CASES[@]}"; do
       printf '  %sskip%s %s %s(%s)%s\n' "$COLOR_YELLOW" "$COLOR_RESET" "$HUMAN_READABLE_NAME" "$COLOR_DIM" "$SKIP_REASON" "$COLOR_RESET"
     fi
     continue
+  fi
+
+  # A test case that asserted nothing verified nothing. It usually means the
+  # case returned early on a condition that no longer holds, and it is the one
+  # failure a passing suite cannot show you, so it is reported as a failure
+  # rather than counted among the green ones
+  if [ ! -f "$TEST_SKIPPED_FILE" ] && [ "$TEST_CASE_ASSERTIONS" -eq 0 ] &&
+    [ ! -s "$TEST_DIAGNOSTICS_FILE" ] && [ "$TEST_CASE_EXIT_CODE" -eq 0 ]; then
+    printf 'the test case recorded no assertion, so it verified nothing\n' > "$TEST_DIAGNOSTICS_FILE"
   fi
 
   if [ -s "$TEST_DIAGNOSTICS_FILE" ] || [ "$TEST_CASE_EXIT_CODE" -ne 0 ]; then


### PR DESCRIPTION
Closes #79. Closes #189.

The suite merged in #158 covers the controller well. What it could not do yet is two things a gate has to do: be unable to pass quietly, and actually stand between `master` and the image users pull.

## Nothing is published unless the tests passed on the tagged commit

The Tests workflow triggers on `push` and `pull_request`. Neither fires on a version tag — and the tag is what publishes to Docker Hub and ghcr.io. The one build that reaches users was the only one no test had ever run on.

The release workflow now has a `test` job, and `build` waits on it. That is the part of #79 that was still missing: the suite existed, it just was not in the path.

## Four ways the suite could end green having verified nothing

All four reproduced on `ea6da8c`, all four now covered by a test case of their own:

| | Before | Now |
| --- | --- | --- |
| A case that asserts nothing | `ok … (0 assertions)`, exit `0` | failure: *the test case recorded no assertion* |
| A case file reaching `exit` while sourced | no output at all, exit `0`, **zero cases run** | failure naming the file |
| `function test_x ()` or an indented definition | never runs, never mentioned | runs; anything discovery still misses is a hard error |
| `skip_test` followed by a failure | reported as skipped, exit `0` | failure reported, skip does not absorb it |

The second is the one that mattered most: a single stray `exit` at the top level of a case file disabled the whole suite while CI stayed green.

Discovery is still a text scan of the case files — that is what keeps test cases in declaration order — but it is now cross-checked against the `test_*` functions the sourcing actually defined. The pattern can be wrong; the cross-check makes it loud instead of silent.

## Test count

112 → **118 test cases (1095 assertions)**, stable across repeated runs. The six new cases run the real runner against throwaway case files in a repository of symlinks, so they exercise the shipped `run_tests.sh`, not a copy of its logic.

One detail worth knowing if you edit `tests/cases/15_test_runner.sh`: since discovery reads case files as text, a file that merely *quotes* a definition would have it discovered too. That file quotes six of them, so its probes build their names through a `PROBE_PREFIX` variable — nothing in it reads as a definition to the outer run.

## Not in this PR

- **#190** — the suite creates `/dev/ipmi/0` on the host, so two runs on one machine interfere. Fixing it properly means giving `functions.sh` a seam for the device path, which is a call for you to make.
- **#186** — the Tests workflow running twice per push. Independent of this change.

Docker was not available in the environment this was written in, so the `test-in-docker-image` job is the one path validated by CI rather than locally.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aho18t4eLgXhpiXWLi91iU)_