### PR TITLE
Stop the test suite from creating an IPMI device under /dev

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -187,6 +187,20 @@ function validate_check_interval_parameter() {
   fi
 }
 
+# Where the Linux IPMI driver exposes its character device, under the three names it has carried across
+# kernel versions and distributions. Local mode needs one of them to be visible inside the container.
+#
+# Kept in a variable rather than written into the check so that the test suite can point the lookup at a
+# file of its own : /dev is machine-global, and creating the real path there to exercise the "device is
+# present" branch is what used to make two runs on the same machine interfere with each other, one
+# silently skipping a case the other had made unreachable.
+#
+# It is out of reach of the container's environment all the same, being an array : bash cannot export
+# one, so "docker run -e IPMI_DEVICE_PATHS=..." cannot reach this. Declared here rather than in
+# constants.sh because healthcheck.sh sources this file alone, and it takes the local mode path too.
+# Not readonly, that being the whole point
+IPMI_DEVICE_PATHS=("/dev/ipmi0" "/dev/ipmi/0" "/dev/ipmidev/0")
+
 # Set the IDRAC_LOGIN_STRING variable based on connection type
 # Usage : set_iDRAC_login_string $IDRAC_HOST $IDRAC_USERNAME $IDRAC_PASSWORD
 # Returns : IDRAC_LOGIN_STRING
