### PR TITLE
Stop the suite from reporting success when nothing was verified

### DIFF
--- a/tests/cases/15_test_runner.sh
+++ b/tests/cases/15_test_runner.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+
+# Checks on the runner itself. Every other case file trusts it to turn a broken
+# controller into a red run ; these pin the four ways it used to stay green
+# while nothing had been verified. A suite that guards master has to be able to
+# fail, and that is what is tested here.
+
+# The runner reads its case files as text to list them in declaration order, so
+# a case file that merely quotes a definition would have it discovered too. That
+# is exactly what this file does, so the probes below name their test cases
+# through this prefix : nothing here reads as a definition to the outer run
+readonly PROBE_PREFIX="test"
+
+# Run the real runner against a throwaway case file, inside a repository of
+# symbolic links to the real scripts. The probe therefore exercises the real
+# controller, and never joins the suite that is currently running
+function run_the_runner_on_a_probe_case_file() {
+  local -r PROBE_CONTENT="$1"
+
+  local -r PROBE_REPOSITORY="$TEST_TEMPORARY_DIRECTORY/runner_probe"
+  rm -rf "$PROBE_REPOSITORY"
+  mkdir -p "$PROBE_REPOSITORY/tests/cases"
+
+  # The runner derives the repository root from its own path
+  local REPOSITORY_FILE
+  for REPOSITORY_FILE in "$REPO_ROOT"/*.sh "$REPO_ROOT/Dockerfile"; do
+    [ -e "$REPOSITORY_FILE" ] && ln -s "$REPOSITORY_FILE" "$PROBE_REPOSITORY/"
+  done
+  cp "$TESTS_DIRECTORY/run_tests.sh" "$PROBE_REPOSITORY/tests/"
+  cp -r "$TESTS_DIRECTORY/lib" "$TESTS_DIRECTORY/mocks" "$PROBE_REPOSITORY/tests/"
+  printf '%s\n' "$PROBE_CONTENT" > "$PROBE_REPOSITORY/tests/cases/50_probe.sh"
+
+  PROBE_OUTPUT=$(bash "$PROBE_REPOSITORY/tests/run_tests.sh" --no-color 2>&1)
+  PROBE_EXIT_CODE=$?
+}
+
+function test_a_test_case_that_asserts_nothing_is_reported_as_a_failure() {
+  # A case returning early on a condition that no longer holds asserts nothing
+  # and used to be counted among the passing ones
+  run_the_runner_on_a_probe_case_file "function ${PROBE_PREFIX}_verifies_nothing() { : ; }"
+
+  assert_equals 1 "$PROBE_EXIT_CODE" "a case that asserted nothing should fail the run"
+  assert_contains "$PROBE_OUTPUT" "recorded no assertion" \
+    "the report should say the case verified nothing"
+}
+
+function test_a_case_file_that_exits_while_being_sourced_fails_the_run() {
+  # Case files are sourced into the runner's own shell, so an exit reached at
+  # their top level ended the run with nothing printed and a zero exit code
+  run_the_runner_on_a_probe_case_file "exit 0
+function ${PROBE_PREFIX}_never_reached() { fail 'this case should never run'; }"
+
+  assert_equals 1 "$PROBE_EXIT_CODE" "a case file exiting while sourced should fail the run"
+  assert_contains "$PROBE_OUTPUT" "while it was being sourced" \
+    "the report should name what happened"
+}
+
+function test_skipping_a_test_case_does_not_hide_a_failure_it_also_recorded() {
+  # skip_test() only records a reason, it does not return from the case, so a
+  # failing assertion written after it used to disappear behind the skip
+  run_the_runner_on_a_probe_case_file "function ${PROBE_PREFIX}_skips_then_fails() {
+  skip_test 'not applicable here'
+  fail 'this failure must stay visible'
+}"
+
+  assert_equals 1 "$PROBE_EXIT_CODE" "a skipped case that also failed should fail the run"
+  assert_contains "$PROBE_OUTPUT" "this failure must stay visible" \
+    "the failure should be reported, not swallowed by the skip"
+}
+
+function test_a_test_case_skipped_without_failing_is_still_a_skip() {
+  # The counterpart of the case above : a genuine skip must stay a skip, or
+  # every environment-dependent case would turn red
+  run_the_runner_on_a_probe_case_file "function ${PROBE_PREFIX}_only_skips() {
+  skip_test 'nothing to check here'
+  return 0
+}"
+
+  assert_equals 0 "$PROBE_EXIT_CODE" "a case that only skipped should not fail the run"
+  assert_contains "$PROBE_OUTPUT" "nothing to check here" "the skip reason should be reported"
+}
+
+function test_every_form_bash_accepts_for_a_test_case_is_discovered() {
+  # Discovery reads the files as text. These three declarations are all valid
+  # bash, and the two indented or spaced ones used to be silently ignored
+  run_the_runner_on_a_probe_case_file "function ${PROBE_PREFIX}_with_a_space_before_the_parens () { pass; }
+  function ${PROBE_PREFIX}_indented() { pass; }
+${PROBE_PREFIX}_without_the_function_keyword() { pass; }"
+
+  assert_equals 0 "$PROBE_EXIT_CODE" "the probe cases should all pass"
+  assert_contains "$PROBE_OUTPUT" "with a space before the parens" "the spaced form should run"
+  assert_contains "$PROBE_OUTPUT" "indented" "the indented form should run"
+  assert_contains "$PROBE_OUTPUT" "without the function keyword" "the bare form should run"
+}
+
+function test_a_test_case_the_runner_cannot_discover_fails_the_run() {
+  # The safety net behind the discovery pattern : whatever form escapes it, a
+  # test case that exists and would never run has to be loud
+  run_the_runner_on_a_probe_case_file "eval 'function ${PROBE_PREFIX}_defined_through_eval() { pass; }'"
+
+  assert_equals 1 "$PROBE_EXIT_CODE" "an undiscoverable test case should fail the run"
+  assert_contains "$PROBE_OUTPUT" "${PROBE_PREFIX}_defined_through_eval" \
+    "the report should name the test case that would never run"
+}

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -98,9 +98,12 @@ if [ -z "$GENERATION_14_OR_NEWER_REGEX" ]; then
 fi
 
 # Collect the test case names of a file, in declaration order (declare -F would
-# sort them alphabetically, which would scramble the story each file tells)
+# sort them alphabetically, which would scramble the story each file tells).
+# Every form bash accepts for a top-level definition is matched : with or
+# without the "function" keyword, indented, and with spaces around the parens
 function test_case_names_of_file() {
-  grep -oE '^(function )?test_[A-Za-z0-9_]+\(\)' "$1" | sed -E 's/^function //; s/\(\)$//'
+  grep -oE '^[[:space:]]*(function[[:space:]]+)?test_[A-Za-z0-9_]+[[:space:]]*\(\)' "$1" |
+    sed -E 's/^[[:space:]]*//; s/^function[[:space:]]+//; s/[[:space:]]*\(\)$//'
 }
 
 # "test_the_fan_speed_is_applied" -> "the fan speed is applied"
