### PR TITLE
Say which columns an arriving CPU renumbered

### DIFF
--- a/Dell_iDRAC_fan_controller.sh
+++ b/Dell_iDRAC_fan_controller.sh
@@ -313,6 +313,19 @@ while true; do
       printf "%19s  %s.\n" "$(date +"%d-%m-%Y %T")" "$(format_detected_CPU_temperature_sensors)"
     fi
 
+    # A CPU joining the set can sort before the ones already there, which shifts the labels above it :
+    # the column a reader was calling "CPU 2" becomes "CPU 3", and the overheating comments printed from
+    # here on use the new name. Said explicitly, on the cycle it happens, so that an older line and a
+    # newer one can't be read as naming the same socket
+    PREVIOUS_CPU_ENTITY_ID_LABEL_PAIRS=()
+    for INDEX in "${!PREVIOUS_CPU_ENTITY_IDS[@]}"; do
+      PREVIOUS_CPU_ENTITY_ID_LABEL_PAIRS+=("${PREVIOUS_CPU_ENTITY_IDS[INDEX]}=${PREVIOUS_CPU_LABELS[INDEX]}")
+    done
+    RELABELLED_CPUS=$(format_relabelled_CPUs "${PREVIOUS_CPU_ENTITY_ID_LABEL_PAIRS[@]}")
+    if [ -n "$RELABELLED_CPUS" ]; then
+      printf "%19s  %s.\n" "$(date +"%d-%m-%Y %T")" "$RELABELLED_CPUS"
+    fi
+
     # Checked again here and not only at startup : a mis-parse can just as well show up mid-run
     warn_if_unexpected_number_of_CPUs
 

--- a/functions.sh
+++ b/functions.sh
@@ -533,6 +533,47 @@ function format_detected_CPU_temperature_sensors() {
   fi
 }
 
