### PR TITLE
Stop a power supply's intake from answering for the chassis one

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -364,9 +364,12 @@ function retrieve_temperature_by_sensor_name() {
   local -r SDR_DATA="$1"
   local -r SENSOR_NAME="$2"
 
-  # On the (unexpected) event of several sensors matching the name, the last one wins, as it did when
-  # the reading was picked with "grep -Po ... | tail -1"
-  local -r SDR_LINE=$(echo "$SDR_DATA" | grep "$SENSOR_NAME" | tail -1)
+  # The name is matched at the start of the line, the sensor name being the first pipe-delimited column.
+  # Matching it anywhere would let "PSU1 Inlet Temp" and "PSU2 Inlet Temp" -- which most servers with
+  # redundant power supplies report -- answer for "Inlet Temp", and the last of them would win, so the
+  # intake column showed a power supply's own intake instead of the chassis air intake (issue #231).
+  # tail -1 is kept for the genuinely unexpected case of two sensors sharing the same leading name
+  local -r SDR_LINE=$(echo "$SDR_DATA" | grep -E "^[[:space:]]*$SENSOR_NAME" | tail -1)
 
   extract_temperature_from_sdr_line "$SDR_LINE"
 }

--- a/tests/cases/40_temperature_parsing.sh
+++ b/tests/cases/40_temperature_parsing.sh
@@ -130,10 +130,21 @@ function test_inlet_and_exhaust_are_told_apart_by_their_name() {
   assert_equals "36" "$(retrieve_temperature_by_sensor_name "$SDR_DATA" "Exhaust")"
 }
 
-function test_the_last_matching_sensor_wins_when_several_share_a_name() {
-  # Big chassis report one inlet sensor per power supply on top of the main one
+function test_a_power_supplys_own_intake_does_not_answer_for_the_chassis_one() {
+  # Most servers with redundant power supplies report "PSU1 Inlet Temp" and
+  # "PSU2 Inlet Temp" alongside the chassis "Inlet Temp". All three contain
+  # "Inlet", so a match anywhere on the line let a power supply's own intake --
+  # several degrees hotter, sitting downstream of its own losses -- be displayed
+  # as the server's air intake (issue #231).
+  #
+  # This test used to assert the opposite. It was written while building the
+  # suite, took the behaviour for intentional because the comment above it said
+  # "on the unexpected event of several sensors matching", and pinned a defect
+  # instead of reporting it
   local -r SDR_DATA=$(make_sdr_output --inlet 21 --exhaust 36 --with-extra-sensors)
 
-  assert_equals "30" "$(retrieve_temperature_by_sensor_name "$SDR_DATA" "Inlet")" \
-    "PSU2 Inlet Temp is the last line matching \"Inlet\""
+  assert_equals "21" "$(retrieve_temperature_by_sensor_name "$SDR_DATA" "Inlet")" \
+    "the chassis air intake is what the Inlet column is about"
+  assert_equals "36" "$(retrieve_temperature_by_sensor_name "$SDR_DATA" "Exhaust")" \
+    "the exhaust sensor is unaffected, but goes through the same matching rule"
 }


### PR DESCRIPTION
Closes #231.

`retrieve_temperature_by_sensor_name()` matched the sensor name anywhere on the line and kept the last match. Most servers with redundant power supplies report their own intake sensors alongside the chassis one, and all three contain `Inlet`:

```
Inlet Temp       | 04h | ok  |  7.1 | 21 degrees C   <- the air intake
PSU1 Inlet Temp  | 68h | ok  | 10.1 | 29 degrees C
PSU2 Inlet Temp  | 69h | ok  | 10.2 | 30 degrees C   <- what was displayed
```

The `Inlet` column reported **30°C** on a server whose air intake was **21°C**.

## Why it is worth fixing

Nothing overheats because of it — the inlet is displayed, never used for fan control. What it costs is diagnosis: the intake temperature is the first thing anyone looks at when a server runs hot, and a power supply's intake sits downstream of its own losses, so the number was systematically several degrees too high. #<!---->49 and #<!---->120 both want to *act* on that reading; either would have inherited the wrong sensor.

## The change

The sensor name is the first pipe-delimited column, so anchoring the match to the start of the line separates `Inlet Temp` from `PSU1 Inlet Temp` without needing a list of names to exclude:

```diff
-  local -r SDR_LINE=$(echo "$SDR_DATA" | grep "$SENSOR_NAME" | tail -1)
+  local -r SDR_LINE=$(echo "$SDR_DATA" | grep -E "^[[:space:]]*$SENSOR_NAME" | tail -1)
```

`tail -1` is kept for the genuinely unexpected case of two sensors sharing the same leading name. `Exhaust` was unaffected in practice — no Dell sensor name contains it as a substring — but it goes through the same rule and is now asserted too.

## About the test

`test_the_last_matching_sensor_wins_when_several_share_a_name` asserted the **old** behaviour, with `--with-extra-sensors` set up precisely to produce those PSU lines. I wrote it while building the suite, took the behaviour for intentional because the comment above the code called several matches "unexpected", and pinned a defect instead of reporting it.

It is now `test_a_power_supplys_own_intake_does_not_answer_for_the_chassis_one`, asserting the opposite, with a note saying why it changed sides.

191 test cases pass, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KYig22vJGjq4UbFDPDCwDB