### PR TITLE
Grant the release workflow only the permissions it uses

### DIFF
--- a/.github/workflows/build_and_publish_docker_image.yml
+++ b/.github/workflows/build_and_publish_docker_image.yml
@@ -9,6 +9,15 @@ on:
   # already exists, instead of having to delete and re-push it
   workflow_dispatch:
 
+# Without this block the whole workflow runs on the repository-wide default
+# token. This one grants only what its two publishing steps need : "contents"
+# for the GitHub release "Generate release note" creates, "packages" for the
+# image pushed to ghcr.io. Everything else the default token may carry
+# (issues, pull requests, deployments...) is dropped
+permissions:
+  contents: write
+  packages: write
+
 jobs:
   build:
     name: Build and publish Docker image to Docker Hub and GitHub Containers Repository


### PR DESCRIPTION
Closes #196.

## What this changes

Adds a `permissions:` block to `build_and_publish_docker_image.yml`, the only workflow here that did not have one:

```yaml
permissions:
  contents: write
  packages: write
```

That is the whole diff — 9 lines, comment included. No step is touched.

## Why these two

| Permission | Used by |
|---|---|
| `contents: write` | `softprops/action-gh-release`, which creates the GitHub release (and `actions/checkout`, which only needs read) |
| `packages: write` | the `ghcr.io` push in `docker/build-push-action` |

Docker Hub authenticates with `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN`, not with `GITHUB_TOKEN`, so it needs nothing here. Everything else the repository-wide default token may carry — issues, pull requests, deployments — is dropped.

`contents: write` is what `softprops/action-gh-release` documents as its requirement, auto-generated release notes included.

## How to verify

Nothing in this repository exercises the release path outside of an actual release, so this cannot be proven green by CI. The check is at the next `v*` tag: the "Generate release note" step must still create the release, and the push must still reach both registries. Re-firing the workflow from the Actions tab against an existing tag works as a dry run — that path is already supported and guarded by `if: startsWith(github.ref, 'refs/tags/v')`.

If the release step were to fail on permissions, the fix is additive rather than a revert.

## Scope

Pre-existing on `master`, found while reviewing #194 but independent of it. The two pull requests touch different regions of this file and merge in either order.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WZ7YrSNZjuaoiq6YZYVbKu)_