### PR TITLE
Check the README's documented defaults against the ones the image ships

### DIFF
--- a/tests/cases/10_shell_scripts.sh
+++ b/tests/cases/10_shell_scripts.sh
@@ -93,6 +93,58 @@ function test_the_test_context_starts_from_the_docker_images_defaults() {
   done < <(grep -E '^ENV [A-Z_]+=' "$REPO_ROOT/Dockerfile" | sed 's/^ENV //')
 }
 
+# The README states the default of every parameter, the Dockerfile declares the
+# real one, and nothing compared the two : the documentation could tell the reader
+# one thing while the container did another, with no test going red. That is the
+# same drift the test case above guards one level down, where the harness kept
+# CHECK_INTERVAL=60 after the image had dropped it to 5.
+#
+# The value is stated in several shapes -- "local", 5(%), 50(°C), false followed by
+# a clause -- so it is normalised rather than matched literally : the wording is
+# free to change, only a value that disagrees fails.
+# Usage : documented_default_value "5(%)" -> "5"
+function documented_default_value() {
+  local VALUE="$1"
+  # Keep what precedes the first comma : some defaults are followed by a clause
+  VALUE="${VALUE%%,*}"
+  # Drop a trailing unit in parentheses : "5(%)", "50(°C)", "5(s)"
+  VALUE="${VALUE%%(*}"
+  # Drop the quotes and backticks the prose wraps some values in
+  VALUE="${VALUE//[\"\`]/}"
+  # Trim
+  VALUE="${VALUE#"${VALUE%%[![:space:]]*}"}"
+  VALUE="${VALUE%"${VALUE##*[![:space:]]}"}"
+  printf '%s' "$VALUE"
+}
+
+function test_the_readme_documents_the_defaults_the_image_actually_ships() {
+  if [ ! -f "$REPO_ROOT/Dockerfile" ] || [ ! -f "$REPO_ROOT/README.md" ]; then
+    # The suite is running inside the built image, which carries neither
+    skip_test "no Dockerfile and README next to the scripts"
+    return 0
+  fi
+
+  local -r README_CONTENT=$(cat "$REPO_ROOT/README.md")
+
+  local ENV_DECLARATION KEY DOCKERFILE_VALUE DOCUMENTED_SENTENCE
+  while IFS= read -r ENV_DECLARATION; do
+    KEY="${ENV_DECLARATION%%=*}"
+    DOCKERFILE_VALUE="${ENV_DECLARATION#*=}"
+
+    DOCUMENTED_SENTENCE=$(printf '%s' "$README_CONTENT" |
+      grep -oE '`'"$KEY"'`[^*]*\*\*Default\*\* value is [^.]*' | head -1)
+
+    if [ -z "$DOCUMENTED_SENTENCE" ]; then
+      fail "$KEY is shipped by the Dockerfile but the README states no default for it"
+      continue
+    fi
+
+    assert_equals "$DOCKERFILE_VALUE" \
+      "$(documented_default_value "${DOCUMENTED_SENTENCE##*value is }")" \
+      "the README's default for $KEY should be the one the Dockerfile ships"
+  done < <(grep -E '^ENV [A-Z_]+=' "$REPO_ROOT/Dockerfile" | sed 's/^ENV //')
+}
+
 function test_the_healthcheck_succeeds_when_the_sensors_can_be_read() {
   local OUTPUT
   OUTPUT=$(bash "$REPO_ROOT/healthcheck.sh" 2>&1)


### PR DESCRIPTION
Closes #208.

The README states the default of every parameter, the Dockerfile declares the real one, and nothing compared the two. They could drift apart silently — the reader told one thing, the container doing another, no test going red.

The same class of drift already happened one level down: when #184 lowered `CHECK_INTERVAL` from 60s to 5s, the harness kept claiming in comment that it started from the Dockerfile's defaults while still setting 60. Nothing failed; the suite simply validated a configuration nobody ran. #185 added the guard for that. **This is the same gap one level up.**

It also gives the workflow change from #201 — running the suite on documentation-only pull requests — something to actually verify, instead of 149 test cases that read no documentation at all.

## Not a literal match

The value is stated in several shapes, so comparing it literally would fail on wording alone:

| Parameter | Dockerfile | README |
| --- | --- | --- |
| `IDRAC_HOST` | `local` | `"local"` |
| `FAN_SPEED` | `5` | `5(%)` |
| `CPU_TEMPERATURE_THRESHOLD` | `50` | `50(°C)` |
| `CHECK_INTERVAL` | `5` | `5(s)` |
| `KEEP_THIRD_PARTY_PCIE_CARD_COOLING_RESPONSE_STATE_ON_EXIT` | `false` | `false, so that it resets …` |

So it normalises: what precedes the first comma, minus a trailing unit in parentheses, minus the quotes and backticks the prose wraps some values in. The documentation stays free to be reworded; only a value that actually disagrees fails.

A parameter shipped by the Dockerfile with no documented default fails too, by name.

## Verified both ways

| | Result |
| --- | --- |
| README changed to say the threshold defaults to 65 while the image ships 50 | **red** — `expected: [50], actual: [65]` |
| the sentence reworded around an unchanged value | **green** |

A test that only did the first would be brittle; one that only did the second would be useless.

**149 test cases, 1260 assertions, green on current master.** Test-only, no controller code touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q2kZqrbw7hzFtytvWAT5yJ)_