### PR TITLE
Test the half of the fallback comment that says a sensor stopped answering

### DIFF
--- a/tests/cases/80_temperature_thresholds.sh
+++ b/tests/cases/80_temperature_thresholds.sh
@@ -161,3 +161,96 @@ function test_an_unreadable_temperature_is_printed_as_a_placeholder() {
   assert_equals "-10" "$(format_temperature_for_display "-10")"
   assert_equals "-40" "$(format_temperature_for_display "-40")"
 }
+
+# The comment the controller prints when it hands the fans back to Dell. It is
+# the only thing telling the user WHY : a server that is genuinely hot, or a
+# sensor that stopped answering. Getting that wrong sends someone looking for a
+# cooling problem they do not have, or ignoring one they do.
+#
+# The "too high" half of it is already exercised end to end in 90_integration.sh;
+# what follows covers the "could not be read" half, which is what #163 added, and
+# the mixed case where both reasons hold at once.
+#
+# The function is only ever called with CPUs the controller has already decided
+# are overheating, so a valid reading here means "genuinely too hot" and an
+# invalid one means "unreadable, failed safe".
+
+readonly FAN_CONTROL_FALLBACK_ACTION="Dell default dynamic fan control profile applied for safety"
+
+function test_the_fallback_comment_names_the_cpu_that_is_too_hot() {
+  assert_equals "CPU 1 temperature is too high, $FAN_CONTROL_FALLBACK_ACTION" \
+    "$(build_fan_control_fallback_comment "CPU 1" "70")"
+
+  assert_equals "CPU 2 temperature is too high, $FAN_CONTROL_FALLBACK_ACTION" \
+    "$(build_fan_control_fallback_comment "CPU 2" "70")"
+}
+
+function test_the_fallback_comment_puts_two_hot_cpus_in_the_plural() {
+  assert_equals "CPU 1 and CPU 2 temperatures are too high, $FAN_CONTROL_FALLBACK_ACTION" \
+    "$(build_fan_control_fallback_comment "CPU 1" "70" "CPU 2" "80")"
+}
+
+function test_the_fallback_comment_says_when_a_reading_could_not_be_read() {
+  # The reason #163 exists : the fans ramping up because a sensor dropped out is
+  # not the same event as the server being hot, and the log must not conflate them
+  local -r COMMENT="$(build_fan_control_fallback_comment "CPU 1" "")"
+
+  assert_equals "CPU 1 temperature could not be read, $FAN_CONTROL_FALLBACK_ACTION" "$COMMENT"
+  assert_not_contains "$COMMENT" "too high" \
+    "an unreadable sensor must not be reported as an overheating CPU"
+}
+
+function test_the_fallback_comment_puts_two_unreadable_cpus_in_the_plural() {
+  assert_equals "CPU 1 and CPU 2 temperatures could not be read, $FAN_CONTROL_FALLBACK_ACTION" \
+    "$(build_fan_control_fallback_comment "CPU 1" "" "CPU 2" "")"
+}
+
+function test_the_fallback_comment_tells_a_hot_cpu_from_an_unreadable_one() {
+  # Both reasons hold at once : one CPU is genuinely too hot, the other's sensor
+  # stopped answering. The comment must carry both, and attribute each to the
+  # right CPU rather than collapsing them
+  assert_equals "CPU 1 temperature is too high and CPU 2 temperature could not be read, $FAN_CONTROL_FALLBACK_ACTION" \
+    "$(build_fan_control_fallback_comment "CPU 1" "70" "CPU 2" "")"
+
+  # The reasons are grouped by kind, not by CPU order : whichever CPU is hot is
+  # named first, so swapping the roles swaps the order of the two halves
+  assert_equals "CPU 2 temperature is too high and CPU 1 temperature could not be read, $FAN_CONTROL_FALLBACK_ACTION" \
+    "$(build_fan_control_fallback_comment "CPU 1" "" "CPU 2" "80")"
+}
+
+function test_every_shape_of_unusable_reading_is_reported_as_unreadable() {
+  # Whatever the sensor answered, if it is not a number it is not a temperature
+  local UNUSABLE_READING
+  for UNUSABLE_READING in "" "-" "n/a" "Disabled" "45.5" "no reading"; do
+    assert_equals "CPU 1 temperature could not be read, $FAN_CONTROL_FALLBACK_ACTION" \
+      "$(build_fan_control_fallback_comment "CPU 1" "$UNUSABLE_READING")" \
+      "\"$UNUSABLE_READING\" is not a reading"
+  done
+}
+
+function test_the_fallback_comment_always_says_what_was_done_about_it() {
+  # Whichever branch produced the reason, the user must be told the fans were
+  # handed back to Dell's own profile
+  local -r COMMENTS=(
+    "$(build_fan_control_fallback_comment "CPU 1" "70")"
+    "$(build_fan_control_fallback_comment "CPU 1" "")"
+    "$(build_fan_control_fallback_comment "CPU 1" "70" "CPU 2" "80")"
+    "$(build_fan_control_fallback_comment "CPU 1" "" "CPU 2" "")"
+    "$(build_fan_control_fallback_comment "CPU 1" "70" "CPU 2" "")"
+  )
+
+  local COMMENT
+  for COMMENT in "${COMMENTS[@]}"; do
+    assert_contains "$COMMENT" "$FAN_CONTROL_FALLBACK_ACTION"
+  done
+}
+
+function test_reasons_are_joined_the_way_a_sentence_is() {
+  # join_with_and builds every list above. Its three-and-more branch is not
+  # reachable with two CPUs, but it is written, and it is what a controller
+  # monitoring every socket would use
+  assert_equals "CPU 1" "$(join_with_and "CPU 1")"
+  assert_equals "CPU 1 and CPU 2" "$(join_with_and "CPU 1" "CPU 2")"
+  assert_equals "CPU 1, CPU 2 and CPU 3" "$(join_with_and "CPU 1" "CPU 2" "CPU 3")"
+  assert_equals "CPU 1, CPU 2, CPU 3 and CPU 4" "$(join_with_and "CPU 1" "CPU 2" "CPU 3" "CPU 4")"
+}

