### PR TITLE
Offer MONITORING_ONLY_MODE in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,4 @@ CPU_TEMPERATURE_THRESHOLD=<decimal temperature threshold, or auto>
 CHECK_INTERVAL=<seconds between each check>
 DISABLE_THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE=<true or false>
 KEEP_THIRD_PARTY_PCIE_CARD_COOLING_RESPONSE_STATE_ON_EXIT=<true or false>
+MONITORING_ONLY_MODE=<true or false>

--- a/tests/cases/10_shell_scripts.sh
+++ b/tests/cases/10_shell_scripts.sh
@@ -163,3 +163,24 @@ function test_the_healthcheck_fails_when_the_sensors_cannot_be_read() {
 
   assert_not_equals 0 "$EXIT_CODE" "the healthcheck should fail when ipmitool fails, so Docker restarts the container"
 }
+
+function test_the_env_example_offers_every_documented_parameter() {
+  # .env.example is what README.md tells users to copy to .env, and a parameter
+  # missing from it is one they never learn they can set : it is not in the file
+  # they edit, and the README bullet describing it is several screens away from
+  # the copy instruction. MONITORING_ONLY_MODE was absent from it for exactly
+  # that reason, documented everywhere else and in none of the .env files
+  local -r README="$REPO_ROOT/README.md"
+  local -r ENV_EXAMPLE="$REPO_ROOT/.env.example"
+
+  local PARAMETER
+  while IFS= read -r PARAMETER; do
+    # The credentials are the reason the file exists, the rest are settings
+    if grep -q "^$PARAMETER=" "$ENV_EXAMPLE"; then
+      pass
+    else
+      fail "$PARAMETER is documented in the README but absent from .env.example" \
+        "add it to $ENV_EXAMPLE, or stop documenting it"
+    fi
+  done < <(grep -oP '^- `\K[A-Z_]+(?=`)' "$README")
+}


### PR DESCRIPTION
Closes #223.

`.env.example` was missing `MONITORING_ONLY_MODE`, the only documented parameter absent from it. Since the README tells users to copy that file and fill it in, anyone following the recommended route never learns the mode exists — and it is the one that lets them watch temperatures before letting the container take the fans.

## Changes

- `.env.example`: the missing line, in the same order as the README and the docker snippets.
- `tests/cases/10_shell_scripts.sh`: a case that derives the expected list from the README's own parameter bullets (`grep -oP '^- \`\K[A-Z_]+(?=\`)'`) instead of hardcoding it, so the next parameter added to one and forgotten in the other fails the suite.

## Verification

The test fails on the defect and passes on the fix:

```
$ git stash -- .env.example && ./tests/run_tests.sh -f env_example
  fail the env example offers every documented parameter
       MONITORING_ONLY_MODE is documented in the README but absent from .env.example

$ git stash pop && ./tests/run_tests.sh -f env_example
  ok   the env example offers every documented parameter (9 assertions)
```

Full suite: **196 test cases passed, 1 skipped (1408 assertions)**.

---
_Generated by [Claude Code](https://claude.ai/code/session_0123Fkaq8Ae7tjD7umqebeXh)_