### PR TITLE
Refuse to run on a server reporting no CPU temperature sensor

### DIFF
--- a/Dell_iDRAC_fan_controller.sh
+++ b/Dell_iDRAC_fan_controller.sh
@@ -151,7 +151,7 @@ SLEEP_PROCESS_PID=$!
 # The target server may be powered off, or its iDRAC may not be answering yet, when the container starts.
 # No sensor can be read then, so keep waiting instead of giving up : this container is expected to
 # outlive its target server being powered off, and exiting here would just make it restart in a loop
-IS_WAITING_FOR_CPU_TEMPERATURE_SENSORS_LOGGED=false
+WAITING_FOR_CPU_TEMPERATURE_SENSORS_CYCLES=0
 while true; do
   IS_TARGET_SERVER_ANSWERING=true
   if $NETWORK_MODE && ! is_server_powered_on; then
@@ -172,17 +172,24 @@ while true; do
     # have left the BMC in manual mode, in which case they would stay pinned at the user's low speed
     # with nobody watching the temperatures
     apply_Dell_default_fan_control_profile
+
+    # The third-party PCIe card cooling response is a setting the user asked for, not a reaction to a
+    # temperature: it has nothing to do with the CPU sensors being readable, and the monitoring loop
+    # applies it on every one of its own cycles. Leaving it out here means a server that never becomes
+    # readable keeps whatever state its iDRAC was left in, silently and for as long as the wait lasts
+    apply_third_party_PCIe_card_cooling_response_setting \
+      "$DELL_POWEREDGE_GEN_14_OR_NEWER" "$DISABLE_THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE" "$MONITORING_ONLY_MODE"
   fi
 
   if ! $IS_TARGET_SERVER_ANSWERING; then
     # Worded and repeated exactly like the monitoring loop does for the same situation : this is the
     # same powered-off server, only observed before the first reading rather than after
     printf "%19s  Target server is powered off, no fan control profile applied.\n" "$(date +"%d-%m-%Y %T")"
-  elif ! $IS_WAITING_FOR_CPU_TEMPERATURE_SENSORS_LOGGED; then
-    # The server answers but exposes nothing readable. Logged once only, to say why the container isn't
-    # printing temperatures yet without flooding the logs every cycle
-    IS_WAITING_FOR_CPU_TEMPERATURE_SENSORS_LOGGED=true
-
+  elif (( WAITING_FOR_CPU_TEMPERATURE_SENSORS_CYCLES % TABLE_HEADER_PRINT_INTERVAL == 0 )); then
+    # The server answers but exposes nothing readable. Repeated on the same rhythm the monitoring loop
+    # reprints its table header, rather than once and never again : a container that says one thing at
+    # startup and then stays silent for days is indistinguishable from a hung one, and this is the
+    # state a user aiming IDRAC_HOST at a chassis controller sits in permanently
     if $NETWORK_MODE; then
       WAITING_REASON="is the target server still starting up ?"
     else
@@ -198,6 +205,8 @@ while true; do
       printf "%19s  No CPU temperature sensor could be read (%s), Dell default dynamic fan control profile applied for safety while waiting...\n" "$(date +"%d-%m-%Y %T")" "$WAITING_REASON"
     fi
   fi
+
+  ((WAITING_FOR_CPU_TEMPERATURE_SENSORS_CYCLES++))
 
   wait $SLEEP_PROCESS_PID
 
@@ -341,22 +350,10 @@ while true; do
     fi
   fi
 
-  # If server model is not Gen 14 (*40) or newer
-  if ! $DELL_POWEREDGE_GEN_14_OR_NEWER; then
-    # Enable or disable, depending on the user's choice, third-party PCIe card Dell default cooling response
-    # No comment will be displayed on the change of this parameter since it is not related to the temperature of any device (CPU, GPU, etc...) but only to the settings made by the user when launching this Docker container
-    if "$DISABLE_THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE"; then
-      disable_third_party_PCIe_card_Dell_default_cooling_response
-      THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE_STATUS="Disabled"
-    else
-      enable_third_party_PCIe_card_Dell_default_cooling_response
-      THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE_STATUS="Enabled"
-    fi
-
-    if $MONITORING_ONLY_MODE; then
-      THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE_STATUS+=" (not applied: monitoring only mode)"
-    fi
-  fi
+  # Enable or disable, depending on the user's choice, third-party PCIe card Dell default cooling
+  # response. Gen 14 and newer dropped the command, so nothing is sent there
+  apply_third_party_PCIe_card_cooling_response_setting \
+    "$DELL_POWEREDGE_GEN_14_OR_NEWER" "$DISABLE_THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE" "$MONITORING_ONLY_MODE"
 
   # Print temperatures, active fan control profile and comment if any change happened during last time interval
   if [ $TABLE_HEADER_PRINT_COUNTER -eq $TABLE_HEADER_PRINT_INTERVAL ]; then