--- a/tests/cases/90_integration.sh
+++ b/tests/cases/90_integration.sh
@@ -41,6 +41,27 @@ function test_the_controller_falls_back_on_the_dell_default_profile_when_a_cpu_s
   fi
 }
 
+function test_the_controller_explains_a_fallback_caused_by_a_sensor_that_dropped_out() {
+  # The real-world case behind the fallback comment : the server is fine, one
+  # sensor simply stopped answering mid-run. The fans ramp up either way, so the
+  # log line is the only thing telling the user which of the two happened
+  simulate_server "PowerEdge R730xd" --cpus 2 --cpu-temperatures "42 44"
+  export MOCK_IPMITOOL_SDR_SECOND_OUTPUT
+  MOCK_IPMITOOL_SDR_SECOND_OUTPUT=$(make_sdr_output --cpus 2 --cpu2-disabled --cpu-temperatures "42")
+  export MOCK_IPMITOOL_SDR_SWITCH_AFTER_CALLS=1
+
+  local -r OUTPUT=$(run_controller "could not be read")
+
+  assert_contains "$OUTPUT" "CPU 2 temperature could not be read, Dell default dynamic fan control profile applied for safety"
+  assert_not_contains "$OUTPUT" "CPU 2 temperature is too high" \
+    "a sensor that stopped answering is not an overheating CPU"
+  if [ "$(count_ipmitool_calls_matching "raw 0x30 0x30 0x01 0x01")" -ge 1 ]; then
+    pass
+  else
+    fail "the controller must still hand the fans back to Dell on an unreadable reading"
+  fi
+}
+
 function test_the_controller_reports_both_cpus_when_they_are_overheating_together() {
   simulate_server "PowerEdge R630" --cpus 2 --cpu-temperatures "42 44"
   export MOCK_IPMITOOL_SDR_SECOND_OUTPUT


### PR DESCRIPTION
Closes #205.

When the controller hands the fans back to Dell's profile, the comment it prints is the only thing telling the user **why**: a server that is genuinely hot, or a sensor that stopped answering. The "too high" half of `build_fan_control_fallback_comment()` was already exercised end to end. The "could not be read" half — the whole reason #163 added the function — had no coverage at all, and `join_with_and()`, which builds every one of these lists, had none either.

## What this adds

9 test cases, 26 assertions, **no controller code touched**.

In `tests/cases/80_temperature_thresholds.sh`, calling the function directly: one hot CPU, two in the plural, one unreadable, two unreadable, and the mixed case where both reasons hold at once and each must be attributed to the right CPU. Every shape of unusable reading (`""`, `-`, `n/a`, `Disabled`, `45.5`, `no reading`) is checked to land in the unreadable bucket, every branch is checked to still say what was done about it, and `join_with_and()` gets its own case up to its three-and-more branch — unreachable with two CPUs today, but that is what #144 would use.

In `tests/cases/90_integration.sh`, the scenario that motivated the feature: a healthy dual socket server whose second sensor drops out mid-run must log `CPU 2 temperature could not be read`, **not** that it is too high, and must still hand the fans back.

## Verified by mutation, not by going green

| Change made to the controller | Suite |
| --- | --- |
| unreadable branch says `is too high` instead of `could not be read` — the exact inversion the feature prevents | **4 test cases red** |
| `join_with_and` loses its `and` | **5 test cases red** |
| the two-or-more unreadable branch is reworded | **1 test case red** |

Before this pull request, the first two of those turned **nothing** red.

## Two things spotted, deliberately not pinned here

1. **The comment never appears on the first cycle.** `COMMENT` is only set on a *transition* between profiles, and `IS_DELL_DEFAULT_FAN_CONTROL_PROFILE_APPLIED` starts at `true`. A container started against a server whose CPU reading is already unreadable applies Dell's profile and prints `-` in the Comment column, never saying why — arguably the moment you would most want the explanation. Reproducible with the enclosure management controller fixture. Left alone because it is a controller behaviour change, not a test change; happy to open it separately.

2. **A valid reading is classified as "too high" unconditionally**, so a sub-zero one would read as hot. Unreachable — the function is only called for a CPU already judged overheating, and #163 made sub-zero readings valid and therefore cold. Not asserted on, on purpose: writing it down would turn nonsense into a specification, which is the exact trap the `-10` cases fell into before #185.

**131 test cases, 1170 assertions, green on current master.**

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q2kZqrbw7hzFtytvWAT5yJ)_