### PR TITLE
Say why the fans were handed to Dell when the server starts out too hot

### DIFF
--- a/Dell_iDRAC_fan_controller.sh
+++ b/Dell_iDRAC_fan_controller.sh
@@ -134,6 +134,14 @@ echo ""
 TABLE_HEADER_PRINT_COUNTER=$TABLE_HEADER_PRINT_INTERVAL
 # Set the flag used to check if the active fan control profile has changed
 IS_DELL_DEFAULT_FAN_CONTROL_PROFILE_APPLIED=true
+# The comment column explains a profile CHANGE, and the first cycle changes nothing:
+# it establishes the profile. Without this, whichever branch the first cycle takes
+# stays silent -- and since the flag above starts at true, the silent one is the
+# fail-safe branch, so a server whose sensors could not be read has its fans handed
+# to Dell's profile with no explanation, which is exactly when the user needs one.
+# No starting value of that flag fixes it: setting it the other way just moves the
+# silence onto the healthy path
+IS_FIRST_MONITORING_CYCLE=true
 # Tracks whether the target server was powered off on the previous cycle, so temperatures can be
 # refreshed right when it powers back on instead of reusing data read before/during the outage
 IS_TARGET_SERVER_POWERED_OFF=false
@@ -312,7 +320,7 @@ while true; do
   if is_any_CPU_overheating; then
     apply_Dell_default_fan_control_profile
 
-    if ! $IS_DELL_DEFAULT_FAN_CONTROL_PROFILE_APPLIED; then
+    if ! $IS_DELL_DEFAULT_FAN_CONTROL_PROFILE_APPLIED || $IS_FIRST_MONITORING_CYCLE; then
       IS_DELL_DEFAULT_FAN_CONTROL_PROFILE_APPLIED=true
 
       # is_any_CPU_overheating() collected every CPU concerned, however many of them there are, each
@@ -327,7 +335,7 @@ while true; do
     apply_user_fan_control_profile
 
     # Check if user fan control profile is applied then apply it if not
-    if $IS_DELL_DEFAULT_FAN_CONTROL_PROFILE_APPLIED; then
+    if $IS_DELL_DEFAULT_FAN_CONTROL_PROFILE_APPLIED || $IS_FIRST_MONITORING_CYCLE; then
       IS_DELL_DEFAULT_FAN_CONTROL_PROFILE_APPLIED=false
       # Kept symmetric with the clause naming the CPUs that triggered the switch, plural included.
       # It says the temperatures are OK rather than that they decreased, because the Dell default profile
@@ -364,6 +372,7 @@ while true; do
     TABLE_HEADER_PRINT_COUNTER=0
   fi
   print_temperature_array_line "$CPU_COLUMN_CONTENT_WIDTH" "$INLET_TEMPERATURE" "$CPUS_TEMPERATURES" "$EXHAUST_TEMPERATURE" "$CURRENT_FAN_CONTROL_PROFILE" "$THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE_STATUS" "$COMMENT"
+  IS_FIRST_MONITORING_CYCLE=false
   ((TABLE_HEADER_PRINT_COUNTER++))
 
   wait $SLEEP_PROCESS_PID

--- a/tests/cases/90_integration.sh
+++ b/tests/cases/90_integration.sh
@@ -22,6 +22,52 @@ function test_the_controller_applies_the_user_fan_control_profile_on_a_healthy_s
     "Dell's dynamic profile is only applied once, when the container is stopped"
 }
 
