### PR TITLE
Fail safe on an unusable temperature threshold too, not just an unusable reading

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -1370,14 +1370,27 @@ function is_temperature_reading_valid() {
 # Like the per-CPU checks it replaces, it deliberately returns true both when a CPU is genuinely too hot
 # and when its reading is unusable, so an unverifiable temperature still falls back to Dell's profile
 # instead of crashing (bash's "-gt" throws "unary operator expected" on empty/non-numeric input) or
-# silently running the low user fan speed on unverified data
+# silently running the low user fan speed on unverified data. The same goes for an unusable threshold,
+# the comparison having two operands and only one of them having been guarded until now
 function is_any_CPU_overheating() {
   OVERHEATING_CPUS_AND_TEMPERATURES=()
+
+  # The threshold is the comparison's other operand, and "-gt" fails the same way on either side : on a
+  # value it cannot parse the test returns non-zero, which reads as "not overheating" -- the one answer
+  # that leaves a hot CPU running on the user's low static fan speed. It is therefore checked like the
+  # readings are, and normalized once here rather than per CPU, an empty result meaning "unusable".
+  # Dell_iDRAC_fan_controller.sh resolves and validates the threshold before the monitoring loop starts
+  # and then makes it readonly, so this is not reachable from the container : it is what keeps the answer
+  # safe on its own terms instead of by depending on a check living in another file (see issue #218)
+  local NORMALIZED_CPU_TEMPERATURE_THRESHOLD=""
+  if is_temperature_reading_valid "$CPU_TEMPERATURE_THRESHOLD"; then
+    NORMALIZED_CPU_TEMPERATURE_THRESHOLD=$(normalize_decimal_value "$CPU_TEMPERATURE_THRESHOLD")
+  fi
 
   local INDEX CPU_TEMPERATURE
   for INDEX in "${!DETECTED_CPU_TEMPERATURES[@]}"; do
     CPU_TEMPERATURE="${DETECTED_CPU_TEMPERATURES[INDEX]}"
-    if ! is_temperature_reading_valid "$CPU_TEMPERATURE" || [ "$(normalize_decimal_value "$CPU_TEMPERATURE")" -gt "$CPU_TEMPERATURE_THRESHOLD" ]; then
+    if [ -z "$NORMALIZED_CPU_TEMPERATURE_THRESHOLD" ] || ! is_temperature_reading_valid "$CPU_TEMPERATURE" || [ "$(normalize_decimal_value "$CPU_TEMPERATURE")" -gt "$NORMALIZED_CPU_TEMPERATURE_THRESHOLD" ]; then
       # The label is taken from the table's own labels rather than rebuilt here, so that the CPU named
       # in the comment is always the one whose column shows the reading that triggered it. It falls back
       # to the position rather than to an empty string, so that a comment naming no CPU at all can never

--- a/tests/cases/80_temperature_thresholds.sh
+++ b/tests/cases/80_temperature_thresholds.sh
@@ -285,3 +285,57 @@ function test_reasons_are_joined_the_way_a_sentence_is() {
   assert_equals "CPU 1, CPU 2 and CPU 3" "$(join_with_and "CPU 1" "CPU 2" "CPU 3")"
   assert_equals "CPU 1, CPU 2, CPU 3 and CPU 4" "$(join_with_and "CPU 1" "CPU 2" "CPU 3" "CPU 4")"
 }
+
+function test_an_unusable_threshold_fails_safe_like_an_unusable_reading() {
+  # The decision compares two operands and "-gt" fails the same way on either
+  # side. A failing test returns non-zero, which the caller reads as "not
+  # overheating" -- the one answer that leaves a hot CPU on the user's low fan
+  # speed. The reading side has been guarded since #134; this is the other side.
+  #
+  # Dell_iDRAC_fan_controller.sh validates the threshold before the loop starts
+  # and makes it readonly, so the container cannot reach this state today. The
+  # guard is what keeps the answer safe without depending on that
+  given_the_detected_cpu_temperatures 95 95
+
+  local UNUSABLE_THRESHOLD
+  for UNUSABLE_THRESHOLD in "" "abc" "60°C" "60C" "50.5" "1e2"; do
+    export CPU_TEMPERATURE_THRESHOLD="$UNUSABLE_THRESHOLD"
+    assert_a_cpu_is_overheating \
+      "CPUs at 95°C must fall back on Dell's profile when the threshold is \"$UNUSABLE_THRESHOLD\""
+  done
+}
+
+function test_an_unusable_threshold_names_every_cpu_in_the_fallback_comment() {
+  # The comment is what the user has to diagnose the fallback with, so it must
+  # still name the CPUs rather than come out empty
+  export CPU_TEMPERATURE_THRESHOLD="abc"
+  given_the_detected_cpu_temperatures 45 46
+
+  is_any_CPU_overheating
+
+  assert_equals "CPU 1 45 CPU 2 46" "${OVERHEATING_CPUS_AND_TEMPERATURES[*]}" \
+    "every CPU should be reported when the threshold itself cannot be compared against"
+}
+
+function test_a_usable_threshold_still_decides_normally() {
+  # The added guard must not turn every comparison into an overheat
+  export CPU_TEMPERATURE_THRESHOLD=50
+
+  given_the_detected_cpu_temperatures 45 30
+  assert_no_cpu_is_overheating
+
+  given_the_detected_cpu_temperatures 45 95
+  assert_a_cpu_is_overheating
+}
+
+function test_a_threshold_with_a_leading_zero_is_not_read_as_octal() {
+  # "070" would be an invalid octal number to bash's "-gt". The threshold reaches
+  # the loop already normalized, so this only matters if it ever stops being
+  export CPU_TEMPERATURE_THRESHOLD="070"
+
+  given_the_detected_cpu_temperatures 65
+  assert_no_cpu_is_overheating "070°C is 70°C, so a CPU at 65°C is not overheating"
+
+  given_the_detected_cpu_temperatures 75
+  assert_a_cpu_is_overheating "070°C is 70°C, so a CPU at 75°C is overheating"
+}


### PR DESCRIPTION
Closes #218

## Problem

`is_any_CPU_overheating` compares two operands, and bash's `-gt` fails the same way on either side. The **reading** has been guarded since #134. The **threshold** never was:

```bash
if ! is_temperature_reading_valid "$CPU_TEMPERATURE" || [ "$(normalize_decimal_value "$CPU_TEMPERATURE")" -gt "$CPU_TEMPERATURE_THRESHOLD" ]; then
#    ^ guarded                                                                              not guarded ^
```

A failing test returns non-zero, which the caller reads as "not overheating" — the one answer that leaves a hot CPU on the user's low static fan speed. With two CPUs at 95°C, on `master`:

```
threshold=[50]    OVERHEAT
threshold=[]      not-overheat
threshold=[abc]   not-overheat
threshold=[60°C]  not-overheat
```

This is the structural half of #149. The defect that issue reported — the container accepting such a threshold in the first place — was fixed in #143.

## This is not reachable from the container

`Dell_iDRAC_fan_controller.sh` resolves and validates the threshold before the monitoring loop starts, then makes it `readonly`. Nothing the image ships can put the decision in that state. This is a latent trap, not a live bug, and the PR is written as such.

It is worth closing because the safety of the decision otherwise rests on a check living in another file, several dozen lines earlier, and on nobody ever making that variable writable again — in a function that has already been rewritten once since the guard was written for its predecessors, carrying the gap forward unnoticed.

## Change

The threshold goes through the same validity check the readings do, normalized once per call rather than per CPU, an empty result meaning "unusable". After, all four cases above hand the fans back to Dell, and the fallback comment still names every CPU rather than coming out empty.

Normalizing also means the comparison holds on a padded value instead of reading `070` as an invalid octal number.

## Testing

Four cases added to `tests/cases/80_temperature_thresholds.sh`:

- an unusable threshold (`""`, `abc`, `60°C`, `60C`, `50.5`, `1e2`) fails safe, like an unusable reading;
- it still names every CPU in `OVERHEATING_CPUS_AND_TEMPERATURES`, that comment being what the user has to diagnose the fallback with;
- a usable threshold still decides normally — the guard must not turn every comparison into an overheat;
- a threshold with a leading zero is not read as octal.

Full suite: **310 passed, 1754 assertions**. The before/after table above was produced by sourcing each version of `functions.sh` against the same globals.

Two files, +69/−2, no change outside `is_any_CPU_overheating` and its test file.