### PR TITLE
Look the exhaust sensor up on every cycle instead of writing it off

### DIFF
--- a/Dell_iDRAC_fan_controller.sh
+++ b/Dell_iDRAC_fan_controller.sh
@@ -155,9 +155,6 @@ IS_FIRST_MONITORING_CYCLE=true
 # refreshed right when it powers back on instead of reusing data read before/during the outage
 IS_TARGET_SERVER_POWERED_OFF=false
 
-# Check present sensors
-IS_EXHAUST_TEMPERATURE_SENSOR_PRESENT=true
-
 # Start timer in background
 sleep "$CHECK_INTERVAL" &
 SLEEP_PROCESS_PID=$!
@@ -230,15 +227,13 @@ echo "$(format_detected_CPU_temperature_sensors)."
 
 warn_if_unexpected_number_of_CPUs
 
-retrieve_temperatures $IS_EXHAUST_TEMPERATURE_SENSOR_PRESENT "$SDR_TEMPERATURE_DATA"
+retrieve_temperatures "$SDR_TEMPERATURE_DATA"
 
+# Said once, at startup, so that a server that has no exhaust sensor at all is diagnosable from the log.
+# It reports what this reading found rather than a verdict for the whole run : the sensor is looked up
+# again on every cycle, so one that was merely slow to answer still gets its column filled later
 if [ -z "$EXHAUST_TEMPERATURE" ]; then
   echo "No exhaust temperature sensor detected."
-  IS_EXHAUST_TEMPERATURE_SENSOR_PRESENT=false
-  # This reading was taken before the sensor was known to be absent, so it holds an empty string where
-  # every later cycle will hold the "-" placeholder. Backfilling it here keeps the first printed line
-  # consistent with the rest, instead of leaving a blank under the "Exhaust" heading
-  EXHAUST_TEMPERATURE="-"
 fi
 # Output new line to beautify output
 echo ""
@@ -273,7 +268,7 @@ while true; do
     IS_CPU_REMOVAL_ALLOWED=true
     PENDING_CPU_REMOVAL_SIGNATURE=""
     PENDING_CPU_REMOVAL_READINGS=0
-    retrieve_temperatures $IS_EXHAUST_TEMPERATURE_SENSOR_PRESENT
+    retrieve_temperatures
   fi
 
   # Follow the CPUs the server exposes : one may have been added while it was powered off, one may have
@@ -320,7 +315,7 @@ while true; do
     # entity list rather than reused from before it changed. The same data is handed back rather than
     # fetched again : following the CPUs then costs no IPMI round-trip at all, and the readings keep
     # describing the very instant the set was detected on
-    retrieve_temperatures $IS_EXHAUST_TEMPERATURE_SENSOR_PRESENT "$SDR_TEMPERATURE_DATA"
+    retrieve_temperatures "$SDR_TEMPERATURE_DATA"
   fi
 
   # Initialize a variable to store the comments displayed when the fan control profile changed
@@ -390,5 +385,5 @@ while true; do
   sleep "$CHECK_INTERVAL" &
   SLEEP_PROCESS_PID=$!
 
-  retrieve_temperatures $IS_EXHAUST_TEMPERATURE_SENSOR_PRESENT
+  retrieve_temperatures
 done

--- a/functions.sh
+++ b/functions.sh
@@ -568,21 +568,20 @@ function compute_CPU_column_content_width() {
 }
 
 # Retrieve temperature sensors data using ipmitool