@@ -127,21 +130,72 @@ if [ "${#TEST_FILES[@]}" -eq 0 ]; then
   exit 1
 fi
 
+# The runner and the libraries have helpers of their own whose name starts with
+# "test_" ; only the functions the case files add count as test cases
+TEST_CASE_FUNCTIONS_BEFORE_SOURCING="$(declare -F | sed -n 's/^declare -f \(test_[A-Za-z0-9_]*\)$/\1/p')"
+readonly TEST_CASE_FUNCTIONS_BEFORE_SOURCING
+
+# A case file is sourced into this shell, so an "exit" reached while it is read
+# - a stray one, or a guard clause written at the top level by mistake - ends
+# the runner right here, with that file's own exit code and nothing printed. It
+# would look exactly like a successful run that happened to be quiet. The trap
+# is what turns that silence into a failure
+SOURCING_TEST_FILE=""
+function report_interrupted_sourcing() {
+  [ -n "$SOURCING_TEST_FILE" ] || return 0
+  printf '%s stopped the run while it was being sourced, so no test case ran.\n' \
+    "${SOURCING_TEST_FILE#"$REPO_ROOT"/}" >&2
+  printf 'A case file must only declare functions and constants at its top level.\n' >&2
+  exit 1
+}
+trap report_interrupted_sourcing EXIT
+
 for TEST_FILE in "${TEST_FILES[@]}"; do
