### PR TITLE
Guard the two .env.example parameters the Dockerfile cannot declare

### DIFF
--- a/tests/cases/10_shell_scripts.sh
+++ b/tests/cases/10_shell_scripts.sh
@@ -174,6 +174,34 @@ function test_the_env_example_offers_every_parameter_the_image_declares() {
   done < <(grep -E '^ENV [A-Z_]+=' "$REPO_ROOT/Dockerfile" | sed 's/^ENV //' | cut -d= -f1)
 }
 
+function test_the_env_example_offers_every_parameter_the_readme_documents() {
+  # The test above can only see what the Dockerfile declares, and the Dockerfile
+  # declares no ENV for IDRAC_USERNAME and IDRAC_PASSWORD : they are credentials,
+  # they have no default to ship. So the two parameters .env.example exists for
+  # in the first place are precisely the two its guard does not cover. Dropping
+  # either of them from the file leaves the whole suite green.
+  # The README's own parameter bullets are the list that does include them
+  if [ ! -f "$REPO_ROOT/README.md" ] || [ ! -f "$REPO_ROOT/.env.example" ]; then
+    # The suite is running inside the built image, which carries neither the
+    # README (excluded by .dockerignore) nor the example file shipped beside it
+    skip_test "no README and .env.example next to the scripts"
+    return 0
+  fi
+
+  # Space padded on both ends so a key can be matched whole, as above
+  local ENV_EXAMPLE_KEYS=" "
+  local LINE
+  while IFS= read -r LINE; do
+    ENV_EXAMPLE_KEYS+="${LINE%%=*} "
+  done < <(grep -E '^[A-Z_]+=' "$REPO_ROOT/.env.example")
+
+  local KEY
+  while IFS= read -r KEY; do
+    assert_contains "$ENV_EXAMPLE_KEYS" " $KEY " \
+      "$KEY is documented in the README, .env.example should show users how to set it"
+  done < <(grep -oE '^- `[A-Z_]+`' "$REPO_ROOT/README.md" | tr -d '`' | sed 's/^- //')
+}
+
 function test_the_healthcheck_succeeds_when_the_sensors_can_be_read() {
   local OUTPUT
   OUTPUT=$(bash "$REPO_ROOT/healthcheck.sh" 2>&1)


### PR DESCRIPTION
Closes #243.

One test case, no production code touched.

## The gap

`test_the_env_example_offers_every_parameter_the_image_declares` derives its expected list from the Dockerfile's `ENV` declarations — seven parameters. `IDRAC_USERNAME` and `IDRAC_PASSWORD` declare no `ENV`, because credentials ship no default, so the guard never looks for them. The two parameters `.env.example` exists for are the two it does not cover.

The gap is structural: the Dockerfile can never declare these two, so tightening the existing test cannot reach them.

## The change

A second case deriving its list from the README's parameter bullets, which do include the credentials — nine entries against seven. Same space-padded whole-key matching as the existing test, so `IDRAC_HOST` is not matched by a key merely containing it.

It skips when the README is absent: `.dockerignore` excludes `README.md`, so the copy of the suite that runs inside the built image has none to read. Without that guard the case reads an empty list, records no assertion and fails there — which is what took the previous attempt at this check red in the "Run the test suite inside the Docker image" job.

## Verification

Three conditions, all checked locally:

```
1) nominal
  ok   the env example offers every parameter the image declares (7 assertions)
  ok   the env example offers every parameter the readme documents (9 assertions)

2) IDRAC_USERNAME removed from .env.example
  ok   the env example offers every parameter the image declares (7 assertions)
  fail the env example offers every parameter the readme documents
       IDRAC_USERNAME is documented in the README, .env.example should show users how to set it

3) README absent, as inside the image
  ok   the env example offers every parameter the image declares (7 assertions)
  skip the env example offers every parameter the readme documents (no README and .env.example next to the scripts)
```

Case 2 is the regression the existing guard lets through: on `master` it leaves the suite fully green at 200 passed.

Full suite: **192 test cases passed, 1 skipped (1245 assertions)**, plus `bash -n` on the modified file.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EFjLY2aJbxq62wU4Dnrx5p)_