### PR TITLE
Keep a trailing comment out of the lists the docker actions parse

### DIFF
--- a/tests/cases/12_github_workflows.sh
+++ b/tests/cases/12_github_workflows.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+# The two workflows that publish the image are the only ones no pull request
+# ever runs : "Docker image CI" fires on a version tag, "Base image refresh" on
+# a schedule. A mistake in either is found at release time, or the morning
+# after, by which point it has already cost a release or a night's rebuild.
+# This is where they get read anyway.
+
+function test_no_docker_action_list_entry_ends_with_a_comment() {
+  # docker/metadata-action reads its multi-line inputs with a CSV parser it asks
+  # to treat "#" as a comment. Up to v5 that stripped a "#" found anywhere on the
+  # line, so a note could sit at the end of an image name and disappear before
+  # the action read it. From v6 on only a "#" that STARTS a line is a comment and
+  # a trailing one is kept, because a "#" belongs inside values such as a URL
+  # fragment or a label. Both "images" entries were written in the older form, so
+  # the bump to v6 resolved them to "owner/image # docker.io/owner/image" : an
+  # invalid reference the action accepts without a word, failing later at the
+  # push, in the one workflow no pull request would have caught it in.
+  #
+  # A note about a list entry belongs above the key, where YAML strips it and the
+  # action never sees it at all. On its own line inside the block it works too,
+  # but there it is data whose indentation is load-bearing : one extra space and
+  # it silently becomes an image name again, which is the trap this guards.
+  if [ ! -d "$REPO_ROOT/.github/workflows" ]; then
+    # The suite is running inside the built image, which does not carry the
+    # workflows that built it
+    skip_test "no .github/workflows next to the scripts"
+    return 0
+  fi
+
+  # The multi-line inputs the docker/* actions parse this way. Their single-line
+  # form needs no guard : there the "#" is a YAML comment, stripped before the
+  # action is handed anything
+  local -r PARSED_LIST_INPUTS='images|tags|labels|flavor|annotations|build-args|cache-from|cache-to|platforms|outputs|no-cache-filters|allow|attests'
+
+  local WORKFLOW
+  for WORKFLOW in "$REPO_ROOT"/.github/workflows/*.yml "$REPO_ROOT"/.github/workflows/*.yaml; do
+    [ -f "$WORKFLOW" ] || continue
+
+    # Character classes spelled out rather than [[:space:]] : the suite runs on
+    # mawk on the runner and on GNU awk inside the image, and this form is read
+    # the same way by both
+    local TRAILING_COMMENTS
+    TRAILING_COMMENTS=$(awk -v inputs="$PARSED_LIST_INPUTS" '
+      FNR == 1 { in_block = 0 }
+
+      # A block scalar opens on "<key>: |", and only the listed keys are read by
+      # a parser that gives "#" a meaning
+      $0 ~ "^[ \t]*(" inputs "):[ \t]*[|>]" {
+        in_block = 1
+        key_indent = match($0, /[^ \t]/) - 1
+        next
+      }
+
+      in_block {
+        # A blank line inside a block scalar is content, not its end
+        if ($0 ~ /^[ \t]*$/) next
+
+        # The block ends where the indentation returns to the key or above it
+        if (match($0, /[^ \t]/) - 1 <= key_indent) {
+          in_block = 0
+          next
+        }
+
+        # A value, then a "#" : the form v6 keeps. A line whose first character
+        # is the "#" is a comment to the parser too, so it is left alone
+        if ($0 ~ /^[ \t]*[^ \t#][^#]*#/) {
+          printf "  line %d: %s\n", FNR, $0
+        }
+      }
+    ' "$WORKFLOW")
+
+    if [ -z "$TRAILING_COMMENTS" ]; then
+      pass
+    else
+      fail "${WORKFLOW#$REPO_ROOT/} ends a list entry with a comment, which the action reads as part of the value" \
+        "$TRAILING_COMMENTS"
+    fi
+  done
+}


### PR DESCRIPTION
Closes #247.

The bump of `docker/metadata-action` to v6 in #237 changed which `#` is a comment: up to v5 one found anywhere on the line was stripped, from v6 on only one that starts a line is, so that a `#` can live inside a value such as a URL fragment. Both `images` entries were written in the older form, so the bump resolved them to `owner/image # docker.io/owner/image`, an invalid reference the action reports nothing about and that fails at the push.

Those four lines were fixed inside #237. This is the guard against them coming back, because nothing else here would say so:

- `Docker image CI` runs on a version tag and `Base image refresh` on a schedule, so no pull request ever exercises either;
- to a YAML linter the whole block is opaque scalar content, so the mistake is invisible to `actionlint`;
- `metadata-action` emits the broken reference silently, so the run only fails a job later.

The suite is the one thing here a pull request does run, hence its place. It reads the workflows the way the actions do: the block scalars of the inputs a `docker/*` action parses with a comment character, flagging a line that carries a value before its `#` and leaving alone one that starts with it. It follows the guards already in `tests/cases/10_shell_scripts.sh`, which cross-check the Dockerfile against the README and `.env.example` for the same kind of drift.

One new file, `tests/cases/12_github_workflows.sh`. No workflow or controller change.

## Checked

- Passes on master as it stands, five assertions, one per workflow file.
- Reintroducing the trailing comment on `build_and_publish_docker_image.yml` fails it, naming the file and quoting the offending line:
  ```
  fail no docker action list entry ends with a comment
       .github/workflows/build_and_publish_docker_image.yml ends a list entry with a comment, which the action reads as part of the value
           line 125:             ${{ steps.docker_image_name.outputs.value }} # docker.io/tigerblue77/dell_idrac_fan_controller
  ```
- A note on its own line inside the block still passes: it is the valid form, only a fragile one.
- Full suite green: 198 cases, 1256 assertions.
- The awk spells its character classes out rather than using `[[:space:]]`, because the suite runs on mawk on the runner and on GNU awk inside the image.

## Note

The single-line form of these inputs needs no guard: there the `#` is a YAML comment, stripped before the action is handed anything. Only block scalars are read.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MnSTY14YCqLSgb4HduAnzA)_