### PR TITLE
Say when adopting a CPU renumbered the columns above it

### DIFF
--- a/Dell_iDRAC_fan_controller.sh
+++ b/Dell_iDRAC_fan_controller.sh
@@ -277,11 +277,27 @@ while true; do
     # been looking at, and with their entity so the line can be matched against an ipmitool output
     REMOVED_CPU_LABELS=()
     REMOVED_CPU_ENTITY_IDS=()
+    # Columns are numbered from 1 in entity order, so a CPU joining the table renumbers every column
+    # above it : an entity that was "CPU 2" becomes "CPU 3" when a lower entity becomes readable. That
+    # is reachable in normal use -- a socket slow to become readable after POST, or a CPU added while
+    # the server was powered off -- and unreported it makes an older "CPU 3 temperature is too high"
+    # comment and today's "CPU 3" column name two different physical sockets
+    RENUMBERED_CPU_DESCRIPTIONS=()
     for INDEX in "${!PREVIOUS_CPU_ENTITY_IDS[@]}"; do
       if [[ " ${DETECTED_CPU_ENTITY_IDS[*]} " != *" ${PREVIOUS_CPU_ENTITY_IDS[INDEX]} "* ]]; then
         REMOVED_CPU_LABELS+=("${PREVIOUS_CPU_LABELS[INDEX]}")
         REMOVED_CPU_ENTITY_IDS+=("${PREVIOUS_CPU_ENTITY_IDS[INDEX]}")
+        continue
       fi
+
+      for NEW_INDEX in "${!DETECTED_CPU_ENTITY_IDS[@]}"; do
+        if [ "${DETECTED_CPU_ENTITY_IDS[NEW_INDEX]}" == "${PREVIOUS_CPU_ENTITY_IDS[INDEX]}" ]; then
+          if [ "${DETECTED_CPU_LABELS[NEW_INDEX]}" != "${PREVIOUS_CPU_LABELS[INDEX]}" ]; then
+            RENUMBERED_CPU_DESCRIPTIONS+=("${PREVIOUS_CPU_LABELS[INDEX]} is now ${DETECTED_CPU_LABELS[NEW_INDEX]} (entity ${PREVIOUS_CPU_ENTITY_IDS[INDEX]})")
+          fi
+          break
+        fi
+      done
     done
 
     # A CPU leaving the table means one less heat source watched, which deserves more than the plain
@@ -294,6 +310,13 @@ while true; do
       printf "%19s  %s are considered removed from the server: their temperature sensors (entities %s) reported nothing on the %s readings that followed the server powering back on. %s.\n" "$(date +"%d-%m-%Y %T")" "$(join_with_and "${REMOVED_CPU_LABELS[@]}")" "$(join_with_and "${REMOVED_CPU_ENTITY_IDS[@]}")" "$CPU_REMOVAL_CONFIRMING_READINGS" "$(format_detected_CPU_temperature_sensors)"
     else
       printf "%19s  %s.\n" "$(date +"%d-%m-%Y %T")" "$(format_detected_CPU_temperature_sensors)"
+    fi
+
+    # Printed on its own line rather than folded into the ones above, so that it shows up whichever of
+    # them was taken : a CPU can be renumbered by another one joining, by another one leaving, or by
+    # both on the same cycle
+    if [ "${#RENUMBERED_CPU_DESCRIPTIONS[@]}" -gt 0 ]; then
+      printf "%19s  Columns were renumbered: %s. A comment naming a CPU refers to the numbering in force on the cycle it was printed.\n" "$(date +"%d-%m-%Y %T")" "$(join_with_and "${RENUMBERED_CPU_DESCRIPTIONS[@]}")"
     fi
 
     # Checked again here and not only at startup : a mis-parse can just as well show up mid-run

--- a/tests/cases/60_cpu_topologies.sh
+++ b/tests/cases/60_cpu_topologies.sh
@@ -403,3 +403,26 @@ function test_adopting_a_lower_entity_shifts_the_labels_above_it() {
   assert_equals "3.1 3.2 3.3 3.4" "${DETECTED_CPU_ENTITY_IDS[*]}"
   assert_equals "CPU 1 CPU 2 CPU 3 CPU 4" "${DETECTED_CPU_LABELS[*]}" "entity 3.3 is now CPU 3"
 }