+  SOURCING_TEST_FILE="$TEST_FILE"
   source "$TEST_FILE"
 done
 
+SOURCING_TEST_FILE=""
+trap - EXIT
+
 # Build the ordered list of test cases to run, as "file<tab>function" pairs
 declare -a SELECTED_TEST_CASES=()
+declare -a DISCOVERED_TEST_CASES=()
 for TEST_FILE in "${TEST_FILES[@]}"; do
   while IFS= read -r TEST_CASE_NAME; do
     [ -n "$TEST_CASE_NAME" ] || continue
+    DISCOVERED_TEST_CASES+=("$TEST_CASE_NAME")
     if [ -n "$FILTER" ] && [[ ! "$TEST_CASE_NAME" =~ $FILTER ]] && [[ ! "$TEST_FILE" =~ $FILTER ]]; then
       continue
     fi
     SELECTED_TEST_CASES+=("$TEST_FILE"$'\t'"$TEST_CASE_NAME")
   done < <(test_case_names_of_file "$TEST_FILE")
 done
+
+# Discovery reads the files as text, execution runs what bash actually defined.
+# When the two disagree, a test case exists and never runs - the failure mode
+# that costs the most, because the suite stays green while covering less than
+# it says. Comparing the two lists is what keeps them honest
+declare -a UNDISCOVERED_TEST_CASES=()
+while IFS= read -r DEFINED_TEST_CASE; do
+  [ -n "$DEFINED_TEST_CASE" ] || continue
+  FOUND=false
+  for TEST_CASE_NAME in "${DISCOVERED_TEST_CASES[@]}"; do
+    if [ "$TEST_CASE_NAME" == "$DEFINED_TEST_CASE" ]; then
+      FOUND=true
+      break
+    fi
+  done
+  $FOUND || UNDISCOVERED_TEST_CASES+=("$DEFINED_TEST_CASE")
+done < <(declare -F | sed -n 's/^declare -f \(test_[A-Za-z0-9_]*\)$/\1/p' |
+  grep -Fxv -f <(printf '%s\n' "$TEST_CASE_FUNCTIONS_BEFORE_SOURCING") || true)
+
+if [ "${#UNDISCOVERED_TEST_CASES[@]}" -ne 0 ]; then
+  printf 'These test cases are defined but were not found by the runner, so they would never run :\n' >&2
+  printf '  %s\n' "${UNDISCOVERED_TEST_CASES[@]}" >&2
+  printf 'Declare them at the top level of their file, as "function test_name() {".\n' >&2
+  exit 1
+fi
 
 readonly TOTAL_TEST_CASES="${#SELECTED_TEST_CASES[@]}"
 
@@ -225,7 +279,10 @@ for TEST_CASE in "${SELECTED_TEST_CASES[@]}"; do
   TEST_SUITE_NAME="$(humanize_test_file_name "$TEST_FILE")"
   TEST_FILE_PATH="${TEST_FILE#"$REPO_ROOT"/}"
 
-  if [ -f "$TEST_SKIPPED_FILE" ]; then
+  # skip_test() only records a reason, it does not return from the test case.
+  # Anything that failed before or after that call still counts : a skip is a
+  # statement that nothing was verified, so it cannot also hide a failure
+  if [ -f "$TEST_SKIPPED_FILE" ] && [ ! -s "$TEST_DIAGNOSTICS_FILE" ] && [ "$TEST_CASE_EXIT_CODE" -eq 0 ]; then
     ((SKIPPED_TEST_CASES++))
     SKIP_REASON="$(cat "$TEST_SKIPPED_FILE")"
     record_test_result "$TEST_SUITE_NAME" "$TEST_FILE_PATH" "$TEST_CASE_NAME" "$HUMAN_READABLE_NAME" \
