### PR TITLE
Refuse boolean parameters the shell would run as something other than a test

### DIFF
--- a/Dell_iDRAC_fan_controller.sh
+++ b/Dell_iDRAC_fan_controller.sh
@@ -14,6 +14,15 @@ trap 'graceful_exit' SIGINT SIGQUIT SIGTERM
 
 # readonly DELL_FRESH_AIR_COMPLIANCE=45
 
+# The boolean parameters are dispatched by running their value as a command ("if $MONITORING_ONLY_MODE"),
+# an idiom that is only safe once the value is known to be one of the two literals it expects : anything
+# else is read as false without a word, or run as whatever command it happens to name. Validate them
+# first, before the first IPMI command and before anything reads them. MONITORING_ONLY_MODE especially,
+# since it decides how the check interval just below is bounded and what graceful_exit does on the way out
+validate_boolean_parameter "MONITORING_ONLY_MODE" "$MONITORING_ONLY_MODE"
+validate_boolean_parameter "DISABLE_THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE" "$DISABLE_THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE"
+validate_boolean_parameter "KEEP_THIRD_PARTY_PCIE_CARD_COOLING_RESPONSE_STATE_ON_EXIT" "$KEEP_THIRD_PARTY_PCIE_CARD_COOLING_RESPONSE_STATE_ON_EXIT"
+
 # CHECK_INTERVAL paces the whole monitoring loop and is handed straight to sleep, whose exit status the
 # loop never looks at, so an unusable value doesn't stop anything : it makes every cycle return at once
 # and turns the loop into a busy loop hammering the iDRAC. It is also the controller's reaction time,
@@ -71,7 +80,7 @@ if [[ "$CHECK_INTERVAL" =~ ^[0-9]+$ ]]; then
 else
   echo "Check interval: $CHECK_INTERVAL"
 fi
-if $MONITORING_ONLY_MODE; then
+if "$MONITORING_ONLY_MODE"; then
   echo "Monitoring only mode: Enabled (no fan control profile will be applied, temperatures will only be logged)"
 else
   echo "Monitoring only mode: Disabled"
@@ -186,7 +195,7 @@ while true; do
       THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE_STATUS="Enabled"
     fi
 
-    if $MONITORING_ONLY_MODE; then
+    if "$MONITORING_ONLY_MODE"; then
       THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE_STATUS+=" (not applied: monitoring only mode)"
     fi
   fi

