### PR TITLE
Assert that no boolean parameter is ever dispatched unquoted

### DIFF
--- a/tests/cases/10_shell_scripts.sh
+++ b/tests/cases/10_shell_scripts.sh
@@ -255,3 +255,33 @@ function test_the_healthcheck_fails_when_the_sensors_cannot_be_read() {
 
   assert_not_equals 0 "$EXIT_CODE" "the healthcheck should fail when ipmitool fails, so Docker restarts the container"
 }
+
+function test_no_boolean_parameter_is_dispatched_unquoted() {
+  # The boolean parameters are dispatched by running their value as a command
+  # ("if $MONITORING_ONLY_MODE"). validate_boolean_parameter() is what makes that
+  # idiom safe, and the call sites deliberately keep it rather than being
+  # rewritten -- so the invariant it rests on has to hold at every one of them.
+  #
+  # Quoting is the part that stops a value carrying arguments from running with
+  # them, should any dispatch ever be reached before the validation: a new
+  # parameter, the validation block moving, or a value reassigned mid-run. #166
+  # measured what that costs (MONITORING_ONLY_MODE=yes runs /usr/bin/yes, fills
+  # the log at hundreds of MB/s and defers the graceful_exit trap so that
+  # docker stop cannot end the container).
+  #
+  # It drifted once already: #166 asked for the quoting, #217 delivered the
+  # validation and 8 of the 9 quotes, and the 9th was only caught later (#245).
+  local -r BOOLEAN_PARAMETERS='MONITORING_ONLY_MODE|DISABLE_THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE|KEEP_THIRD_PARTY_PCIE_CARD_COOLING_RESPONSE_STATE_ON_EXIT'
+  local SCRIPT UNQUOTED
+  for SCRIPT in "$REPO_ROOT"/*.sh; do
+    [ -f "$SCRIPT" ] || continue
+
+    # Comments quote the idiom while explaining it, so they are skipped
+    UNQUOTED=$(grep -nE "^[^#]*\bif !? ?\\\$($BOOLEAN_PARAMETERS)\b" "$SCRIPT" || true)
+    if [ -z "$UNQUOTED" ]; then
+      pass
+    else
+      fail "${SCRIPT#$REPO_ROOT/} dispatches a boolean parameter unquoted" "$UNQUOTED"
+    fi
+  done
+}


### PR DESCRIPTION
Closes #245. **Scope reduced since this PR was opened**: `master` has made the one-line fix moot, so only the guard remains.

## What changed under it

#245 reported one unquoted dispatch left at `Dell_iDRAC_fan_controller.sh:207`, in the "no CPU temperature sensor could be read, waiting..." branch. `master` has since **restructured that block away** — the wait now ends in `print_error_and_exit` rather than looping with a per-mode message — and the line went with it.

Checked against current `master`: **zero** unquoted boolean dispatches remain, in either shipped script. The fix this PR carried is no longer needed, so it is gone from the diff. What is left is one test file.

## Why the guard is still worth merging

The boolean parameters are dispatched by running their value as a command (`if $MONITORING_ONLY_MODE`). `validate_boolean_parameter()`'s own comment states the trade the codebase rests on:

> Refusing anything but the two literals is what makes that idiom safe, which is why the call sites keep it instead of being rewritten.

That holds only while the validation is reachable before every dispatch. Quoting is what stops a value carrying arguments from *running with them* should a dispatch ever be reached first — a new parameter, the validation block moving, or a value reassigned mid-run. #166 measured the cost: `MONITORING_ONLY_MODE=yes` runs `/usr/bin/yes`, fills the log at hundreds of MB/s, and defers the `graceful_exit` trap so `docker stop` cannot end the container.

**It has already drifted once.** #166 asked for both the validation and the quoting; #217 delivered the validation and 8 of the 9 quotes; the 9th surfaced only later, and master fixed it incidentally rather than deliberately. Nothing would have caught it, and nothing would catch the next one.

## Verified to fail, not merely to pass

A lint-style assertion that cannot fail is exactly the shape #205 warns about, so it was checked in both directions. Unquoting a dispatch in either shipped script makes it report the file and the line:

```
fail no boolean parameter is dispatched unquoted
     functions.sh dispatches a boolean parameter unquoted
```

Restoring the quotes makes it green. Comments are skipped, since they quote the idiom while explaining it.

## Verification

**203 test cases pass**, 1 skipped (1275 assertions), on current `master`. The diff is a single test file, +30 lines, with no production change.