@@ -236,6 +293,15 @@ for TEST_CASE in "${SELECTED_TEST_CASES[@]}"; do
       printf '  %sskip%s %s %s(%s)%s\n' "$COLOR_YELLOW" "$COLOR_RESET" "$HUMAN_READABLE_NAME" "$COLOR_DIM" "$SKIP_REASON" "$COLOR_RESET"
     fi
     continue
+  fi
+
+  # A test case that asserted nothing verified nothing. It usually means the
+  # case returned early on a condition that no longer holds, and it is the one
+  # failure a passing suite cannot show you, so it is reported as a failure
+  # rather than counted among the green ones
+  if [ ! -f "$TEST_SKIPPED_FILE" ] && [ "$TEST_CASE_ASSERTIONS" -eq 0 ] &&
+    [ ! -s "$TEST_DIAGNOSTICS_FILE" ] && [ "$TEST_CASE_EXIT_CODE" -eq 0 ]; then
+    printf 'the test case recorded no assertion, so it verified nothing\n' > "$TEST_DIAGNOSTICS_FILE"
   fi
 
   if [ -s "$TEST_DIAGNOSTICS_FILE" ] || [ "$TEST_CASE_EXIT_CODE" -ne 0 ]; then


### PR DESCRIPTION
Closes #189. **Split out of #191** — merge this one first, then #199.

The suite is what keeps a broken controller off `master`, so the one thing it must never do is pass quietly. It had four independent ways to do exactly that, and none of them was covered by a test.

All four reproduced on the real suite before fixing:

| | Before | Now |
| --- | --- | --- |
| A case that asserts nothing | `ok … (0 assertions)`, exit `0` | failure: *the test case recorded no assertion* |
| A case file reaching `exit` while sourced | **no output at all**, exit `0`, zero cases run | failure naming the file |
| `function test_x ()`, or an indented definition | never runs, never mentioned | runs; anything discovery still misses is a hard error |
| `skip_test` followed by a failure | reported as skipped, exit `0` | failure reported, the skip does not absorb it |

## The second one is the one that mattered

Case files are `source`d into the runner's own shell, so an `exit` reached at their top level ended the runner then and there:

```console
$ printf 'exit 0\nfunction test_never_reached() { assert_equals a b x; }\n' > tests/cases/05_probe.sh
$ ./tests/run_tests.sh; echo "exit=$?"
exit=0
```

Nothing printed, exit code `0`, **zero test cases run**. On CI that is indistinguishable from a successful run: one stray `exit` — or a guard clause written at the top level by mistake — disabled the whole suite while the check stayed green. An `EXIT` trap around the sourcing loop now turns that silence into a named failure.

## Discovery

The pattern was anchored at the start of the line with `()` glued to the name, so `function test_x ()` and any indented definition were silently never executed. It now covers the forms bash accepts — but the real guarantee is the cross-check that follows it: the names found by reading the files as text are compared against the `test_*` functions the sourcing actually defined, and anything defined but not discovered stops the run. The pattern can still be wrong; it can no longer be wrong *quietly*.

## Six test cases on the runner itself

This is the part that did not exist: **the runner's ability to fail had no coverage at all.** The new cases run the real `run_tests.sh` against throwaway case files inside a repository of symlinks, so they exercise the shipped runner rather than a copy of its logic. They cover the four holes above plus the two properties that must not regress the other way — a genuine skip is still a skip, and all three declaration forms run.

One thing to know before editing `tests/cases/15_test_runner.sh`: discovery reads case files **as text**, and this file has to contain multi-line strings holding fake test definitions. Their continuation lines start at column zero, so the outer runner would read them as real definitions of this file and try to call functions that are only quoted text. That is why the probes build their names through a `PROBE_PREFIX` variable — `function ${PROBE_PREFIX}_indented()` does not match the pattern, while the file written to disk still contains `function test_indented()`.

## Verification

122 → **128 test cases (1159 assertions)**, stable across repeated runs. No production file is touched — `functions.sh`, `Dell_iDRAC_fan_controller.sh`, `constants.sh`, `healthcheck.sh` and the `Dockerfile` are all untouched, so container behaviour is unchanged.