--- a/Dell_iDRAC_fan_controller.sh
+++ b/Dell_iDRAC_fan_controller.sh
@@ -192,10 +192,10 @@ while true; do
     apply_Dell_default_fan_control_profile
 
     print_error_and_exit "No CPU temperature sensor could be read from $SERVER_MANUFACTURER $SERVER_MODEL, and every PowerEdge has at least one CPU.
- If IDRAC_HOST points at a chassis management controller (VRTX, FX2, M1000e, MX7000), point it at a node\'s own iDRAC instead : the chassis hosts no CPU, and its CMC drives the enclosure fans rather than a node\'s.
+ If IDRAC_HOST points at a chassis management controller (VRTX, FX2, M1000e, MX7000), point it at a node's own iDRAC instead : the chassis hosts no CPU, and its CMC drives the enclosure fans rather than a node's.
  Otherwise, run \"ipmitool -I lanplus -H <iDRAC IP address> -U <iDRAC username> -P <iDRAC password> sdr type temperature\" (drop the connection options in local mode) and look for lines whose 4th column is an entity \"3.<something>\" and whose reading ends in \"degrees C\".
  If some are listed and the container still reports none, or if none is listed at all, please open an issue with your server model and that output : https://github.com/tigerblue77/Dell_iDRAC_fan_controller_Docker/issues
- Dell default dynamic fan control profile applied for safety before exiting."
+ Dell default dynamic fan control profile applied for safety before exiting"
   fi
 
   # Worded and repeated exactly like the monitoring loop does for the same situation : this is the

--- a/Dell_iDRAC_fan_controller.sh
+++ b/Dell_iDRAC_fan_controller.sh
@@ -163,10 +163,11 @@ SLEEP_PROCESS_PID=$!
 # Detect the CPU temperature sensors before entering the monitoring loop, the table header being built
 # from them. The loop then keeps watching for CPUs showing up later, so a partial set read here is not
 # final.
-# The target server may be powered off, or its iDRAC may not be answering yet, when the container starts.
-# No sensor can be read then, so keep waiting instead of giving up : this container is expected to
-# outlive its target server being powered off, and exiting here would just make it restart in a loop
-WAITING_FOR_CPU_TEMPERATURE_SENSORS_CYCLES=0
+# The target server may be powered off when the container starts. No sensor can be read then, so keep
+# waiting instead of giving up : this container is expected to outlive its target server being powered
+# off, and exiting there would just make it restart in a loop.
+# A server that does answer is a different matter, and is handled inside the loop : it has CPUs, so
+# reporting none of them is a fault to report rather than a state to wait out
 while true; do
   IS_TARGET_SERVER_ANSWERING=true
   if $NETWORK_MODE && ! is_server_powered_on; then
@@ -182,45 +183,26 @@ while true; do
       break
     fi
 
-    # The server answers but exposes no readable CPU temperature, so nothing can be supervised. Hand the
-    # fans back to Dell rather than leave them wherever they were: a previous run of this container may
-    # have left the BMC in manual mode, in which case they would stay pinned at the user's low speed
-    # with nobody watching the temperatures
+    # The server answers, and answers that it has no readable CPU temperature sensor. Every PowerEdge
+    # has at least one CPU, so this is not a state to sit and wait out : an iDRAC that exposes no
+    # processor entity does so on every check, not on this one. Retrying forever would leave a container
+    # that looks alive and supervises nothing.
+    #
+    # Hand the fans back to Dell before leaving, rather than leave them wherever they were : a previous
+    # run of this container may have left the BMC in manual mode, in which case they would stay pinned
+    # at the user's low speed with nobody watching the temperatures. graceful_exit is not reached here,
+    # the trap only covering the termination signals
     apply_Dell_default_fan_control_profile
 
