### PR TITLE
Cover the four CPU detection rules that had none

### DIFF
--- a/tests/cases/60_cpu_topologies.sh
+++ b/tests/cases/60_cpu_topologies.sh
@@ -326,3 +326,62 @@ function test_a_socket_slow_to_become_readable_after_a_reboot_keeps_its_column()
   assert_equals "false" "$IS_CPU_REMOVAL_ALLOWED" "the server came back complete, nothing left to remove"
 }
 
+
+function test_two_sensors_sharing_an_entity_get_a_single_column() {
+  # retrieve_temperature_by_entity_id() stops at its first match, so a duplicated
+  # entity would otherwise get two columns both showing the same reading
+  local -r SDR_DATA="$(make_sdr_line "Temp" "0Eh" "ok" "3.1" "40 degrees C")
+$(make_sdr_line "Temp" "0Fh" "ok" "3.1" "41 degrees C")
+$(make_sdr_line "Temp" "10h" "ok" "3.2" "42 degrees C")"
+
+  detect_CPU_temperature_sensors "$SDR_DATA"
+
+  assert_equals "3.1 3.2" "${DETECTED_CPU_ENTITY_IDS[*]}" "the repeated entity is counted once"
+  assert_equals "CPU 1 CPU 2" "${DETECTED_CPU_LABELS[*]}"
+}
+
+function test_a_tenth_processor_entity_sorts_after_the_second_one() {
+  # A lexicographic sort puts 3.10 between 3.1 and 3.2, which would label the
+  # sockets in an order that doesn't match the entities they are read from
+  local -r SDR_DATA="$(make_sdr_line "Temp" "20h" "ok" "3.10" "43 degrees C")
+$(make_sdr_line "Temp" "0Eh" "ok" "3.1" "40 degrees C")
+$(make_sdr_line "Temp" "0Fh" "ok" "3.2" "41 degrees C")"
+
+  detect_CPU_temperature_sensors "$SDR_DATA"
+
+  assert_equals "3.1 3.2 3.10" "${DETECTED_CPU_ENTITY_IDS[*]}" "instances are sorted as numbers"
+  assert_equals "CPU 1 CPU 2 CPU 3" "${DETECTED_CPU_LABELS[*]}" "columns stay numbered from 1"
+}
+
+function test_a_non_processor_entity_is_not_taken_for_a_cpu() {
+  # The entity is matched anchored : "13.1" and "30.1" both contain "3.1" but
+  # neither is entity 3, and counting them would add columns for heat sources
+  # that don't exist
+  local -r SDR_DATA="$(make_sdr_line "Temp" "0Eh" "ok" "3.1" "40 degrees C")
+$(make_sdr_line "Temp" "11h" "ok" "13.1" "44 degrees C")
+$(make_sdr_line "Temp" "12h" "ok" "30.1" "45 degrees C")"
+
+  detect_CPU_temperature_sensors "$SDR_DATA"
+
+  assert_equals "3.1" "${DETECTED_CPU_ENTITY_IDS[*]}" "only entity 3 is a processor"
+  assert_equals "CPU 1" "${DETECTED_CPU_LABELS[*]}"
+}
+
+function test_every_cpu_going_silent_at_once_never_empties_the_table() {
+  # Every socket falling silent together is an IPMI or host problem, not four
+  # CPUs being unplugged at the same instant. Emptying the table would leave
+  # is_any_CPU_overheating() with nothing to fail safe on
+  export MOCK_IPMITOOL_SDR_OUTPUT
+  MOCK_IPMITOOL_SDR_OUTPUT=$(make_sdr_output --cpus 4 --cpu-temperatures "40 41 42 43")
+  detect_then_retrieve_temperatures
+
+  IS_CPU_REMOVAL_ALLOWED=true
+  PENDING_CPU_REMOVAL_SIGNATURE=""
+
+  local READING
+  for ((READING = 1; READING <= CPU_REMOVAL_CONFIRMING_READINGS + 2; READING++)); do
+    refresh_CPU_temperature_sensors ""
+    assert_equals "3.1 3.2 3.3 3.4" "${DETECTED_CPU_ENTITY_IDS[*]}" \
+      "reading $READING left the table intact"
+  done
+}


### PR DESCRIPTION
Follow-up to #144.

Its description listed entity deduplication, numeric instance ordering, the anchored entity match and the never-empty-table guard among the behaviours the suite covered. **All four work** — probed by hand against the merged code — but none had a test case, so nothing would catch a regression.

## What is added

Four cases in `tests/cases/60_cpu_topologies.sh`:

| Case | What it pins |
|---|---|
| `two_sensors_sharing_an_entity_get_a_single_column` | `retrieve_temperature_by_entity_id()` stops at its first match, so a duplicated entity would give two columns showing the same reading |
| `a_tenth_processor_entity_sorts_after_the_second_one` | a lexicographic sort puts `3.10` between `3.1` and `3.2`, labelling sockets in an order that doesn't match their entities |
| `a_non_processor_entity_is_not_taken_for_a_cpu` | `13.1` and `30.1` both contain `3.1`, neither is entity 3; counting them adds columns for heat sources that don't exist |
| `every_cpu_going_silent_at_once_never_empties_the_table` | every socket falling silent together is an IPMI or host problem, not four CPUs unplugged at once |

The last one is the one worth having: it existed on the earlier expiry-based design as `test_every_cpu_going_silent_at_once_keeps_the_table_intact` and was lost when that design was replaced by the power-cycle confirmation. It guards a safety path — an emptied table leaves `is_any_CPU_overheating()` with nothing to fail safe on.

## Tests

`tests/run_tests.sh`: **184 test cases, 1337 assertions**, all passing. Tests only — no production code is touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HpEjf2GP5EGE2BHr7jCtua)_