### PR TITLE
Declare build_header and print_temperature_array_line locals

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -525,8 +525,11 @@ function build_header() {
 
   local header="                     ----" # Width ready for 1 CPU
 
-  # Calculate the number of dashes to add on each side of the title
-  number_of_dashes=$(((number_of_CPUs-1)*CPU_column_width/2))
+  # Calculate the number of dashes to add on each side of the title.
+  # Declared local like its neighbours: functions.sh is sourced into the entry point, so anything left
+  # undeclared here lands in the container's main shell
+  local -r number_of_dashes=$(((number_of_CPUs-1)*CPU_column_width/2))
+  local i
 
   # Loop to add dashes
   for ((i=1; i<=number_of_dashes; i++)); do
@@ -569,6 +572,9 @@ function print_temperature_array_line() {
 
   # Creating an array from the string
   local -r CPUs_temperatures_array=(${LOCAL_CPUS_TEMPERATURES//;/ })
+  # The loop variable below is the one that actually escapes: unlike build_header(), which the caller
+  # runs in a command substitution, this function is called directly on every cycle
+  local temperature
 
   printf "%19s  %s°C " "$(date +"%d-%m-%Y %T")" "$(format_temperature_for_display "$LOCAL_INLET_TEMPERATURE")"
   # Itération sur les températures dans le tableau


### PR DESCRIPTION
Closes #171.

Re-opens the branch left without a pull request when #181 was closed. Same single commit, rebased on the current tip of the stack.

## Problem

`functions.sh` is sourced by the entry point, so a variable a function forgets to declare is created in the container's main shell and stays there for the life of the container.

Three escape today:

| Variable | Function | Escapes because |
| --- | --- | --- |
| `number_of_dashes` | `build_header()` | plain assignment |
| `i` | `build_header()` | `for ((i=1; ...))` loop variable |
| `temperature` | `print_temperature_array_line()` | `for temperature in ...` loop variable |

`build_header()` is run in a command substitution, so its two only pollute the subshell — real but contained. `print_temperature_array_line()` is different: it is called **directly**, on every cycle of the monitoring loop, so `temperature` is written into the main shell every time and survives between cycles. That is the one #171 reports.

Nothing reads those names today, so this is a latent trap rather than a live bug: the next `temperature` or `i` added anywhere in the entry point silently shares storage with a loop that reassigns it every cycle.

## Change

Three declarations, no behaviour change.

- `number_of_dashes` becomes `local -r` — it is computed once and never reassigned, so the value is pinned as well as scoped.
- `i` and `temperature` become `local`. They are loop variables, so they cannot be `readonly`.

Each carries a short comment saying *why* the declaration is needed, since "sourced into the entry point" is the part that is not visible from the function itself.

This follows the file's existing convention: every other local in both functions — `header`, `CPUs_temperatures_array`, `CPU_column_width` — is already declared, which is what makes the three missing ones easy to overlook.

## Verification

```
$ ./tests/run_tests.sh
```

passes unchanged — the output of both functions is byte-identical before and after, which is the property that matters here.

Checked directly that the leak is gone, by sourcing `functions.sh`, calling `print_temperature_array_line`, and looking for the name afterwards:

```
before: temperature=45
after:  (unset)
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01LnM43wrpTSDSxcBZum6aPc)_