-    # The third-party PCIe card cooling response is a setting the user asked for, not a reaction to a
-    # temperature : it has nothing to do with the CPU sensors being readable, and the monitoring loop
-    # applies it on every one of its own cycles
-    apply_third_party_PCIe_card_cooling_response_setting \
-      "$DISABLE_THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE" "$MONITORING_ONLY_MODE"
+    print_error_and_exit "No CPU temperature sensor could be read from $SERVER_MANUFACTURER $SERVER_MODEL, and every PowerEdge has at least one CPU.
+ Run \"ipmitool -I lanplus -H <iDRAC IP address> -U <iDRAC username> -P <iDRAC password> sdr type temperature\" (drop the connection options in local mode) and look for lines whose 4th column is an entity \"3.<something>\" and whose reading ends in \"degrees C\".
+ If some are listed and the container still reports none, or if none is listed at all, please open an issue with your server model and that output : https://github.com/tigerblue77/Dell_iDRAC_fan_controller_Docker/issues
+ Dell default dynamic fan control profile applied for safety before exiting."
   fi
 
-  if ! $IS_TARGET_SERVER_ANSWERING; then
-    # Worded and repeated exactly like the monitoring loop does for the same situation : this is the
-    # same powered-off server, only observed before the first reading rather than after
-    printf "%19s  Target server is powered off, no fan control profile applied.\n" "$(date +"%d-%m-%Y %T")"
-  elif (( WAITING_FOR_CPU_TEMPERATURE_SENSORS_CYCLES % TABLE_HEADER_PRINT_INTERVAL == 0 )); then
-    # The server answers but exposes nothing readable. Repeated on the same rhythm the monitoring loop
-    # reprints its table header, rather than once and never again : a container that says one thing at
-    # startup and then stays silent for days is indistinguishable from a hung one, and this is the
-    # state a user aiming IDRAC_HOST at a chassis controller sits in permanently
-    if $NETWORK_MODE; then
-      WAITING_REASON="is the target server still starting up ?"
-    else
-      # In local mode the server is by definition powered on, so pointing at its power state would send
-      # the user looking in the wrong direction: the sensors are there, they just can't be parsed
-      WAITING_REASON="see the troubleshooting section of the README"
-    fi
-
-    # The profile is only claimed when it was really sent : applying it is a no-op in monitoring only mode
-    if $MONITORING_ONLY_MODE; then
-      printf "%19s  No CPU temperature sensor could be read (%s), waiting...\n" "$(date +"%d-%m-%Y %T")" "$WAITING_REASON"
-    else
-      printf "%19s  No CPU temperature sensor could be read (%s), Dell default dynamic fan control profile applied for safety while waiting...\n" "$(date +"%d-%m-%Y %T")" "$WAITING_REASON"
-    fi
-  fi
-
-  ((WAITING_FOR_CPU_TEMPERATURE_SENSORS_CYCLES++))
+  # Worded and repeated exactly like the monitoring loop does for the same situation : this is the
+  # same powered-off server, only observed before the first reading rather than after
+  printf "%19s  Target server is powered off, no fan control profile applied.\n" "$(date +"%d-%m-%Y %T")"
 
   wait $SLEEP_PROCESS_PID
 
@@ -374,8 +356,36 @@ while true; do
   # ipmitool exits non-zero both for a command the BMC does not have and for a BMC it never reached, and
   # only the completion code it prints tells the two apart. The controller therefore stops asking on the
   # first genuine "I do not have this command", and never on a network outage, however long it lasts