+# Names the CPUs whose column label moved while the sensor behind it stayed the same, or nothing when
+# none did.
+# Usage : format_relabelled_CPUs "3.1=CPU 1" "3.3=CPU 2"...
+#
+# Labels are handed out 1, 2, 3... in entity order on every refresh, so adopting a CPU whose entity sorts
+# before an already-monitored one shifts every label above it. The entity list logged on the same cycle
+# does say what the new numbering is, but nothing says the old one is no longer valid : a reader
+# correlating a "CPU 3 temperature is too high" comment with an earlier "CPU 3" column would be looking
+# at two different sockets. This is the line that says so, on the cycle it happens
+#
+# The previous pairs are passed as "entity=label" because an entity ID holds no space and a label does,
+# which makes the split unambiguous whatever the label ends up being
+function format_relabelled_CPUs() {
+  local -r -a PREVIOUS_CPU_ENTITY_ID_LABEL_PAIRS=("$@")
+
+  local -a RELABELLINGS=()
+  local PAIR PREVIOUS_CPU_ENTITY_ID PREVIOUS_CPU_LABEL INDEX
+  for PAIR in "${PREVIOUS_CPU_ENTITY_ID_LABEL_PAIRS[@]}"; do
+    PREVIOUS_CPU_ENTITY_ID="${PAIR%%=*}"
+    PREVIOUS_CPU_LABEL="${PAIR#*=}"
+
+    for INDEX in "${!DETECTED_CPU_ENTITY_IDS[@]}"; do
+      [ "${DETECTED_CPU_ENTITY_IDS[INDEX]}" == "$PREVIOUS_CPU_ENTITY_ID" ] || continue
+      if [ "${DETECTED_CPU_LABELS[INDEX]}" != "$PREVIOUS_CPU_LABEL" ]; then
+        # Only the first fragment carries the verb, the rest reading as a list under it :
+        # "CPU 3 was previously reported as CPU 2, CPU 4 as CPU 3 and CPU 5 as CPU 4"
+        if (( ${#RELABELLINGS[@]} == 0 )); then
+          RELABELLINGS+=("${DETECTED_CPU_LABELS[INDEX]} was previously reported as $PREVIOUS_CPU_LABEL")
+        else
+          RELABELLINGS+=("${DETECTED_CPU_LABELS[INDEX]} as $PREVIOUS_CPU_LABEL")
+        fi
+      fi
+      break
+    done
+  done
+
+  (( ${#RELABELLINGS[@]} > 0 )) || return 0
+
+  printf '%s' "$(join_with_and "${RELABELLINGS[@]}")"
+}
+
 # Warns when more CPU temperature sensors are detected than any Dell server has sockets.
 # Usage : warn_if_unexpected_number_of_CPUs
 #

--- a/tests/cases/60_cpu_topologies.sh
+++ b/tests/cases/60_cpu_topologies.sh
@@ -385,3 +385,104 @@ function test_every_cpu_going_silent_at_once_never_empties_the_table() {
       "reading $READING left the table intact"
   done
 }
+
+# Labels are handed out in entity order on every refresh, so a CPU joining the set
+# renumbers every column above it. Nothing said so, and the overheating comments
+# printed afterwards use the new numbering : an older "CPU 3" column and a newer
+# "CPU 3 temperature is too high" comment could name two different sockets.
+# format_relabelled_CPUs() is what makes the shift readable, on the cycle it happens.
+#
+# The previous labels are passed as "entity=label" pairs, which is what the entry
+# point builds from the arrays it saved before the refresh.
+function previous_CPU_entity_id_label_pairs() {
+  local INDEX
+  for INDEX in "${!DETECTED_CPU_ENTITY_IDS[@]}"; do
+    printf '%s\n' "${DETECTED_CPU_ENTITY_IDS[INDEX]}=${DETECTED_CPU_LABELS[INDEX]}"
+  done
+}
+
+function test_adopting_a_cpu_that_sorts_first_reports_the_columns_it_renumbered() {
+  # The reproduction from issue #222 : 3.2 becomes readable, so the socket the user
+  # was reading as "CPU 2" is now "CPU 3"
+  export MOCK_IPMITOOL_SDR_OUTPUT
+  MOCK_IPMITOOL_SDR_OUTPUT=$(make_sdr_output --cpus 4 --cpu-temperatures "41 40 39 38")
+  MOCK_IPMITOOL_SDR_OUTPUT=$(printf '%s\n' "$MOCK_IPMITOOL_SDR_OUTPUT" | grep -v ' 3\.2 ')
+  detect_then_retrieve_temperatures
+  assert_equals "3.1 3.3 3.4" "${DETECTED_CPU_ENTITY_IDS[*]}"
+  assert_equals "CPU 1 CPU 2 CPU 3" "${DETECTED_CPU_LABELS[*]}"
+
+  local -a PREVIOUS_PAIRS
+  mapfile -t PREVIOUS_PAIRS < <(previous_CPU_entity_id_label_pairs)
+
+  MOCK_IPMITOOL_SDR_OUTPUT=$(make_sdr_output --cpus 4 --cpu-temperatures "41 42 39 38")
+  refresh_CPU_temperature_sensors "$(retrieve_sdr_temperature_data)"
+  assert_equals "3.1 3.2 3.3 3.4" "${DETECTED_CPU_ENTITY_IDS[*]}" "the socket that woke up is adopted"
+
+  assert_equals "CPU 3 was previously reported as CPU 2 and CPU 4 as CPU 3" \
+    "$(format_relabelled_CPUs "${PREVIOUS_PAIRS[@]}")" \
+    "both columns above the adopted CPU are named, old label and new"
+}
+
+function test_a_cpu_appearing_after_the_known_ones_renumbers_nothing() {
+  # The common case : the adopted entity sorts last, so every existing column keeps
+  # its label and there is nothing to report
+  export MOCK_IPMITOOL_SDR_OUTPUT
+  MOCK_IPMITOOL_SDR_OUTPUT=$(make_sdr_output --cpus 2 --cpu-temperatures "40 41")
+  detect_then_retrieve_temperatures
+
+  local -a PREVIOUS_PAIRS
+  mapfile -t PREVIOUS_PAIRS < <(previous_CPU_entity_id_label_pairs)
+
+  MOCK_IPMITOOL_SDR_OUTPUT=$(make_sdr_output --cpus 4 --cpu-temperatures "40 41 42 43")
+  refresh_CPU_temperature_sensors "$(retrieve_sdr_temperature_data)"
+  assert_equals "3.1 3.2 3.3 3.4" "${DETECTED_CPU_ENTITY_IDS[*]}"
+
+  assert_empty "$(format_relabelled_CPUs "${PREVIOUS_PAIRS[@]}")" \
+    "CPU 1 and CPU 2 still name the same sockets, so the line stays quiet"
+}
+
+function test_a_cpu_leaving_the_set_reports_the_columns_it_renumbered_too() {
+  # The symmetric case : a confirmed removal closes the gap it leaves behind, which
+  # shifts the labels above it just as much as an arrival does
+  export MOCK_IPMITOOL_SDR_OUTPUT
+  MOCK_IPMITOOL_SDR_OUTPUT=$(make_sdr_output --cpus 4 --cpu-temperatures "40 41 42 43")
+  detect_then_retrieve_temperatures
+
+  local -a PREVIOUS_PAIRS
+  mapfile -t PREVIOUS_PAIRS < <(previous_CPU_entity_id_label_pairs)
+
+  # The server has just been powered back on with its second CPU removed
+  IS_CPU_REMOVAL_ALLOWED=true
+  PENDING_CPU_REMOVAL_SIGNATURE=""
+  MOCK_IPMITOOL_SDR_OUTPUT=$(make_sdr_output --cpus 4 --cpu-temperatures "40 41 42 43")
+  MOCK_IPMITOOL_SDR_OUTPUT=$(printf '%s\n' "$MOCK_IPMITOOL_SDR_OUTPUT" | grep -v ' 3\.2 ')
+  local -r SDR_DATA=$(retrieve_sdr_temperature_data)
+
+  local READING
+  for ((READING = 1; READING <= CPU_REMOVAL_CONFIRMING_READINGS; READING++)); do
+    refresh_CPU_temperature_sensors "$SDR_DATA"
+  done
+  assert_equals "3.1 3.3 3.4" "${DETECTED_CPU_ENTITY_IDS[*]}" "the removal is confirmed"
+
+  assert_equals "CPU 2 was previously reported as CPU 3 and CPU 3 as CPU 4" \
+    "$(format_relabelled_CPUs "${PREVIOUS_PAIRS[@]}")" \
+    "the two columns that moved down are named"
+}
+
+function test_a_relabelling_is_reported_for_a_single_column_without_an_enumeration() {
+  # One moved column must read as a sentence, not as a list of one
+  DETECTED_CPU_ENTITY_IDS=("3.1" "3.2")
+  DETECTED_CPU_LABELS=("CPU 1" "CPU 2")
+
+  assert_equals "CPU 2 was previously reported as CPU 1" \
+    "$(format_relabelled_CPUs "3.2=CPU 1")"
+}
+
+function test_a_cpu_that_left_the_set_is_not_reported_as_relabelled() {
+  # A removed CPU has no current label to compare against : it is reported by the
+  # removal line, and must not turn up here as well
+  DETECTED_CPU_ENTITY_IDS=("3.1")
+  DETECTED_CPU_LABELS=("CPU 1")
+
+  assert_empty "$(format_relabelled_CPUs "3.1=CPU 1" "3.2=CPU 2")"
+}

--- a/tests/cases/90_integration.sh
+++ b/tests/cases/90_integration.sh
@@ -346,3 +346,23 @@ function test_a_removed_cpu_is_reported_as_removed_and_not_merely_as_silent() {
     "and the entities, so the line can be matched against an ipmitool output"
   assert_contains "$OUTPUT" "2 CPU temperature sensors detected (entities 3.1 3.2)."
 }
+
+function test_a_cpu_joining_the_set_says_which_columns_it_renumbered() {
+  # A socket slow to become readable after POST joins the set on a later cycle,
+  # and its entity sorts before two that are already monitored. Every label above
+  # it moves up by one, so the "CPU 3" the reader was looking at is now "CPU 4" --
+  # and the overheating comments printed from here on use the new numbering.
+  # The count line alone does not say that, hence the second line
+  simulate_server "PowerEdge R930" --cpus 4 --cpu-temperatures "41 40 39 38"
+  MOCK_IPMITOOL_SDR_OUTPUT=$(printf '%s\n' "$MOCK_IPMITOOL_SDR_OUTPUT" | grep -v ' 3\.2 ')
+  export MOCK_IPMITOOL_SDR_SECOND_OUTPUT MOCK_IPMITOOL_SDR_SWITCH_AFTER_CALLS
+  MOCK_IPMITOOL_SDR_SECOND_OUTPUT=$(make_sdr_output --cpus 4 --cpu-temperatures "41 40 39 38")
+  MOCK_IPMITOOL_SDR_SWITCH_AFTER_CALLS=2
+
+  local -r OUTPUT=$(run_controller "was previously reported as")
+
+  assert_contains "$OUTPUT" "4 CPU temperature sensors detected (entities 3.1 3.2 3.3 3.4)." \
+    "the adopted socket is monitored"
+  assert_contains "$OUTPUT" "CPU 3 was previously reported as CPU 2 and CPU 4 as CPU 3." \
+    "and the columns it pushed up are named, old label and new"
+}


### PR DESCRIPTION
Closes #222, implementing the issue's **option 1** — say so in the log on the cycle it happens.

## Problem

`set_detected_CPU_temperature_sensors()` hands labels out `1, 2, 3...` in entity order on **every** refresh, so adopting a CPU whose entity sorts before an already-monitored one shifts every label above it:

```
readable entities  3.1 3.3 3.4    →  CPU 1  CPU 2  CPU 3
3.2 becomes readable
readable entities  3.1 3.2 3.3 3.4 →  CPU 1  CPU 2  CPU 3  CPU 4
```

Entity `3.3` was `CPU 2` and is now `CPU 3`. `is_any_CPU_overheating()` names the hot socket with the **new** label, and the only line logged on that cycle was the plain count:

```
4 CPU temperature sensors detected (entities 3.1 3.2 3.3 3.4).
```

Nothing said the existing columns had been renamed, so a reader correlating a `CPU 3 temperature is too high` comment with an earlier `CPU 3` column could be looking at two different physical sockets.

## Change

A new line, printed right after the count line and only when something actually moved:

```
01-01-2024 00:00:00  4 CPU temperature sensors detected (entities 3.1 3.2 3.3 3.4).
01-01-2024 00:00:00  CPU 3 was previously reported as CPU 2 and CPU 4 as CPU 3.
```

`format_relabelled_CPUs()` compares the label each **entity** carries now with the one it carried before the refresh, so it reports the columns that moved and nothing else. The previous pairs reach it as `"3.1=CPU 1"` strings: an entity ID holds no space and a label does, which makes the split unambiguous.

Three properties fall out of comparing by entity rather than by position:

- **a CPU that left is not reported here.** It has no current label to compare against, and the removal line already names it — it must not turn up twice.
- **a confirmed removal is covered too**, without a second code path. Removing entity `3.2` from `3.1 3.2 3.3 3.4` closes the gap and pushes `CPU 3`/`CPU 4` down to `CPU 2`/`CPU 3`, which shifts labels exactly as much as an arrival does.
- **the common case stays quiet.** A CPU whose entity sorts *after* the known ones renumbers nothing, so no line is printed.

Only the first fragment carries the verb, the rest reading as a list under it, so several moved columns stay one sentence: `CPU 3 was previously reported as CPU 2, CPU 4 as CPU 3 and CPU 5 as CPU 4`.

## Scope

Diagnosability only. No fan behaviour, no reading, no column and no label changes — the labels shift exactly as they did before, the shift is simply stated now.

Options 2 (document it in the README instead) and 3 (leave it) from the issue remain open; this is the one that keeps a pasted log self-sufficient, which is how the README already asks users to report problems.

The unrelated observation at the end of #222 — the unreachable `No CPU temperature could be read` branch, `Dell_iDRAC_fan_controller.sh:351` on this branch — is deliberately **left in place**, for the reason given there: it is a belt-and-braces guard on the safety path. (#239 is what makes it reachable, by monitoring a server that exposes no processor entity at all. The two PRs touch different lines and do not conflict.)

## Tests

Full suite on the current `master`: **201 test cases passed, 1 skipped (1251 assertions)**.

Six cases added:

- `tests/cases/60_cpu_topologies.sh` — the issue's own reproduction (`3.1 3.3 3.4` then `3.2` waking up); a CPU appended after the known ones renumbering nothing; a confirmed removal closing its gap; a single moved column reading as a sentence rather than a list of one; a removed CPU not being reported as relabelled.
- `tests/cases/90_integration.sh` — the same arrival driven through the real entry point, asserting both lines in the container's output.

**Four of the six fail without the change**, checked by putting `master`'s two source files back under the new tests:

```
$ git checkout origin/master -- Dell_iDRAC_fan_controller.sh functions.sh
$ ./tests/run_tests.sh -f "renumber|relabel"
  fail adopting a cpu that sorts first reports the columns it renumbered
  ok   a cpu appearing after the known ones renumbers nothing
  fail a cpu leaving the set reports the columns it renumbered too
  fail a relabelling is reported for a single column without an enumeration
  ok   a cpu that left the set is not reported as relabelled
  fail a cpu joining the set says which columns it renumbered
4 test cases failed, 2 passed
```

The two that pass either way are the ones asserting **silence** — no renumbering to report — which holds with or without the feature. They are kept because they are what pins the "stays quiet" half of the contract.

`master` was merged into this branch on 8 August (no conflict) and the suite re-run against it.