+function test_the_very_first_line_says_when_the_server_started_out_hot() {
+  # A server already above its threshold when the container starts. The comment
+  # column explains a profile CHANGE, and the first cycle changes nothing -- it
+  # establishes the profile -- so this stayed silent : Dell's profile applied, and
+  # a bare "-" where the reason belongs.
+  #
+  # The neighbouring case, a server with no readable CPU sensor at all, is already
+  # covered by the startup waiting path and is deliberately not retested here : it
+  # passes with or without this change, so asserting on it would prove nothing
+  simulate_server "PowerEdge R730xd" --cpus 2 --cpu-temperatures "80 41"
+
+  local -r OUTPUT=$(run_controller)
+
+  assert_contains "$OUTPUT" "CPU 1 temperature is too high, Dell default dynamic fan control profile applied for safety"
+}
+
+function test_the_very_first_line_still_explains_a_healthy_start() {
+  # The branch that already spoke must keep speaking : the fix must not trade one
+  # silence for another
+  simulate_server "PowerEdge R730xd" --cpus 2 --cpu-temperatures "40 41"
+
+  local -r OUTPUT=$(run_controller)
+
+  assert_contains "$OUTPUT" "user's fan control profile applied."
+}
+
+function test_the_explanation_is_printed_once_not_on_every_cycle() {
+  # It explains a change, so a server that stays hot must not repeat it forever :
+  # that would be the log spam the comment column exists to avoid.
+  #
+  # The second cycle reports a different reading, still above the threshold, so
+  # the harness has a positive signal to wait for. Waiting for the message NOT to
+  # reappear would mean waiting for the poll budget to run out -- eight seconds
+  # per run, and a test whose meaning depends on a timeout rather than on output
+  simulate_server "PowerEdge R730xd" --cpus 2 --cpu-temperatures "80 41"
+  export MOCK_IPMITOOL_SDR_SECOND_OUTPUT
+  MOCK_IPMITOOL_SDR_SECOND_OUTPUT=$(make_sdr_output --cpus 2 --cpu-temperatures "81 41")
+  export MOCK_IPMITOOL_SDR_SWITCH_AFTER_CALLS=1
+
+  local -r OUTPUT=$(run_controller "81°C")
+
+  assert_contains "$OUTPUT" "81°C" "the second cycle must have been reached"
+  assert_equals "1" "$(printf '%s' "$OUTPUT" | grep -c "CPU 1 temperature is too high")" \
+    "the reason is stated on the cycle that established the profile, then not again"
+}
+
 function test_the_controller_falls_back_on_the_dell_default_profile_when_a_cpu_starts_overheating() {
   # Cold CPUs on the first cycle, CPU 2 above the threshold from the second one :
   # the profile change is what the user must see in the logs


### PR DESCRIPTION
Closes #210.

⚠️ **This one changes what the controller prints**, unlike the test-only work before it. The behaviour is a judgment call — say the word and I'll close it.

> **This description was rewritten on `fea04bf`.** The original was written against `ea6da8c` and claimed a scope this pull request no longer has: the multi-CPU rework and the startup waiting path have landed since. Everything below is measured against `159081b`.

## What is silent today

`COMMENT` explains a profile **change**. The first cycle changes nothing — it *establishes* the profile — and `IS_DELL_DEFAULT_FAN_CONTROL_PROFILE_APPLIED` starts at `true`, so a container started against a server already above its threshold applies Dell's dynamic profile and prints a bare `-` where the reason belongs.

The asymmetry is the tell: the healthy path explains itself on line one, this one does not.

| At startup | `master` | with this change |
| --- | --- | --- |
| healthy server | explains itself | **unchanged** |
| **readable CPU already above the threshold** | **`-`** | `CPU 1 temperature is too high, Dell default dynamic fan control profile applied for safety` |
| no readable CPU sensor at all | already explained by the startup waiting path (`Dell_iDRAC_fan_controller.sh:204-206`) | **unchanged** |

That third row is why this is narrower than #210 says. I wrote a test case for it, measured it passing **with and without** this change, and deleted it: it was exercising the startup path, not this fix. Keeping it would have been the same mistake #185 had to undo.

## Why not just flip the flag's starting value

The comment is emitted on a *change*, and the first cycle has no previous state to change from. Starting the flag at `false` makes the fail-safe path talk and silences the healthy one — the same bug, mirrored. The first cycle has to be recognised as such.

## The change

`Dell_iDRAC_fan_controller.sh`, **+11 / −2**:

- `IS_FIRST_MONITORING_CYCLE=true` next to the existing flag, with the reasoning above as a comment
- `|| $IS_FIRST_MONITORING_CYCLE` on the **two** guards the loop has today — the `is_any_CPU_overheating` branch and the `else` branch
- `IS_FIRST_MONITORING_CYCLE=false` right after the line is printed

Nothing in `functions.sh`. Clearing the marker matters as much as setting it: a server that stays hot must state the reason on the cycle that established the profile and not on every one after, or the comment column becomes the log spam it exists to avoid.

`tests/cases/90_integration.sh`, **+46**: three test cases — the hot start, the healthy start as a regression guard, and the printed-once property.

## Verified by mutation

| Change made to the controller | Suite |
| --- | --- |
| `|| $IS_FIRST_MONITORING_CYCLE` removed from both guards | **2 test cases red** |
| the marker never cleared, so the reason repeats every cycle | **1 test case red** |

Every test case added here is discriminating; none of them passes on `master` alone for the wrong reason.

**183 test cases passed, 1 skipped, 1328 assertions** — locally and in CI on `fea04bfc`, against base `159081bc`.