-  apply_third_party_PCIe_card_cooling_response_setting \
-    "$DISABLE_THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE" "$MONITORING_ONLY_MODE"
+  if $IS_THIRD_PARTY_PCIE_CARD_COOLING_RESPONSE_SUPPORTED; then
+    # Enable or disable, depending on the user's choice, third-party PCIe card Dell default cooling response
+    # No comment will be displayed on the change of this parameter since it is not related to the temperature of any device (CPU, GPU, etc...) but only to the settings made by the user when launching this Docker container
+    if "$DISABLE_THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE"; then
+      REQUESTED_THIRD_PARTY_PCIE_CARD_COOLING_RESPONSE="Disabled"
+      disable_third_party_PCIe_card_Dell_default_cooling_response
+    else
+      REQUESTED_THIRD_PARTY_PCIE_CARD_COOLING_RESPONSE="Enabled"
+      enable_third_party_PCIe_card_Dell_default_cooling_response
+    fi
+    # The status of the command the branch above just ran
+    THIRD_PARTY_PCIE_CARD_COOLING_RESPONSE_EXIT_CODE=$?
+
+    if [ $THIRD_PARTY_PCIE_CARD_COOLING_RESPONSE_EXIT_CODE -eq 0 ]; then
+      THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE_STATUS="$REQUESTED_THIRD_PARTY_PCIE_CARD_COOLING_RESPONSE"
+
+      if "$MONITORING_ONLY_MODE"; then
+        THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE_STATUS+=" (not applied: monitoring only mode)"
+      fi
+    elif does_the_server_lack_this_command "$THIRD_PARTY_PCIE_CARD_COOLING_RESPONSE_STDERR"; then
+      # The BMC answered, and answered that it does not have this command. That will not change while
+      # this container runs, so stop sending it
+      IS_THIRD_PARTY_PCIE_CARD_COOLING_RESPONSE_SUPPORTED=false
+      THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE_STATUS="Not supported by this server"
+    else
+      # The command did not go through, but nothing says the server refused it : an unreachable iDRAC, a
+      # busy BMC, an answer this controller does not recognize. Report the cycle and try again on the next
+      THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE_STATUS="Could not be applied on this cycle"
+    fi
+  fi
 
   # Print temperatures, active fan control profile and comment if any change happened during last time interval
   if [ $TABLE_HEADER_PRINT_COUNTER -eq $TABLE_HEADER_PRINT_INTERVAL ]; then

--- a/Dell_iDRAC_fan_controller.sh
+++ b/Dell_iDRAC_fan_controller.sh
@@ -195,7 +195,8 @@ while true; do
     apply_Dell_default_fan_control_profile
 
     print_error_and_exit "No CPU temperature sensor could be read from $SERVER_MANUFACTURER $SERVER_MODEL, and every PowerEdge has at least one CPU.
- Run \"ipmitool -I lanplus -H <iDRAC IP address> -U <iDRAC username> -P <iDRAC password> sdr type temperature\" (drop the connection options in local mode) and look for lines whose 4th column is an entity \"3.<something>\" and whose reading ends in \"degrees C\".
+ If IDRAC_HOST points at a chassis management controller (VRTX, FX2, M1000e, MX7000), point it at a node\'s own iDRAC instead : the chassis hosts no CPU, and its CMC drives the enclosure fans rather than a node\'s.
+ Otherwise, run \"ipmitool -I lanplus -H <iDRAC IP address> -U <iDRAC username> -P <iDRAC password> sdr type temperature\" (drop the connection options in local mode) and look for lines whose 4th column is an entity \"3.<something>\" and whose reading ends in \"degrees C\".
  If some are listed and the container still reports none, or if none is listed at all, please open an issue with your server model and that output : https://github.com/tigerblue77/Dell_iDRAC_fan_controller_Docker/issues
  Dell default dynamic fan control profile applied for safety before exiting."
   fi