@@ -200,8 +214,20 @@ function set_iDRAC_login_string() {
   # Check if the iDRAC host is set to 'local' or not then set the IDRAC_LOGIN_STRING accordingly
   if [[ "$IDRAC_HOST" == "local" ]]; then
     # Check that the Docker host IPMI device (the iDRAC) has been exposed to the Docker container
-    if [ ! -e "/dev/ipmi0" ] && [ ! -e "/dev/ipmi/0" ] && [ ! -e "/dev/ipmidev/0" ]; then
-      print_error_and_exit "Could not open device at /dev/ipmi0 or /dev/ipmi/0 or /dev/ipmidev/0, check that you added the device to your Docker container or stop using local mode"
+    local IPMI_DEVICE_PATH
+    local IS_IPMI_DEVICE_EXPOSED=false
+    for IPMI_DEVICE_PATH in "${IPMI_DEVICE_PATHS[@]}"; do
+      if [ -e "$IPMI_DEVICE_PATH" ]; then
+        IS_IPMI_DEVICE_EXPOSED=true
+        break
+      fi
+    done
+
+    if ! $IS_IPMI_DEVICE_EXPOSED; then
+      # A device path holds no space, so joining on the separator is enough to enumerate them the way
+      # the error always has : "/dev/ipmi0 or /dev/ipmi/0 or /dev/ipmidev/0"
+      local -r IPMI_DEVICE_PATHS_ENUMERATION="${IPMI_DEVICE_PATHS[*]}"
+      print_error_and_exit "Could not open device at ${IPMI_DEVICE_PATHS_ENUMERATION// / or }, check that you added the device to your Docker container or stop using local mode"
     fi
     IDRAC_LOGIN_STRING='open'
   else

--- a/tests/cases/30_idrac_login_string.sh
+++ b/tests/cases/30_idrac_login_string.sh
@@ -5,44 +5,87 @@
 # ("lanplus"). Everything else in the script depends on the login string built
 # here, and the password must never leak into the container's process list.
 
-function test_local_mode_uses_the_open_interface() {
-  local IPMI_DEVICE_CREATED=false
+# Local mode looks the IPMI character device up through IPMI_DEVICE_PATHS, so the
+# cases below point it at a file of their own inside the run's temporary directory
+# rather than at /dev, which is machine-global. Both branches of the lookup are
+# then reachable on any machine, whether or not it has a real IPMI device, and two
+# runs sharing a machine cannot make each other skip or fail.
+function fake_IPMI_device() {
+  local -r FAKE_IPMI_DEVICE="$TEST_TEMPORARY_DIRECTORY/ipmi0"
 
-  if [ ! -e /dev/ipmi0 ] && [ ! -e /dev/ipmi/0 ] && [ ! -e /dev/ipmidev/0 ]; then
-    # No real IPMI device here : fake the one the function looks for. /dev is
-    # only writable when the suite runs as root (in the Docker image, or in a
-    # CI container), so give up gracefully rather than fail elsewhere
-    if ! (mkdir -p /dev/ipmi && touch /dev/ipmi/0) 2> /dev/null; then
-      skip_test "no IPMI device available and /dev is not writable"
-      return 0
-    fi
-    IPMI_DEVICE_CREATED=true
-  fi
+  touch "$FAKE_IPMI_DEVICE"
+  IPMI_DEVICE_PATHS=("$FAKE_IPMI_DEVICE")
+}
+
+function no_IPMI_device() {
+  IPMI_DEVICE_PATHS=("$TEST_TEMPORARY_DIRECTORY/absent/ipmi0")
+}
+
+function test_local_mode_uses_the_open_interface() {
+  fake_IPMI_device
 
   set_iDRAC_login_string "local" "root" "calvin"
-  assert_equals "open" "$IDRAC_LOGIN_STRING"
 
-  if $IPMI_DEVICE_CREATED; then
-    rm -f /dev/ipmi/0
-    rmdir /dev/ipmi 2> /dev/null
-  fi
+  assert_equals "open" "$IDRAC_LOGIN_STRING"
+}
+
+function test_local_mode_accepts_any_of_the_device_paths_the_driver_may_use() {
+  # The driver has exposed its device under three different names, and only one of
+  # them is ever present : finding the last one must work as well as the first
+  local -r FAKE_IPMI_DEVICE="$TEST_TEMPORARY_DIRECTORY/ipmidev_0"
+  touch "$FAKE_IPMI_DEVICE"
+  IPMI_DEVICE_PATHS=("$TEST_TEMPORARY_DIRECTORY/absent0" "$TEST_TEMPORARY_DIRECTORY/absent1" "$FAKE_IPMI_DEVICE")
+
+  set_iDRAC_login_string "local" "root" "calvin"
+
+  assert_equals "open" "$IDRAC_LOGIN_STRING"
 }
 
 function test_local_mode_stops_the_controller_when_no_ipmi_device_is_exposed() {
-  if [ -e /dev/ipmi0 ] || [ -e /dev/ipmi/0 ] || [ -e /dev/ipmidev/0 ]; then
-    skip_test "this machine really has an IPMI device"
-    return 0
-  fi
+  no_IPMI_device
 
   local OUTPUT
   OUTPUT=$(set_iDRAC_login_string "local" "root" "calvin" 2>&1)
   local -r EXIT_CODE=$?
 
   assert_equals 1 "$EXIT_CODE" "local mode without an IPMI device should stop the controller"
-  assert_contains "$OUTPUT" "/dev/ipmi0" "the error should name the device paths that were looked for"
-  assert_contains "$OUTPUT" "/dev/ipmi/0"
-  assert_contains "$OUTPUT" "/dev/ipmidev/0"
   assert_contains "$OUTPUT" "stop using local mode" "the error should tell the user how to recover"
+}
+
+function test_the_error_enumerates_every_path_that_was_looked_for() {
+  # The paths in the error are what a user matches against their --device flag, so
+  # every one that was tried has to appear, joined the way the message always has
+  IPMI_DEVICE_PATHS=("$TEST_TEMPORARY_DIRECTORY/absent0" "$TEST_TEMPORARY_DIRECTORY/absent1" "$TEST_TEMPORARY_DIRECTORY/absent2")
+
+  local OUTPUT
+  OUTPUT=$(set_iDRAC_login_string "local" "root" "calvin" 2>&1)
+
+  assert_contains "$OUTPUT" "Could not open device at $TEST_TEMPORARY_DIRECTORY/absent0 or $TEST_TEMPORARY_DIRECTORY/absent1 or $TEST_TEMPORARY_DIRECTORY/absent2,"
+}
+
+function test_the_shipped_lookup_is_the_three_paths_the_driver_may_use() {
+  # Asserted on the list itself rather than through the error, so that the case
+  # holds identically on a machine that does have a real IPMI device.
+  # Re-sourcing functions.sh in a subshell is what restores the shipped list
+  assert_equals "/dev/ipmi0 /dev/ipmi/0 /dev/ipmidev/0" \
+    "$(source "$REPO_ROOT/functions.sh"; printf '%s' "${IPMI_DEVICE_PATHS[*]}")"
+}
+
+function test_the_suite_never_writes_the_ipmi_device_to_dev() {
+  # /dev is machine-global : creating the real path there to exercise the "device
+  # is present" branch is what used to make two runs on the same machine interfere,
+  # one silently skipping a case the other had made unreachable, and what left an
+  # empty /dev/ipmi behind on a developer's machine. Regression test for issue #190
+  local DEVICE_CREATED_UNDER_DEV
+  DEVICE_CREATED_UNDER_DEV=$(grep -rnE '(^|[[:space:]])(mkdir|touch|ln|cp|mv|rm|rmdir)[[:space:]][^;|&]*/dev/ipmi' "$TESTS_DIRECTORY" || true)
+
+  assert_empty "$DEVICE_CREATED_UNDER_DEV" \
+    "no test may create or delete a device under /dev : the lookup is injectable for that reason"
+
+  fake_IPMI_device
+  set_iDRAC_login_string "local" "root" "calvin"
+
+  assert_equals "open" "$IDRAC_LOGIN_STRING" "and the present-device branch is still covered"
 }
 
 function test_network_mode_builds_a_lanplus_login_string() {


### PR DESCRIPTION
Closes #190, taking the direction suggested there — make the device path the controller looks for injectable, defaulting to the three real ones.

## Problem

`tests/cases/30_idrac_login_string.sh` reached the "an IPMI device exists" branch of `set_iDRAC_login_string "local"` by creating the real path on the machine running the suite, and the next case decided what to do by looking at that same global path. `/dev` was the one place the suite wrote outside its own temporary directory, and both consequences described in the issue follow from it: two runs on the same machine interfere, and a run as root outside a container leaves an empty `/dev/ipmi` behind whenever an assertion fails before the best-effort cleanup.

## Change

`functions.sh` grows one variable:

```bash
IPMI_DEVICE_PATHS=("/dev/ipmi0" "/dev/ipmi/0" "/dev/ipmidev/0")
```

and the check walks it instead of naming the three paths inline. The error keeps its exact wording — the paths hold no space, so joining the array on its separator reproduces `at /dev/ipmi0 or /dev/ipmi/0 or /dev/ipmidev/0` — and now enumerates whatever was actually looked for.

Two placement decisions worth the review:

- **In `functions.sh`, not `constants.sh`.** `healthcheck.sh` sources `functions.sh` alone and takes the local mode path too, so a list living in `constants.sh` would leave the healthcheck walking an empty one and failing on every local-mode container. `functions.sh` already declares state at top level (`IS_CPU_REMOVAL_ALLOWED`, `PENDING_CPU_REMOVAL_*`), so this follows the file's existing shape.
- **Not `readonly`.** Being writable after sourcing is what makes it a seam; the tests run each case in a subshell, so a `readonly` set in the parent could not be overridden.

## The seam does not become a user-facing knob

It is an **array**, and bash cannot export one. `docker run -e IPMI_DEVICE_PATHS=...` therefore cannot reach it: it stays available to anything that *sources* `functions.sh`, which is the test suite and the healthcheck, and invisible to the container's environment. No new parameter to document, and nothing a user can set by accident.

The cost of that choice is stated plainly: an integration case that starts the controller as a **separate process** cannot inject through it either. That is why `test_auto_is_resolved_from_lm_sensors_in_local_mode` in `tests/cases/22_cpu_temperature_threshold.sh` still skips on a machine without a real IPMI device — it only ever *read* `/dev`, so it is not part of this defect, and it is left exactly as it was. Making the seam an exportable colon-separated string would un-skip it, at the price of a real environment variable users can set; happy to switch if you would rather have the coverage.

## Tests

Full suite: **203 test cases passed, 1 skipped (1414 assertions)** — the skip being the unrelated case above.

`tests/cases/30_idrac_login_string.sh` no longer names a path under `/dev` at all:

- `local mode uses the open interface` and `local mode stops the controller when no ipmi device is exposed` point the lookup at the run's temporary directory. **Neither skips any more**, on any machine.
- `local mode accepts any of the device paths the driver may use` covers a device found at the *last* candidate, which no case exercised before.
- `the error enumerates every path that was looked for` pins the joined message.
- `the shipped lookup is the three paths the driver may use` pins the default list itself, asserted on the array rather than through the error so that it holds identically on a machine that does have a real device.
- `the suite never writes the ipmi device to dev` is the regression test: it greps the whole `tests/` tree for anything creating or deleting a path under `/dev/ipmi`, so the next case tempted to take that shortcut fails the suite.

Verified that two suites now run at once without interfering, which was the point:

```
$ ./tests/run_tests.sh & ./tests/run_tests.sh & wait
203 test cases passed, 1 skipped (1414 assertions)
203 test cases passed, 1 skipped (1414 assertions)
```

Both exit 0, with the same single skip — before, one of them skipped a case the other had made unreachable. Nothing is left under `/dev` afterwards.

No production behaviour changes: the same three paths are checked, in the same order, and the error reads exactly as it did.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LnM43wrpTSDSxcBZum6aPc)_