+
+function test_removing_a_lower_entity_shifts_the_labels_above_it_too() {
+  # The direction that needs no CPU added at all : a socket other than the last
+  # one loses its CPU, and every surviving socket above it moves down a number.
+  # Entity 3.3 was CPU 3 and becomes CPU 2, which is exactly the case the removal
+  # rule already supports -- across a power cycle, once enough readings agree
+  export MOCK_IPMITOOL_SDR_OUTPUT
+  MOCK_IPMITOOL_SDR_OUTPUT=$(make_sdr_output --cpus 4 --cpu-temperatures "40 41 42 43")
+  detect_then_retrieve_temperatures
+  assert_equals "CPU 1 CPU 2 CPU 3 CPU 4" "${DETECTED_CPU_LABELS[*]}"
+
+  MOCK_IPMITOOL_SDR_OUTPUT=$(make_sdr_output --cpus 4 --cpu-temperatures "40 42 43" --cpu2-disabled)
+  IS_CPU_REMOVAL_ALLOWED=true
+  PENDING_CPU_REMOVAL_SIGNATURE=""
+
+  local READING
+  for ((READING = 1; READING <= CPU_REMOVAL_CONFIRMING_READINGS; READING++)); do
+    refresh_CPU_temperature_sensors "$(retrieve_sdr_temperature_data)"
+  done
+
+  assert_equals "3.1 3.3 3.4" "${DETECTED_CPU_ENTITY_IDS[*]}" "the socket 2 CPU is gone"
+  assert_equals "CPU 1 CPU 2 CPU 3" "${DETECTED_CPU_LABELS[*]}" "entity 3.3 was CPU 3 and is now CPU 2"
+}

--- a/tests/cases/60_cpu_topologies.sh
+++ b/tests/cases/60_cpu_topologies.sh
@@ -326,3 +326,21 @@ function test_a_socket_slow_to_become_readable_after_a_reboot_keeps_its_column()
   assert_equals "false" "$IS_CPU_REMOVAL_ALLOWED" "the server came back complete, nothing left to remove"
 }
 
+
+function test_adopting_a_lower_entity_shifts_the_labels_above_it() {
+  # The mechanism behind the renumbering notice the entrypoint prints : labels are
+  # recomputed from 1 in entity order on every refresh, so they are only stable
+  # for a fixed readable set
+  export MOCK_IPMITOOL_SDR_OUTPUT
+  MOCK_IPMITOOL_SDR_OUTPUT=$(make_sdr_output --cpus 4 --cpu-temperatures "41 39 38" --cpu2-disabled)
+  detect_then_retrieve_temperatures
+
+  assert_equals "3.1 3.3 3.4" "${DETECTED_CPU_ENTITY_IDS[*]}"
+  assert_equals "CPU 1 CPU 2 CPU 3" "${DETECTED_CPU_LABELS[*]}" "entity 3.3 is CPU 2 while 3.2 is silent"
+
+  MOCK_IPMITOOL_SDR_OUTPUT=$(make_sdr_output --cpus 4 --cpu-temperatures "41 40 39 38")
+  refresh_CPU_temperature_sensors "$(retrieve_sdr_temperature_data)"
+
+  assert_equals "3.1 3.2 3.3 3.4" "${DETECTED_CPU_ENTITY_IDS[*]}"
+  assert_equals "CPU 1 CPU 2 CPU 3 CPU 4" "${DETECTED_CPU_LABELS[*]}" "entity 3.3 is now CPU 3"
+}

--- a/tests/cases/90_integration.sh
+++ b/tests/cases/90_integration.sh
@@ -300,3 +300,22 @@ function test_a_removed_cpu_is_reported_as_removed_and_not_merely_as_silent() {
     "and the entities, so the line can be matched against an ipmitool output"
   assert_contains "$OUTPUT" "2 CPU temperature sensors detected (entities 3.1 3.2)."
 }
