### PR TITLE
Run the test suite before publishing a release image

### DIFF
--- a/.github/workflows/build_and_publish_docker_image.yml
+++ b/.github/workflows/build_and_publish_docker_image.yml
@@ -10,9 +10,29 @@ on:
   workflow_dispatch:
 
 jobs:
+  # The Tests workflow runs on push and pull_request, neither of which fires on
+  # a version tag : without this job a release would be built and published
+  # without a single test having run on the commit being released
+  test:
+    name: Run the test suite before publishing
+    runs-on: ubuntu-latest
+    # Reading the repository is all this job does ; publishing keeps the
+    # workflow's default token
+    permissions:
+      contents: read
+    if: startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Run the test suite
+        run: ./tests/run_tests.sh --summary "$GITHUB_STEP_SUMMARY"
+
   build:
     name: Build and publish Docker image to Docker Hub and GitHub Containers Repository
     runs-on: ubuntu-latest
+    # Nothing is published unless the suite passed on the tagged commit
+    needs: [test]
     # The workflow_dispatch ref dropdown offers branches too. Publishing an image
     # built from a branch would move "latest" onto unreleased code, so only run
     # when the ref is a version tag


### PR DESCRIPTION
Closes #79. **Split out of #191** — best merged after #198, though the two are independent.

The Tests workflow triggers on `push` and `pull_request`. Neither fires on a version tag — and a version tag is exactly what publishes an image to Docker Hub and to ghcr.io.

So the one build that reaches users was the only one no test had ever run on. `master` could be green, the tag built from it published, and a regression introduced between the last push and the tag would ship unnoticed.

## What changes

A `test` job is added to the release workflow, and `build` gets `needs: [test]`. Nothing is published unless the suite passed **on the tagged commit itself**.

The test job only reads the repository, so it takes `contents: read`. The publishing job is left exactly as it is — it still needs the workflow's default token for the release note and for ghcr.io, and nothing about it changes.

20 lines, one file, no production code.

## This is the part of #79 that was still missing

The suite itself landed in #158. What #79 actually asks for is tests *before generating a new Docker image* — the suite existed, it just was not standing between `master` and the image.

## One design note

This job runs the suite on the runner, not inside the built image. The `test-in-docker-image` job in the Tests workflow already covers that path on every push to `master`, and a tag necessarily points at a commit that went through it, so the marginal risk is a tag placed on a commit that never reached `master`.

Closing that would mean building a single-arch image in the release workflow purely to test in it, then building the multi-arch one to publish — roughly 40s for a case that does not arise in the current release process. Happy to add it if you would rather the gate be self-contained.

## Verification

The suite passes on this branch (122 test cases, 1144 assertions — unchanged, since only the workflow is touched), and the workflow parses with `build` correctly gated behind `test`. Merged together with #198 locally: 128 test cases, no conflict, the two branches touch disjoint files.

`actions/checkout` is pinned to `@v7` to match what the rest of the workflow now uses after the Dependabot bumps.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aho18t4eLgXhpiXWLi91iU)_