### PR TITLE
Run the test suite on documentation-only changes too

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,11 +7,7 @@ on:
     # twice, and leaves a skipped "event file" check behind. Keeping master is
     # what gives the published results a baseline to compare against
     branches: [master]
-    paths-ignore:
-      - "**/README.md"
   pull_request:
-    paths-ignore:
-      - "**/README.md"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Closes #200.

`.github/workflows/tests.yml` carried `paths-ignore: "**/README.md"` on both triggers, so a pull request touching only documentation started **no run at all**.

## Why it matters now

It is harmless today. It stops being harmless the moment `Run the test suite` and `Run the test suite inside the Docker image` become **required status checks** on `master` — the protection that would have prevented #185, where a pull request was merged against a `master` that had moved under it and turned the default branch red.

GitHub does not treat a check that never ran as passed. It waits for it. A README-only pull request would sit on *Expected — Waiting for status to be reported*, permanently unmergeable, the only way out being to know to fire the workflow by hand from **Actions → Tests → Run workflow**. Not something a drive-by documentation contributor will find.

Smaller second effect: a documentation-only commit on `master` produced no run either, so it got no published check run, and the next pull request's `± Comparison against base commit` had no baseline at that commit.

## The change

```diff
 on:
   push:
     branches: [master]
-    paths-ignore:
-      - "**/README.md"
   pull_request:
-    paths-ignore:
-      - "**/README.md"
   workflow_dispatch:
```

Four lines removed, nothing else touched.

## What it costs

Next to nothing. The suite runs in **13 seconds**, the image builds in about 20, on free runners for a public repository.

## Follow-up worth considering, not done here

Running the suite on a README change is currently ceremony — nothing under `tests/` reads the documentation. It could be made to mean something: the README states the default of every parameter, and `tests/cases/10_shell_scripts.sh` already carries a guard comparing the Dockerfile's `ENV` defaults against the environment the suite starts from. Extending it to the README would catch documentation drifting away from the image — the same class of bug as the harness staying on `CHECK_INTERVAL=60` after #184 lowered it to 5. Happy to open that separately if you want it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q2kZqrbw7hzFtytvWAT5yJ)_