--- a/README.md
+++ b/README.md
@@ -203,6 +203,8 @@ All parameters are optional as they have default values (including default iDRAC
 - `KEEP_THIRD_PARTY_PCIE_CARD_COOLING_RESPONSE_STATE_ON_EXIT` parameter is a boolean that allows to keep the third-party PCIe card Dell default cooling response state upon exit. **Default** value is false, so that it resets the third-party PCIe card Dell default cooling response to Dell default.
 - `MONITORING_ONLY_MODE` parameter is a boolean that allows to run the container in a read-only, monitoring-only mode: temperatures are still read and logged at each `CHECK_INTERVAL`, but no fan control profile (neither the user-defined one nor Dell's default) and no third-party PCIe card cooling response change is ever sent to the server. Useful to observe temperatures and validate your `FAN_SPEED`/`CPU_TEMPERATURE_THRESHOLD` values before letting the container actually take control of the fans. **Default** value is false.
 
+The three boolean parameters above accept **only the lowercase literals `true` and `false`**, and the container refuses to start on anything else — `True`, `TRUE`, `1`, `on` and `yes` included. This is not pickiness: these parameters are dispatched by running their value, so those spellings used to be taken as `false` without a word. `MONITORING_ONLY_MODE=True` would take control of the fans on a server you had explicitly asked the container to leave alone, while logging "Monitoring only mode: Disabled".
+
 <p align="right">(<a href="#top">back to top</a>)</p>
 
 <!-- TROUBLESHOOTING -->

--- a/functions.sh
+++ b/functions.sh
@@ -2,7 +2,7 @@
 # This function applies Dell's default dynamic fan control profile
 # In monitoring only mode, the profile is only logged, not actually applied
 function apply_Dell_default_fan_control_profile() {
-  if $MONITORING_ONLY_MODE; then
+  if "$MONITORING_ONLY_MODE"; then
     CURRENT_FAN_CONTROL_PROFILE="Dell default dynamic fan control profile (monitoring only, not applied)"
     return
   fi
@@ -22,7 +22,7 @@ function apply_Dell_default_fan_control_profile() {
 # This function applies a user-specified static fan control profile
 # In monitoring only mode, the profile is only logged, not actually applied
 function apply_user_fan_control_profile() {
-  if $MONITORING_ONLY_MODE; then
+  if "$MONITORING_ONLY_MODE"; then
     CURRENT_FAN_CONTROL_PROFILE="User static fan control profile ($DECIMAL_FAN_SPEED%) (monitoring only, not applied)"
     return
   fi
@@ -76,6 +76,44 @@ function convert_check_interval_to_seconds() {
     *d) echo "$((NUMBER * 86400))" ;;
     *) echo "$NUMBER" ;;
   esac
+}
+
+# Stop the container unless the given parameter is one of the two literals the shell can safely run
+# Usage : validate_boolean_parameter "$PARAMETER_NAME" "$VALUE"
+#
+# Boolean parameters are dispatched by running their value as a command : "if $MONITORING_ONLY_MODE".
+# The idiom is exact for "true" and "false", which really are commands returning 0 and 1, and it is a
+# trap for every other spelling, because every other spelling is a command too.
+#
+# A value naming nothing exits 127, which the branch reads as false. "True", "TRUE", "1", "on" and
+# "Yes" therefore all silently mean false : MONITORING_ONLY_MODE=True seizes manual fan control and
+# pins the fans on a server the operator explicitly asked it not to touch, while logging "Monitoring
+# only mode: Disabled", and KEEP_THIRD_PARTY_PCIE_CARD_COOLING_RESPONSE_STATE_ON_EXIT=True resets on
+# exit the very state it names.
+#
+# A value that does name a real command is worse. "yes" is /usr/bin/yes, so the branch never returns :
+# it fills the log at hundreds of megabytes a second and, running in the foreground, defers the
+# graceful_exit trap indefinitely, so docker stop cannot end the container and only SIGKILL does. The
+# unquoted occurrences word-split on top of that, so a value carrying arguments runs with them.
+#
+# Refusing anything but the two literals is what makes that idiom safe, which is why the call sites
+# keep it instead of being rewritten. No coherent configuration stops working : the rejected spellings
+# were already read as false, or already hanging the container. The one that did reach the monitoring
+# branch is an empty MONITORING_ONLY_MODE, which the unquoted dispatch expanded to no words at all, so
+# the branch tested nothing and succeeded ; it reached it while validate_check_interval_parameter, given
+# that same empty value and defaulting it with "${3:-false}", judged the interval as if the fans were
+# being driven. That value never meant one thing, so refusing it settles a contradiction rather than
+# taking a working setup away.
+#
+# This function must be called as a statement, never through a command substitution : the exit inside
+# print_error_and_exit would otherwise only leave the subshell and the container would keep running
+function validate_boolean_parameter() {
+  local -r PARAMETER_NAME="$1"
+  local -r VALUE="$2"
+
+  if [ "$VALUE" != "true" ] && [ "$VALUE" != "false" ]; then
+    print_error_and_exit "$PARAMETER_NAME must be exactly \"true\" or \"false\", but is \"$VALUE\". Spellings such as \"True\", \"1\", \"yes\" or \"on\" are not accepted : this parameter is dispatched by running its value, so anything else is either read as false without a word or run as whatever command it names"
+  fi
 }
 
 # Stop the container unless the given parameter is a duration sleep can actually wait for, and unless
@@ -324,7 +362,7 @@ function is_server_powered_on() {
 # /!\ Use this function only for Gen 13 and older generation servers /!\
 # In monitoring only mode, this is a no-op
 function enable_third_party_PCIe_card_Dell_default_cooling_response() {
-  if $MONITORING_ONLY_MODE; then
+  if "$MONITORING_ONLY_MODE"; then
     return
   fi
   # We could check the current cooling response before applying but it's not very useful so let's skip the test and apply directly
@@ -339,7 +377,7 @@ function enable_third_party_PCIe_card_Dell_default_cooling_response() {
 # /!\ Use this function only for Gen 13 and older generation servers /!\
 # In monitoring only mode, this is a no-op
 function disable_third_party_PCIe_card_Dell_default_cooling_response() {
-  if $MONITORING_ONLY_MODE; then
+  if "$MONITORING_ONLY_MODE"; then
     return
   fi
   # We could check the current cooling response before applying but it's not very useful so let's skip the test and apply directly
@@ -370,7 +408,7 @@ function disable_third_party_PCIe_card_Dell_default_cooling_response() {
 
 # Prepare traps in case of container exit
 function graceful_exit() {
-  if $MONITORING_ONLY_MODE; then
+  if "$MONITORING_ONLY_MODE"; then
     print_warning_and_exit "Container stopped (monitoring only mode, no fan control profile was ever applied)"
   fi
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -23,6 +23,7 @@ It exits `0` when every test case passed, `1` otherwise.
 | `cases/10_shell_scripts.sh` | Syntax of every script, files shipped in the Docker image, healthcheck |
 | `cases/20_fan_speed_conversions.sh` | `FAN_SPEED` given as a percentage or as a hexadecimal byte |
 | `cases/25_check_interval_validation.sh` | `CHECK_INTERVAL` values the monitoring loop can actually be paced by, and the reaction time bounds above them |
+| `cases/26_boolean_parameter_validation.sh` | The boolean parameters, which are dispatched by running their value as a command |
 | `cases/30_idrac_login_string.sh` | Local (`/dev/ipmi0`) and network (`lanplus`) modes, password handling |
 | `cases/40_temperature_parsing.sh` | Reading the sensors out of `ipmitool sdr type temperature` |
 | `cases/50_server_model_detection.sh` | Identifying the server, and detecting Gen 14 or newer |

--- a/tests/cases/26_boolean_parameter_validation.sh
+++ b/tests/cases/26_boolean_parameter_validation.sh
@@ -1,0 +1,194 @@
+#!/bin/bash
+
+# The three boolean parameters, which the controller dispatches by running their
+# value as a command : "if $MONITORING_ONLY_MODE; then". That idiom is exact for
+# the two literals and a trap for everything else, because everything else is a
+# command too. A spelling naming nothing exits 127 and is read as false, so
+# MONITORING_ONLY_MODE=True takes the fans on a server the operator asked it not
+# to touch ; a spelling naming something real runs it, so =yes never returns.
+
+function assert_boolean_is_refused() {
+  local -r PARAMETER_NAME="$1"
+  local -r VALUE="$2"
+  local -r MESSAGE="${3:-\"$VALUE\" should stop the controller}"
+
+  # The call has to happen in the subshell a command substitution creates : the
+  # exit inside print_error_and_exit would otherwise take the test runner down
+  local OUTPUT
+  OUTPUT=$(validate_boolean_parameter "$PARAMETER_NAME" "$VALUE" 2>&1)
+  local -r EXIT_CODE=$?
+
+  assert_equals 1 "$EXIT_CODE" "$MESSAGE"
+  assert_contains "$OUTPUT" "$PARAMETER_NAME" "the error should name the parameter at fault"
+}
+
+function assert_boolean_is_accepted() {
+  local -r PARAMETER_NAME="$1"
+  local -r VALUE="$2"
+
+  local OUTPUT
+  OUTPUT=$(validate_boolean_parameter "$PARAMETER_NAME" "$VALUE" 2>&1)
+  local -r EXIT_CODE=$?
+
+  assert_equals 0 "$EXIT_CODE" "\"$VALUE\" is what the dispatch idiom expects and should be accepted"
+  assert_empty "$OUTPUT" "accepting a value should print nothing"
+}
+
+# The three parameters the user supplies, all read through the same idiom
+readonly BOOLEAN_PARAMETERS=(
+  "MONITORING_ONLY_MODE"
+  "DISABLE_THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE"
+  "KEEP_THIRD_PARTY_PCIE_CARD_COOLING_RESPONSE_STATE_ON_EXIT"
+)
+
+function test_the_two_literals_are_accepted() {
+  local PARAMETER_NAME
+  for PARAMETER_NAME in "${BOOLEAN_PARAMETERS[@]}"; do
+    assert_boolean_is_accepted "$PARAMETER_NAME" "true"
+    assert_boolean_is_accepted "$PARAMETER_NAME" "false"
+  done
+}
+
+function test_a_capitalised_spelling_stops_the_controller() {
+  # These are the values that used to be read as false without a word. The mode
+  # they silently disabled is the one the README tells users to run first,
+  # precisely to check the container before letting it touch the fans
+  local VALUE
+  for VALUE in "True" "TRUE" "False" "FALSE"; do
+    assert_boolean_is_refused "MONITORING_ONLY_MODE" "$VALUE"
+  done
+}
+
+function test_a_plausible_boolean_spelling_stops_the_controller() {
+  # Every one of these is a perfectly reasonable thing for a user to write, and
+  # every one of them meant false whatever it said
+  local VALUE
+  for VALUE in "1" "0" "on" "off" "Yes" "No" "enabled" "disabled" ""; do
+    assert_boolean_is_refused "MONITORING_ONLY_MODE" "$VALUE"
+  done
+}
+
+function test_an_unfilled_env_placeholder_stops_the_controller() {
+  # docker takes everything after the "=" verbatim, so a .env copied but not
+  # filled in arrives as its own placeholder text rather than as an empty value
+  local -r PLACEHOLDER="<true or false>"
+
+  assert_boolean_is_refused "MONITORING_ONLY_MODE" "$PLACEHOLDER"
+
+  # The value has to be quoted back at the user, not merely described. This is
+  # the needle that proves it : the two literals the message lists are in its
+  # static text, so asserting on either of those would pass without the value
+  # ever being interpolated
+  local -r OUTPUT=$(validate_boolean_parameter "MONITORING_ONLY_MODE" "$PLACEHOLDER" 2>&1)
+
+  assert_contains "$OUTPUT" "$PLACEHOLDER" "the error should quote the offending value back"
+}
+
+function test_the_three_parameters_are_all_validated() {
+  # The exit-time booleans invert the user's intent just as quietly : =True on
+  # KEEP_..._ON_EXIT resets on exit the very state its name asks to keep
+  local PARAMETER_NAME
+  for PARAMETER_NAME in "${BOOLEAN_PARAMETERS[@]}"; do
+    assert_boolean_is_refused "$PARAMETER_NAME" "True"
+    assert_boolean_is_refused "$PARAMETER_NAME" "1"
+  done
+}
+
+function test_the_validation_never_runs_the_value_it_is_given() {
+  # The unquoted occurrences word-split, so a value carrying arguments used to
+  # run with them. The validation that now guards them must not reproduce that :
+  # it compares the value, it never dispatches it
+  local -r WITNESS="$TEST_TEMPORARY_DIRECTORY/the_value_was_executed"
+  rm -f "$WITNESS"
+
+  assert_boolean_is_refused "MONITORING_ONLY_MODE" "touch $WITNESS"
+
+  assert_command_fails "validating a value must not execute it, whatever it names" \
+    test -e "$WITNESS"
+}
+
+function test_the_error_says_what_is_accepted_and_why() {
+  local -r OUTPUT=$(validate_boolean_parameter "MONITORING_ONLY_MODE" "yes" 2>&1)
+
+  assert_contains "$OUTPUT" "yes" "the error should quote the offending value"
+  assert_contains "$OUTPUT" "true" "the error should say which values are accepted"
+  assert_contains "$OUTPUT" "false" "the error should name both of them"
+}
+
+function test_the_controller_refuses_to_start_on_a_capitalised_boolean() {
+  export MONITORING_ONLY_MODE="True"
+
+  local OUTPUT
+  OUTPUT=$(run_controller)
+  local -r EXIT_CODE=$?
+
+  assert_equals 1 "$EXIT_CODE" "a value that is not one of the two literals should stop the controller"
+  assert_contains "$OUTPUT" "MONITORING_ONLY_MODE" "the error should name the parameter at fault"
+  assert_empty "$(recorded_ipmitool_calls)" \
+    "the booleans are validated before the first IPMI command, so a refused value costs no iDRAC session"
+}
+
+function test_the_controller_no_longer_seizes_the_fans_on_a_capitalised_monitoring_mode() {
+  # The defect this replaces : MONITORING_ONLY_MODE=True was read as false, so
+  # the container disabled Dell's dynamic fan control and pinned the fans on a
+  # server the operator had explicitly asked it to leave alone, all while
+  # logging "Monitoring only mode: Disabled"
+  export MONITORING_ONLY_MODE="True"
+
+  run_controller > /dev/null
+
+  assert_equals 0 "$(count_ipmitool_calls_matching "raw 0x30 0x30")" \
+    "no fan control command should reach a server whose operator asked for monitoring only"
+}
+
+function test_the_controller_refuses_to_start_on_each_of_the_three_booleans() {
+  local PARAMETER_NAME OUTPUT
+  for PARAMETER_NAME in "${BOOLEAN_PARAMETERS[@]}"; do
+    setup_test_context
+    export "$PARAMETER_NAME=True"
+
+    OUTPUT=$(run_controller)
+
+    assert_contains "$OUTPUT" "$PARAMETER_NAME" \
+      "$PARAMETER_NAME should be validated too, not just the monitoring mode"
+  done
+}
+
+function test_the_monitoring_mode_is_validated_before_the_check_interval_reads_it() {
+  # validate_check_interval_parameter takes the mode as an argument, to decide
+  # whether the reaction time bounds apply. It must receive a value that has
+  # already been checked, or an unusable mode would silently pick the bounds
+  export MONITORING_ONLY_MODE="True"
+  export CHECK_INTERVAL="2h"
+
+  local -r OUTPUT=$(run_controller)
+
+  assert_contains "$OUTPUT" "MONITORING_ONLY_MODE" \
+    "the mode should be reported first, being what decides how the interval is judged"
+  assert_not_contains "$OUTPUT" "CHECK_INTERVAL" \
+    "the interval should not be judged against a mode that was never valid"
+}
+
+function test_the_controller_does_not_hang_on_a_boolean_naming_a_real_command() {
+  # "yes" is /usr/bin/yes, so the branch never returned : the container filled
+  # the log at hundreds of megabytes a second and, that binary running in the
+  # foreground, the graceful_exit trap stayed deferred, so docker stop could not
+  # end it and only SIGKILL did.
+  #
+  # This case is deliberately not run through run_controller : it waits on the
+  # controller after signaling it, and a regression here would never answer that
+  # signal, so the suite would hang instead of going red. The timeout bounds the
+  # wait ; head bounds the disk, a regression being killed by SIGPIPE as soon as
+  # it writes past what head reads, long before it can fill anything. PIPESTATUS
+  # is what carries the controller's own exit code out of that pipeline
+  export MONITORING_ONLY_MODE="yes"
+
+  local OUTPUT
+  OUTPUT=$(cd "$REPO_ROOT" && timeout 10 bash ./Dell_iDRAC_fan_controller.sh 2>&1 | head -c 2048; exit "${PIPESTATUS[0]}")
+  local -r EXIT_CODE=$?
+
+  # Anything but a clean refusal is the defect : 124 if it looped until the
+  # timeout, 141 if head cut it short, 0 if it somehow carried on
+  assert_equals 1 "$EXIT_CODE" "the controller should refuse the value and exit, not loop on it"
+  assert_contains "$OUTPUT" "MONITORING_ONLY_MODE" "it should stop by naming the parameter at fault"
+}


### PR DESCRIPTION
Closes #166.

The three boolean parameters are dispatched by running their value as a command — `if $MONITORING_ONLY_MODE; then`. That idiom is exact for the two literals, which really are commands returning 0 and 1, and a trap for every other spelling, because every other spelling is a command too.

## What changed

`validate_boolean_parameter` refuses anything but `true` and `false`, and is called for all three parameters at startup, before the first IPMI command and before anything reads them. The occurrences that were unquoted now are.

Refusing is what makes the existing idiom safe, so the call sites keep it rather than being rewritten — which is what #166 suggested.

### Ordering

`MONITORING_ONLY_MODE` is validated **before** `validate_check_interval_parameter`, which takes it as an argument to decide whether the reaction time bounds from #203 apply, and before anything `graceful_exit` reads on the way out. A test pins that order rather than leaving it to line placement.

### On compatibility

No coherent configuration stops working. The rejected spellings were already read as `false`, or already hanging the container.

The one that did reach the monitoring branch is an **empty** `MONITORING_ONLY_MODE`: the unquoted dispatch expanded it to no words at all, so the branch tested nothing and succeeded. But it reached it while `validate_check_interval_parameter`, handed that same empty value and defaulting it with `${3:-false}`, judged the interval as if the fans were being driven. That value never meant one thing, so refusing it settles a contradiction rather than taking a working setup away.

(Worth noting the other two parameters were already quoted on `master`, where `if ""` is a command with an empty *name* — bash prints `: command not found`, returns 127, and the value reads as `false`. Only `MONITORING_ONLY_MODE` was unquoted.)

## Tests

`tests/cases/26_boolean_parameter_validation.sh`, 12 cases. Beyond the accepted/refused spellings, it covers the two scenarios the issue documents end to end:

- `MONITORING_ONLY_MODE=True` no longer seizes the fans — asserted as **zero** `raw 0x30 0x30` commands reaching a server whose operator asked for monitoring only.
- `MONITORING_ONLY_MODE=yes` no longer hangs. That case deliberately avoids `run_controller`, which waits on the controller after signalling it and would hang the whole suite on a regression instead of going red. It is bounded by `timeout` and by `head -c`, so a regression is killed by SIGPIPE long before it can fill a disk, and `PIPESTATUS` carries the controller's own exit code out of the pipeline.

Verified by mutation rather than by passing: removing the three validation calls turns 5 of the 12 cases red, including the `yes` case, without hanging the runner.

**160 test cases, 1324 assertions, all passing.**

## Review

This branch was put through a four-lens adversarial review (correctness, security, test quality, documentation), each finding then handed to a separate agent tasked with refuting it. Nine findings were raised, four survived — all four in the new test file, none in the shipped fix:

- **The witness assertion was inert.** `assert_command_fails` takes its message *first*; the call passed the command first, so it consumed the literal `test` as the message and ran `-e <path> "<message>"` as the command under test. `-e` names nothing, exit 127, assertion unconditionally green. It was the sole guard for the property that matters most here — that the validator *compares* its input instead of dispatching it — and it could never fail. Fixed and re-verified by mutation: with a bare `$VALUE` inserted into the validator, the corrected assertion goes red where the original stayed green.
- **A tautological assertion.** "the error should quote the offending value" was asserted with a needle that also appears in the message's static text, so it passed without any interpolation. It now asserts on the unfilled-placeholder value, which does not.

The two documentation findings were refuted with evidence, but one of them was right about a smaller thing than it claimed: the original wording said *nothing* that worked stops working, which the empty-value case above contradicts. The claim is now the accurate, narrower one.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRz4qSXQKGNk8frZzEXon8)_