--- a/functions.sh
+++ b/functions.sh
@@ -676,62 +676,6 @@ function disable_third_party_PCIe_card_Dell_default_cooling_response() {
 
 # Whether the given ipmitool stderr says the BMC itself answered and does not have the command, as
 # opposed to ipmitool never having reached it.
-# Apply the user's third-party PCIe card Dell default cooling response setting, and report what the
-# server answered.
-# Usage : apply_third_party_PCIe_card_cooling_response_setting \
-#           "$DISABLE_THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE" "$MONITORING_ONLY_MODE"
-# Reads and updates : IS_THIRD_PARTY_PCIE_CARD_COOLING_RESPONSE_SUPPORTED, latched false once the
-#                     server has answered that it does not have the command
-# Returns : THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE_STATUS, the string the table's column shows
-#
-# Extracted so the monitoring loop and the loop waiting for readable CPU sensors apply it the same way.
-# It is a setting the user asked for, not a reaction to a temperature, so it must not depend on whether
-# a CPU can be read : a server whose sensors never become readable would otherwise keep whatever cooling
-# response state its iDRAC was left in, silently and for as long as the wait lasts
-function apply_third_party_PCIe_card_cooling_response_setting() {
-  if (( $# != 2 )); then
-    print_error "Illegal number of parameters. Usage: apply_third_party_PCIe_card_cooling_response_setting \$DISABLE_THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE \$MONITORING_ONLY_MODE"
-    return 1
-  fi
-  local -r IS_DISABLE_REQUESTED="$1"
-  local -r IS_MONITORING_ONLY_MODE="$2"
-
-  if ! $IS_THIRD_PARTY_PCIE_CARD_COOLING_RESPONSE_SUPPORTED; then
-    return 0
-  fi
-
-  # Enable or disable, depending on the user's choice, third-party PCIe card Dell default cooling response.
-  # No comment is displayed when this changes : it is not related to the temperature of any device, only to
-  # the settings the user made when launching the container
-  local REQUESTED_COOLING_RESPONSE
-  if "$IS_DISABLE_REQUESTED"; then
-    REQUESTED_COOLING_RESPONSE="Disabled"
-    disable_third_party_PCIe_card_Dell_default_cooling_response
-  else
-    REQUESTED_COOLING_RESPONSE="Enabled"
-    enable_third_party_PCIe_card_Dell_default_cooling_response
-  fi
-  # The status of the command the branch above just ran
-  local -r COOLING_RESPONSE_EXIT_CODE=$?
-
-  if [ "$COOLING_RESPONSE_EXIT_CODE" -eq 0 ]; then
-    THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE_STATUS="$REQUESTED_COOLING_RESPONSE"
-
-    if "$IS_MONITORING_ONLY_MODE"; then
-      THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE_STATUS+=" (not applied: monitoring only mode)"
-    fi
-  elif does_the_server_lack_this_command "$THIRD_PARTY_PCIE_CARD_COOLING_RESPONSE_STDERR"; then
-    # The BMC answered, and answered that it does not have this command. That will not change while
-    # this container runs, so stop sending it
-    IS_THIRD_PARTY_PCIE_CARD_COOLING_RESPONSE_SUPPORTED=false
-    THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE_STATUS="Not supported by this server"
-  else
-    # The command did not go through, but nothing says the server refused it : an unreachable iDRAC, a
-    # busy BMC, an answer this controller does not recognize. Report the cycle and try again on the next
-    THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE_STATUS="Could not be applied on this cycle"
-  fi
-}
-
 # Usage : does_the_server_lack_this_command "$THIRD_PARTY_PCIE_CARD_COOLING_RESPONSE_STDERR"
 #
 # ipmitool exits non-zero for both, which is exactly why the text is needed. A BMC that answered reports

--- a/functions.sh
+++ b/functions.sh
@@ -604,6 +604,45 @@ function enable_third_party_PCIe_card_Dell_default_cooling_response() {
   ipmitool -I $IDRAC_LOGIN_STRING raw 0x30 0xce 0x00 0x16 0x05 0x00 0x00 0x00 0x05 0x00 0x00 0x00 0x00 > /dev/null 2>&1
 }
 
+# Apply the user's third-party PCIe card Dell default cooling response setting, on the generations that
+# expose it.
+# Usage : apply_third_party_PCIe_card_cooling_response_setting $DELL_POWEREDGE_GEN_14_OR_NEWER \
+#           $DISABLE_THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE $MONITORING_ONLY_MODE
+# Returns : THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE_STATUS, the string the table's own
+#           column shows
+#
+# Extracted so that the monitoring loop and the loop waiting for readable CPU sensors apply it the same
+# way. It is a setting the user asked for, not a reaction to a temperature, so it must not depend on
+# whether a CPU can be read : Gen 14 and newer simply dropped the command, which is the only case where
+# nothing is sent
+function apply_third_party_PCIe_card_cooling_response_setting() {
+  if (( $# != 3 )); then
+    print_error "Illegal number of parameters. Usage: apply_third_party_PCIe_card_cooling_response_setting \$DELL_POWEREDGE_GEN_14_OR_NEWER \$DISABLE_THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE \$MONITORING_ONLY_MODE"
+    return 1
+  fi
+  local -r IS_GEN_14_OR_NEWER="$1"
+  local -r IS_DISABLE_REQUESTED="$2"
+  local -r IS_MONITORING_ONLY_MODE="$3"
+
+  if $IS_GEN_14_OR_NEWER; then
+    return 0
+  fi
+
+  # No comment is displayed when this changes : it is not related to the temperature of any device, only
+  # to the settings the user made when launching the container
+  if $IS_DISABLE_REQUESTED; then
+    disable_third_party_PCIe_card_Dell_default_cooling_response
+    THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE_STATUS="Disabled"
+  else
+    enable_third_party_PCIe_card_Dell_default_cooling_response
+    THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE_STATUS="Enabled"
+  fi
+
+  if $IS_MONITORING_ONLY_MODE; then
+    THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE_STATUS+=" (not applied: monitoring only mode)"
+  fi
+}
+
 # /!\ Use this function only for Gen 13 and older generation servers /!\
 # In monitoring only mode, this is a no-op
 function disable_third_party_PCIe_card_Dell_default_cooling_response() {

--- a/tests/cases/55_enclosure_housed_servers.sh
+++ b/tests/cases/55_enclosure_housed_servers.sh
@@ -222,6 +222,10 @@ function test_the_controller_refuses_to_run_on_a_server_reporting_no_cpu_sensor(
   # and the enclosure rejecting the fan control commands anyway
   assert_contains "$OUTPUT" "chassis management controller" \
     "the chassis mistake is named first, being the likeliest cause"
+  assert_contains "$OUTPUT" "point it at a node's own iDRAC instead" \
+    "the apostrophe must not come out escaped, the message being a double quoted string"
+  assert_not_contains "$OUTPUT" "exiting.. Exiting." \
+    "print_error_and_exit appends its own sentence, so the message must not end on a full stop"
 }
 
 function test_the_fans_are_handed_back_to_dell_before_refusing_to_run() {

--- a/tests/cases/55_enclosure_housed_servers.sh
+++ b/tests/cases/55_enclosure_housed_servers.sh
@@ -235,3 +235,34 @@ function test_aiming_the_controller_at_the_enclosure_instead_of_a_blade_fails_sa
   assert_equals "0" "$(count_ipmitool_calls_matching "raw 0x30 0x30 0x02")" \
     "no fan speed must be sent either"
 }
+
+function test_the_controller_keeps_saying_why_it_is_waiting_instead_of_going_silent() {
+  # A container that states its reason once at startup and then never prints
+  # anything again is indistinguishable from a hung one, and this is the state a
+  # user who aimed IDRAC_HOST at a chassis controller sits in permanently
+  simulate_enclosure_management_controller "PowerEdge M1000e"
+
+  # Wait for the reason to have been printed more than once rather than for a
+  # temperature line, which this server can never produce
+  local -r OUTPUT=$(run_controller "No CPU temperature sensor could be read(.|\n)*No CPU temperature sensor could be read")
+
+  local -r OCCURRENCES=$(grep -c "No CPU temperature sensor could be read" <<< "$OUTPUT")
+  assert_command_succeeds \
+    "the reason must be repeated, not printed once and never again (seen $OCCURRENCES times)" \
+    test "$OCCURRENCES" -ge 2
+}
+
+function test_the_third_party_pcie_card_setting_is_applied_while_waiting_for_cpu_sensors() {
+  # It is a setting the user asked for, not a reaction to a temperature : a
+  # server whose CPU sensors never become readable would otherwise keep whatever
+  # cooling response state its iDRAC was left in, silently and indefinitely
+  export DISABLE_THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE=true
+  simulate_enclosure_management_controller "PowerEdge M1000e"
+
+  run_controller "No CPU temperature sensor could be read" > /dev/null
+
+  local -r COOLING_RESPONSE_CALLS=$(count_ipmitool_calls_matching "raw 0x30 0xce 0x00 0x16 0x05")
+  assert_command_succeeds \
+    "the user's third-party PCIe card cooling response setting must be applied while waiting (seen $COOLING_RESPONSE_CALLS times)" \
+    test "$COOLING_RESPONSE_CALLS" -ge 1
+}

--- a/tests/cases/55_enclosure_housed_servers.sh
+++ b/tests/cases/55_enclosure_housed_servers.sh
@@ -217,6 +217,11 @@ function test_the_controller_refuses_to_run_on_a_server_reporting_no_cpu_sensor(
   assert_contains "$OUTPUT" "sdr type temperature" "the user is told what to run"
   assert_contains "$OUTPUT" "github.com/tigerblue77/Dell_iDRAC_fan_controller_Docker/issues" \
     "and where to report it"
+  # The likeliest cause by far, and the only one the user can fix themselves :
+  # lm-sensors cannot rescue this one either, the fallback being local mode only
+  # and the enclosure rejecting the fan control commands anyway
+  assert_contains "$OUTPUT" "chassis management controller" \
+    "the chassis mistake is named first, being the likeliest cause"
 }
 
 function test_the_fans_are_handed_back_to_dell_before_refusing_to_run() {

--- a/tests/cases/55_enclosure_housed_servers.sh
+++ b/tests/cases/55_enclosure_housed_servers.sh
@@ -200,33 +200,49 @@ function test_aiming_the_controller_at_the_enclosure_instead_of_a_blade_fails_sa
     "no fan speed must be sent either"
 }
 
-function test_the_controller_keeps_saying_why_it_is_waiting_instead_of_going_silent() {
-  # A container that states its reason once at startup and then never prints
-  # anything again is indistinguishable from a hung one, and this is the state a
-  # user who aimed IDRAC_HOST at a chassis controller sits in permanently
+function test_the_controller_refuses_to_run_on_a_server_reporting_no_cpu_sensor() {
+  # Every PowerEdge has at least one CPU, and an iDRAC that exposes no processor
+  # entity exposes none on every check : waiting it out would leave a container
+  # that looks alive and supervises nothing. It has to say so and stop, with what
+  # the user needs to report the problem
   simulate_enclosure_management_controller "PowerEdge M1000e"
 
-  # Wait for the reason to have been printed more than once rather than for a
-  # temperature line, which this server can never produce
-  local -r OUTPUT=$(run_controller "No CPU temperature sensor could be read(.|\n)*No CPU temperature sensor could be read")
+  local OUTPUT
+  OUTPUT=$(run_controller "No CPU temperature sensor could be read")
+  local -r EXIT_CODE=$?
 
-  local -r OCCURRENCES=$(grep -c "No CPU temperature sensor could be read" <<< "$OUTPUT")
-  assert_command_succeeds \
-    "the reason must be repeated, not printed once and never again (seen $OCCURRENCES times)" \
-    test "$OCCURRENCES" -ge 2
+  assert_equals 1 "$EXIT_CODE" "the container must stop rather than wait forever"
+  assert_contains "$OUTPUT" "No CPU temperature sensor could be read"
+  assert_contains "$OUTPUT" "every PowerEdge has at least one CPU"
+  assert_contains "$OUTPUT" "sdr type temperature" "the user is told what to run"
+  assert_contains "$OUTPUT" "github.com/tigerblue77/Dell_iDRAC_fan_controller_Docker/issues" \
+    "and where to report it"
 }
 
-function test_the_third_party_pcie_card_setting_is_applied_while_waiting_for_cpu_sensors() {
-  # It is a setting the user asked for, not a reaction to a temperature : a
-  # server whose CPU sensors never become readable would otherwise keep whatever
-  # cooling response state its iDRAC was left in, silently and indefinitely
-  export DISABLE_THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE=true
+function test_the_fans_are_handed_back_to_dell_before_refusing_to_run() {
+  # A previous run of this container may have left the BMC in manual mode, in
+  # which case exiting without a word would leave the fans pinned at the user's
+  # low speed with nobody watching the temperatures. graceful_exit is not reached
+  # on this path, the trap only covering the termination signals
   simulate_enclosure_management_controller "PowerEdge M1000e"
 
   run_controller "No CPU temperature sensor could be read" > /dev/null
 
-  local -r COOLING_RESPONSE_CALLS=$(count_ipmitool_calls_matching "raw 0x30 0xce 0x00 0x16 0x05")
-  assert_command_succeeds \
-    "the user's third-party PCIe card cooling response setting must be applied while waiting (seen $COOLING_RESPONSE_CALLS times)" \
-    test "$COOLING_RESPONSE_CALLS" -ge 1
+  assert_equals "1" "$(count_ipmitool_calls_matching "raw 0x30 0x30 0x01 0x01")" \
+    "Dell's own dynamic profile must be applied before exiting"
+  assert_equals "0" "$(count_ipmitool_calls_matching "raw 0x30 0x30 0x02")" \
+    "and no fan speed must ever be sent on readings the controller never got"
+}
+
+function test_the_refusal_never_prints_the_idrac_password() {
+  # The message tells the user which ipmitool command to run, and the connection
+  # string the controller uses carries -P <password> : printing it would put the
+  # iDRAC password in the container logs
+  export IDRAC_PASSWORD="hunter2-should-never-be-logged"
+  simulate_enclosure_management_controller "PowerEdge M1000e"
+
+  local -r OUTPUT=$(run_controller "No CPU temperature sensor could be read")
+
+  assert_not_contains "$OUTPUT" "$IDRAC_PASSWORD" "the password must never reach the logs"
+  assert_contains "$OUTPUT" "<iDRAC password>" "the command is shown with a placeholder instead"
 }


### PR DESCRIPTION
Closes #221.

## What this replaces

#144 made a container whose server exposes no readable processor entity **wait** for one instead of exiting. This reverses that: it now stops, with an actionable message.

The premise the wait rested on — that the absence could be transient — does not hold. Every PowerEdge has at least one CPU, and an iDRAC that exposes no processor entity exposes none on every check. #219 relies on exactly that determinism to decide its own lm-sensors fallback: *"a firmware that exposes no processor entity says so on every single check; a busy or briefly unreachable BMC recovers."*

Retrying forever left a container that looked alive and supervised nothing — the worst of the three outcomes.

## What happens now

A server that answers IPMI, is a Dell, and reports no CPU temperature sensor gets this and exits 1 — reproduced end to end on the M1000e fixture, not transcribed:

```
/!\ Error /!\ No CPU temperature sensor could be read from DELL PowerEdge M1000e, and every PowerEdge has at least one CPU.
 If IDRAC_HOST points at a chassis management controller (VRTX, FX2, M1000e, MX7000), point it at a node's own iDRAC instead : the chassis hosts no CPU, and its CMC drives the enclosure fans rather than a node's.
 Otherwise, run "ipmitool -I lanplus -H <iDRAC IP address> -U <iDRAC username> -P <iDRAC password> sdr type temperature" (drop the connection options in local mode) and look for lines whose 4th column is an entity "3.<something>" and whose reading ends in "degrees C".
 If some are listed and the container still reports none, or if none is listed at all, please open an issue with your server model and that output : https://github.com/tigerblue77/Dell_iDRAC_fan_controller_Docker/issues
 Dell default dynamic fan control profile applied for safety before exiting. Exiting.
```

**The chassis mistake is named first** because it is the likeliest cause by far, and the only one the user can fix themselves — `lm-sensors` cannot rescue it either (see below).

**The Dell default profile is applied before leaving.** `graceful_exit` is not reached on this path — the trap only covers the termination signals — and a previous run of this container may have left the BMC in manual mode, which would keep the fans pinned at the user's low speed with nobody watching. On a chassis controller that command is itself rejected (`Invalid command`), which is expected and harmless: a CMC was never in manual mode to begin with. On a real server that reports no sensor, it lands. Either way no fan speed is ever sent.

**The command is shown with placeholders, not with `$IDRAC_LOGIN_STRING`.** That variable carries `-P <password>`, so printing it would put the iDRAC password in the container logs. Pinned by a test.

## What is untouched

**The powered-off branch still waits.** That absence really is transient, and the container is expected to outlive its server being powered off — exiting there would just make it restart in a loop.

**`functions.sh` is not modified at all**, nor is anything else: the diff is the entrypoint and one test file. An earlier revision of this branch had extracted master's third-party PCIe card block into a function to share it with the waiting loop; with that loop gone there is one caller left, so the extraction was dropped rather than carried as an unrelated refactor.

## Known, and not this PR's to fix

The line above the refusal runs into it — `Invalid command./!\ Error /!\ No CPU temperature sensor…` — because `print_error` does not terminate its line. That is #169, whose fix is #179.

## Interaction with #219

#219 falls back to lm-sensors, in local mode, after three consecutive checks with no readable CPU. **If #219 lands after this, the exit has to move behind that fallback** — otherwise the container dies before the fallback ever gets its three checks. Say which order you want and I will rebase.

This does not affect the chassis case: #219 refuses lm-sensors in network mode by design, a container cannot run on a CMC, and the enclosure rejects `raw 0x30 0x30` anyway.

## Tests

Three cases in `tests/cases/55_enclosure_housed_servers.sh`: the refusal and its message (including the chassis hint, an apostrophe that must not come out escaped, and the message not colliding with `print_error_and_exit`'s own sentence), the Dell profile being applied before exiting with no fan speed ever sent, and the password never reaching the logs.

**201 test cases, 1 skipped, 1265 assertions**, all passing.

Merged with master through #207, which replaced the inline `$(date ...)` substitutions with `set_log_timestamp` — this branch keeps its own structure and adopts that idiom for the one line it leaves behind, so no `$(date ...)` is left in the entrypoint.