-# Usage : retrieve_temperatures $IS_EXHAUST_TEMPERATURE_SENSOR_PRESENT ["$SDR_DATA"]
+# Usage : retrieve_temperatures ["$SDR_DATA"]
 #
 # The sensor data can be handed over by a caller that has just read it, so that detecting the CPUs and
 # taking their first readings cost a single IPMI round-trip and describe the very same instant
 function retrieve_temperatures() {
-  if (( $# < 1 || $# > 2 )); then
-    print_error "Illegal number of parameters. Usage: retrieve_temperatures \$IS_EXHAUST_TEMPERATURE_SENSOR_PRESENT [\"\$SDR_DATA\"]"
+  if (( $# > 1 )); then
+    print_error "Illegal number of parameters. Usage: retrieve_temperatures [\"\$SDR_DATA\"]"
     return 1
   fi
-  local -r IS_EXHAUST_TEMPERATURE_SENSOR_PRESENT=$1
 
   # Kept in a global so that refresh_CPU_temperature_sensors() can look for a newly readable CPU in the
   # very same data, without spending another IPMI round-trip on it
-  if (( $# == 2 )); then
-    SDR_TEMPERATURE_DATA="$2"
+  if (( $# == 1 )); then
+    SDR_TEMPERATURE_DATA="$1"
   else
     SDR_TEMPERATURE_DATA=$(retrieve_sdr_temperature_data)
   fi
@@ -611,12 +610,17 @@ function retrieve_temperatures() {
   # Parse inlet temperature data, the sensor being located by its name
   INLET_TEMPERATURE=$(retrieve_temperature_by_sensor_name "$DATA" "Inlet")
 
-  # If exhaust temperature sensor is present, parse its temperature data
-  if $IS_EXHAUST_TEMPERATURE_SENSOR_PRESENT; then
-    EXHAUST_TEMPERATURE=$(retrieve_temperature_by_sensor_name "$DATA" "Exhaust")
-  else
-    EXHAUST_TEMPERATURE="-"
-  fi
+  # Parse exhaust temperature data, the sensor being located by its name like the inlet one.
+  # It is looked up on every cycle rather than gated on what the first reading found, for the same
+  # reason the CPU set is re-detected on every cycle : one reading cannot tell a sensor that is absent
+  # from a sensor that did not answer this time. Latching "absent" on the startup reading meant a
+  # partial sdr response, or chassis sensors not yet initialised while the CPU entities already were,
+  # dropped the exhaust column for the whole life of the container even though the sensor answered a
+  # second later. An empty reading means "nothing on this cycle" and prints as the "-" placeholder,
+  # which leaves a later cycle free to read it successfully.
+  # This costs no IPMI round-trip : the exhaust row is parsed out of the sdr data this cycle already
+  # holds, so a server genuinely without the sensor only pays a failed text match
+  EXHAUST_TEMPERATURE=$(retrieve_temperature_by_sensor_name "$DATA" "Exhaust")
 }
 
 # Returns 0 (true) if the target server is currently powered on, 1 (false) otherwise

--- a/tests/cases/40_temperature_parsing.sh
+++ b/tests/cases/40_temperature_parsing.sh
@@ -59,7 +59,7 @@ function test_the_sign_survives_the_whole_read_not_just_the_extraction() {
   MOCK_IPMITOOL_SDR_OUTPUT=$(make_sdr_output --cpus 2 --cpu-temperatures "-40 -5" --inlet -3 --exhaust 12)
 
   detect_CPU_temperature_sensors "$(retrieve_sdr_temperature_data)"
-  retrieve_temperatures true
+  retrieve_temperatures
 
   assert_equals "-40" "${DETECTED_CPU_TEMPERATURES[0]}"
   assert_equals "-5" "${DETECTED_CPU_TEMPERATURES[1]}"

--- a/tests/cases/55_enclosure_housed_servers.sh
+++ b/tests/cases/55_enclosure_housed_servers.sh
@@ -77,7 +77,7 @@ function test_a_blade_reports_no_exhaust_temperature_sensor() {
   MOCK_IPMITOOL_SDR_OUTPUT=$(make_sdr_output --cpus 2 --cpu-temperatures "43 45" --inlet 24 --no-exhaust)
 
   detect_CPU_temperature_sensors "$(retrieve_sdr_temperature_data)"
-  retrieve_temperatures true
+  retrieve_temperatures
 
   assert_equals "2" "${#DETECTED_CPU_ENTITY_IDS[@]}"
   assert_equals "24" "$INLET_TEMPERATURE"
@@ -92,7 +92,7 @@ function test_a_sled_whose_enclosure_owns_the_airflow_reports_no_temperature_aro
   MOCK_IPMITOOL_SDR_OUTPUT=$(make_sdr_output --cpus 2 --cpu-temperatures "47 48" --no-inlet --no-exhaust)
 
   detect_CPU_temperature_sensors "$(retrieve_sdr_temperature_data)"
-  retrieve_temperatures true
+  retrieve_temperatures
 
   assert_equals "47" "${DETECTED_CPU_TEMPERATURES[0]}"
   assert_equals "48" "${DETECTED_CPU_TEMPERATURES[1]}"

--- a/tests/cases/60_cpu_topologies.sh
+++ b/tests/cases/60_cpu_topologies.sh
@@ -12,10 +12,8 @@
 # come from, so a test drives the pair the way the controller does.
 
 function detect_then_retrieve_temperatures() {
-  local -r IS_EXHAUST_TEMPERATURE_SENSOR_PRESENT="${1:-true}"
-
   detect_CPU_temperature_sensors "$(retrieve_sdr_temperature_data)"
-  retrieve_temperatures "$IS_EXHAUST_TEMPERATURE_SENSOR_PRESENT"
+  retrieve_temperatures
 }
 
 function test_a_single_cpu_server_reports_one_cpu() {
@@ -96,17 +94,36 @@ function test_a_gap_between_two_readable_sockets_does_not_truncate_the_list() {
   assert_equals "41;39;38" "$CPUS_TEMPERATURES"
 }
 
-function test_the_sensors_known_to_be_absent_are_replaced_by_placeholders() {
+function test_a_missing_exhaust_sensor_leaves_an_empty_reading_and_the_cpus_alone() {
   export MOCK_IPMITOOL_SDR_OUTPUT
-  MOCK_IPMITOOL_SDR_OUTPUT=$(make_sdr_output --cpus 2 --cpu-temperatures "44 46" --exhaust 36)
+  MOCK_IPMITOOL_SDR_OUTPUT=$(make_sdr_output --cpus 2 --cpu-temperatures "44 46" --no-exhaust)
 
-  # Once the controller has detected that the exhaust sensor is missing, it stops
-  # reading it and prints a placeholder in its place
-  detect_then_retrieve_temperatures false
+  detect_then_retrieve_temperatures
 
-  assert_equals "-" "$EXHAUST_TEMPERATURE"
+  assert_equals "" "$EXHAUST_TEMPERATURE" "nothing was read, which the display turns into a placeholder"
+  assert_equals "  -" "$(format_temperature_for_display "$EXHAUST_TEMPERATURE")"
   assert_equals "2" "${#DETECTED_CPU_ENTITY_IDS[@]}" "a missing exhaust sensor must not change the CPU count"
   assert_equals "44;46" "$CPUS_TEMPERATURES"
+}
+
+function test_an_exhaust_sensor_that_answers_late_is_read_on_the_cycle_it_comes_back() {
+  # Presence is an output of each reading rather than a verdict taken once. A
+  # sensor missing from the first sdr response -- a partial response, or chassis
+  # sensors not yet initialised while the CPU entities already were -- used to
+  # lose its column for the whole life of the container. Its own reading is not
+  # what the fans are driven from, so this costs a column in the log rather than
+  # an unmonitored heat source, but it is the same defect the CPU set was fixed for
+  export MOCK_IPMITOOL_SDR_OUTPUT
+  MOCK_IPMITOOL_SDR_OUTPUT=$(make_sdr_output --cpus 2 --cpu-temperatures "44 46" --no-exhaust)
+
+  detect_then_retrieve_temperatures
+  assert_equals "" "$EXHAUST_TEMPERATURE" "nothing to read on the first cycle"
+
+  # The sensor starts answering, without the container being restarted
+  MOCK_IPMITOOL_SDR_OUTPUT=$(make_sdr_output --cpus 2 --cpu-temperatures "44 46" --exhaust 36)
+  retrieve_temperatures
+
+  assert_equals "36" "$EXHAUST_TEMPERATURE" "the sensor must be looked up again, not written off"
 }
 
 function test_a_server_without_an_inlet_or_exhaust_sensor_reports_no_reading() {
@@ -131,7 +148,7 @@ function test_an_unreadable_cpu1_temperature_keeps_its_column() {
   assert_equals "2" "${#DETECTED_CPU_ENTITY_IDS[@]}"
 
   MOCK_IPMITOOL_SDR_OUTPUT=$(printf '%s\n' "$MOCK_IPMITOOL_SDR_OUTPUT" | grep -v ' 3\.2 ')
-  retrieve_temperatures true
+  retrieve_temperatures
 
   assert_empty "${DETECTED_CPU_TEMPERATURES[1]}" "the raw reading stays empty for the overheating check"
   assert_equals "44;-" "$CPUS_TEMPERATURES" "the printed value falls back on a placeholder"
@@ -140,7 +157,7 @@ function test_an_unreadable_cpu1_temperature_keeps_its_column() {
 function test_the_internal_functions_reject_a_wrong_number_of_parameters() {
   local RETRIEVE_OUTPUT BUILD_HEADER_OUTPUT
 
-  RETRIEVE_OUTPUT=$(retrieve_temperatures true true true 2>&1)
+  RETRIEVE_OUTPUT=$(retrieve_temperatures "one" "two" 2>&1)
   local -r RETRIEVE_EXIT_CODE=$?
   BUILD_HEADER_OUTPUT=$(build_header 5 2>&1)
   local -r BUILD_HEADER_EXIT_CODE=$?
@@ -263,7 +280,7 @@ function test_a_cpu_going_silent_on_a_running_server_keeps_its_column() {
   for ((READING = 1; READING <= CPU_REMOVAL_CONFIRMING_READINGS + 2; READING++)); do
     refresh_CPU_temperature_sensors "$SDR_DATA"
   done
-  retrieve_temperatures true "$SDR_DATA"
+  retrieve_temperatures "$SDR_DATA"
 
   assert_equals "3.1 3.2 3.3 3.4" "${DETECTED_CPU_ENTITY_IDS[*]}" "no power cycle, no removal"
   assert_equals "40;41;-;-" "$CPUS_TEMPERATURES" "the silent CPUs keep their column, reading as a placeholder"


### PR DESCRIPTION
Closing as redundant: #178 landed the same fix while this was being written, and `master` already carries it.

Checked rather than assumed — `master` has the identical change: `retrieve_temperatures` down to `["$SDR_DATA"]`, `IS_EXHAUST_TEMPERATURE_SENSOR_PRESENT` gone entirely, the exhaust looked up unconditionally out of the sdr data the cycle already holds, and equivalent regression tests for both the sensor that comes back and the server that genuinely has none.

Nothing in here is worth carrying over. #150 is fixed by #178, not by this.

My earlier reading, that #178 could not be rebased because its CPU half was superseded by #144, was wrong: it was rebased and merged as the exhaust half alone. Opening this was the duplicate-PR problem I had just flagged on #177, made a second time — apologies for the noise.