+
+function test_the_controller_says_when_adopting_a_cpu_renumbered_the_columns() {
+  # Columns are numbered from 1 in entity order, so a CPU joining renumbers every
+  # column above it : entity 3.3, shown as "CPU 2" while 3.2 was unreadable,
+  # becomes "CPU 3" once 3.2 answers. Unreported, an older "CPU 3 temperature is
+  # too high" comment and today's "CPU 3" column name two different sockets
+  simulate_server "PowerEdge R930" --cpus 4 --cpu-temperatures "41 39 38" --cpu2-disabled
+  export MOCK_IPMITOOL_SDR_SECOND_OUTPUT MOCK_IPMITOOL_SDR_SWITCH_AFTER_CALLS
+  MOCK_IPMITOOL_SDR_SECOND_OUTPUT=$(make_sdr_output --cpus 4 --cpu-temperatures "41 40 39 38")
+  MOCK_IPMITOOL_SDR_SWITCH_AFTER_CALLS=2
+
+  local -r OUTPUT=$(run_controller "Columns were renumbered")
+
+  assert_contains "$OUTPUT" "Columns were renumbered" "the renumbering must not pass silently"
+  assert_contains "$OUTPUT" "CPU 2 is now CPU 3 (entity 3.3)" \
+    "the line must name the entity, which is the only stable identifier across a renumbering"
+  assert_contains "$OUTPUT" "CPU 3 is now CPU 4 (entity 3.4)"
+  assert_contains "$OUTPUT" "4 CPU temperature sensors detected (entities 3.1 3.2 3.3 3.4)."
+}


### PR DESCRIPTION
Closes #222.

## The problem, in one sentence

Columns are numbered `CPU 1`, `CPU 2`, `CPU 3`… **from 1, in entity order, recomputed on every cycle** — so whenever the set of readable sockets changes, the sockets above the change get a different number, and nothing says so.

The clearest case needs **no CPU added at all**. A 4-socket server loses the CPU of socket 2:

```
before   entities 3.1 3.2 3.3 3.4   →  CPU 1  CPU 2  CPU 3  CPU 4
after    entities 3.1     3.3 3.4   →  CPU 1  CPU 2  CPU 3
```

Entity `3.3` was `CPU 3` and is now `CPU 2`. That is exactly the path the removal rule already implements — across a power cycle, once `CPU_REMOVAL_CONFIRMING_READINGS` readings agree.

The same thing happens in the other direction when a socket that was not readable becomes readable and sorts below one that already was — a socket slow to finish POSTing, or a CPU fitted while the server was powered off and the container kept running.

## Why it matters

`is_any_CPU_overheating()` names the hot socket with **today's** label. So a `CPU 3 temperature is too high` line in yesterday's log and the `CPU 3` column in today's table can be two different physical sockets, and the only line printed on the cycle it changed was the plain `3 CPU temperature sensors detected (entities 3.1 3.3 3.4).`

## The fix

One log line, on the cycle the set changes:

```
01-01-2024 00:00:00  3 CPU temperature sensors detected (entities 3.1 3.3 3.4).
01-01-2024 00:00:00  Columns were renumbered: CPU 3 is now CPU 2 (entity 3.3) and CPU 4 is now CPU 3 (entity 3.4). A comment naming a CPU refers to the numbering in force on the cycle it was printed.
```

The entity is named because it is the only identifier that survives a renumbering.

**Numbering behaviour is unchanged.** Labelling columns after their entity instance would be accurate and useless (a two-CPU server reading `CPU 0` / `CPU 96`), which is why #144 rejected it. This only makes the shift visible when it happens — and prints nothing when it doesn't.

## Honest scope

This comes from reading the code, not from a field report. It is a narrow case: it needs a socket other than the highest-numbered one to change state. The cost is one conditional and a log line that stays silent otherwise; the cost of not having it is a log that misleads about which socket a safety decision was made on. If you judge the case too remote to be worth the line, closing this and #222 is a reasonable call.

## Tests

Three cases: `60_cpu_topologies` pins both directions of the label shift (removal and adoption), `90_integration` pins the printed line end to end. **194 test cases, 1 skipped, 1247 assertions**, all passing.

Merged with master (#195, #215) without conflict. Compatible with #227.