### PR TITLE
Add a supervisor process as PID 1, so the fans are handed back even when the controller cannot do it itself

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,9 @@ ADD functions.sh /app/functions.sh
 ADD constants.sh /app/constants.sh
 ADD healthcheck.sh /app/healthcheck.sh
 ADD Dell_iDRAC_fan_controller.sh /app/Dell_iDRAC_fan_controller.sh
+ADD supervisor.sh /app/supervisor.sh
 
-RUN chmod 0777 /app/functions.sh /app/healthcheck.sh /app/Dell_iDRAC_fan_controller.sh
+RUN chmod 0777 /app/functions.sh /app/healthcheck.sh /app/Dell_iDRAC_fan_controller.sh /app/supervisor.sh
 
 WORKDIR /app
 
@@ -30,4 +31,4 @@ ENV DISABLE_THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE=false
 ENV KEEP_THIRD_PARTY_PCIE_CARD_COOLING_RESPONSE_STATE_ON_EXIT=false
 ENV MONITORING_ONLY_MODE=false
 
-ENTRYPOINT ["./Dell_iDRAC_fan_controller.sh"]
+ENTRYPOINT ["./supervisor.sh"]

--- a/constants.sh
+++ b/constants.sh
@@ -44,3 +44,7 @@ readonly MINIMUM_CPU_COLUMN_CONTENT_WIDTH=5
 # slow to become readable after POST, and monitoring one heat source less until it shows up again
 readonly CPU_REMOVAL_CONFIRMING_READINGS=5
 
+# How long the supervisor gives the monitoring process to stop on its own after forwarding it the signal,
+# before killing it outright. Docker's own grace period is 10 seconds by default, so this has to stay
+# comfortably inside it or the container is SIGKILLed as a whole before the supervisor gets to act
+readonly SUPERVISOR_GRACE_PERIOD_IN_SECONDS=3

--- a/supervisor.sh
+++ b/supervisor.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+
+# Supervisor : the container's PID 1, whose only job is to make sure the fans are handed back to Dell's
+# dynamic profile when the container stops, even when the monitoring process cannot do it itself.
+#
+# The monitoring process normally does it, in graceful_exit(). It sometimes cannot : a SIGTERM landing
+# while bash is expanding a command substitution corrupts its parser, so the trap fails to parse and the
+# handler never runs, and in a third of those cases bash does not even exit -- it wedges and ignores the
+# signal until docker's ten second grace period runs out and SIGKILL takes it (issues #188 and #249).
+# Nothing running inside that shell can recover from it, which is why this runs in a shell of its own.
+#
+# This process spends effectively all of its life blocked in "wait", with no command substitution in
+# flight, which is precisely the state where a trap parses cleanly. It runs no loop, formats nothing and
+# reads no sensor : everything it does happens once, either at startup or on the way out.
+#
+# Usage : supervisor.sh [COMMAND [ARGUMENT...]]
+# The command defaults to the monitoring process, ./Dell_iDRAC_fan_controller.sh
+
+source functions.sh
+source constants.sh
+
+# The monitoring process is started through "bash" rather than executed directly, because its executable
+# bit is not what the repository tracks : the file is a regular 644 one and only the image's "chmod 0777"
+# makes it runnable. Running it from anywhere else -- the test suite, a clone, a bind mount -- would fail
+# with "Permission denied" and the container would stop before it ever started monitoring anything
+if [ "$#" -gt 0 ]; then
+  readonly MONITORED_COMMAND=("$@")
+else
+  readonly MONITORED_COMMAND=(bash ./Dell_iDRAC_fan_controller.sh)
+fi
+
+# Whether a signal was ever forwarded to the monitored process.
+#
+# This is what keeps the safety net from firing at a server the monitoring process refused to run on. A
+# container that stops because CHECK_INTERVAL was unusable, because the iDRAC never answered or because
+# the server is not a Dell exits on its own, without this supervisor signalling anything, and must be
+# left alone : sending a fan control command to a machine the controller deliberately declined to touch
+# would be worse than the problem this file exists to solve
+SIGNAL_WAS_FORWARDED=false
+
+# Hand the fans back to Dell's dynamic fan control profile, on the way out and on this process's behalf.
+#
+# Only ever called after the monitored process has gone without doing it itself. Applying the profile
+# twice would be harmless -- it is the same idempotent IPMI command -- but saying so twice in the log
+# would not, so the caller decides
+function apply_Dell_default_fan_control_profile_on_behalf_of_the_monitoring_process() {
+  if "$MONITORING_ONLY_MODE"; then
+    print_warning "Monitoring process stopped without exiting cleanly. Monitoring only mode, so no fan control profile was ever applied and none is applied now"
+    printf "\n"
+    return 0
+  fi
+
+  print_warning "Monitoring process stopped without handing the fans back. Applying Dell default dynamic fan control profile for safety"
+  printf "\n"
+
+  apply_Dell_default_fan_control_profile
+
+  if ! "$KEEP_THIRD_PARTY_PCIE_CARD_COOLING_RESPONSE_STATE_ON_EXIT"; then
+    enable_third_party_PCIe_card_Dell_default_cooling_response
+  fi
+}
+
+# Stop the monitored process, giving it a chance to stop itself first.
+#
+# It is asked with the signal it traps, then given SUPERVISOR_GRACE_PERIOD_IN_SECONDS to run its own
+# graceful_exit(). A process that is still there afterwards is one whose trap never ran -- the wedged
+# case -- and no further signal it can catch will change that, so it is killed outright. Docker's own
+# grace period is ten seconds by default, so this deadline has to be comfortably inside it or the
+# container is SIGKILLed as a whole before this ever gets to act
+function stop_the_monitored_process() {
+  SIGNAL_WAS_FORWARDED=true
+
+  kill -TERM "$MONITORED_PROCESS_PID" 2> /dev/null
+
+  local WAITED_TENTHS_OF_A_SECOND=0
+  local -r DEADLINE_IN_TENTHS_OF_A_SECOND=$((SUPERVISOR_GRACE_PERIOD_IN_SECONDS * 10))
+  while [ "$WAITED_TENTHS_OF_A_SECOND" -lt "$DEADLINE_IN_TENTHS_OF_A_SECOND" ]; do
+    kill -0 "$MONITORED_PROCESS_PID" 2> /dev/null || break
+    sleep 0.1
+    WAITED_TENTHS_OF_A_SECOND=$((WAITED_TENTHS_OF_A_SECOND + 1))
+  done
+
+  if kill -0 "$MONITORED_PROCESS_PID" 2> /dev/null; then
+    print_warning "Monitoring process did not stop within ${SUPERVISOR_GRACE_PERIOD_IN_SECONDS}s, killing it"
+    printf "\n"
+    kill -KILL "$MONITORED_PROCESS_PID" 2> /dev/null
+  fi
+}
+
+trap 'stop_the_monitored_process' SIGINT SIGQUIT SIGTERM
+
+# The login string is built here too : the monitored process builds its own, and this one needs it to be
+# able to send the safety command without it. Its output is dropped so the username is not logged twice
+set_iDRAC_login_string "$IDRAC_HOST" "$IDRAC_USERNAME" "$IDRAC_PASSWORD" > /dev/null
+
+"${MONITORED_COMMAND[@]}" &
+MONITORED_PROCESS_PID=$!
+
+# "wait" is interrupted by the trap, so this returns either when the monitored process ended on its own
+# or once stop_the_monitored_process() has dealt with it
+MONITORED_PROCESS_EXIT_CODE=0
+wait "$MONITORED_PROCESS_PID" 2> /dev/null || MONITORED_PROCESS_EXIT_CODE=$?
+
+if $SIGNAL_WAS_FORWARDED; then
+  # A "wait" cut short by a trap reports the signal that interrupted it (128 + 15), not what the process
+  # it was waiting for did. Only bash's own "wait" reaps a background job, so the process has not been
+  # reaped yet and this second call collects its real status : 0 if its graceful_exit() ran, the signal
+  # that killed it otherwise
+  MONITORED_PROCESS_EXIT_CODE=0
+  wait "$MONITORED_PROCESS_PID" 2> /dev/null || MONITORED_PROCESS_EXIT_CODE=$?
+fi
+
+if ! $SIGNAL_WAS_FORWARDED; then
+  # The monitored process stopped by itself : it refused to start, or it stopped for a reason of its own.
+  # Either way nothing here has any business sending it IPMI commands
+  exit "$MONITORED_PROCESS_EXIT_CODE"
+fi
+
+if [ "$MONITORED_PROCESS_EXIT_CODE" -ne 0 ]; then
+  # It was signalled and did not stop cleanly : either its graceful_exit() never ran, or it had to be
+  # killed. In both cases the fans are still on whatever profile was last applied
+  apply_Dell_default_fan_control_profile_on_behalf_of_the_monitoring_process
+fi
+
+exit 0

--- a/tests/README.md
+++ b/tests/README.md
@@ -34,6 +34,7 @@ It exits `0` when every test case passed, `1` otherwise.
 | `cases/80_temperature_thresholds.sh` | The overheating decision, including its fail-safe behavior |
 | `cases/85_power_state.sh` | Skipping the cycle when the target server is powered off |
 | `cases/90_integration.sh` | The whole controller, started like its Docker image does |
+| `cases/95_supervisor.sh` | The supervisor, and the fan handover it guarantees when the controller cannot do it itself |
 
 Server generations are covered from the catalogue in
 `lib/dell_server_catalogue.sh`, which lists more than a hundred PowerEdge models

--- a/tests/cases/10_shell_scripts.sh
+++ b/tests/cases/10_shell_scripts.sh
@@ -56,8 +56,35 @@ function test_every_file_sourced_at_runtime_is_shipped_in_the_docker_image() {
     assert_matches "$DOCKERFILE_CONTENT" "(ADD|COPY) $SOURCED_FILE " \
       "$SOURCED_FILE is sourced at runtime, the Dockerfile must copy it into the image"
   done < <(grep -hoE '^source [A-Za-z0-9_.-]+\.sh' \
-    "$REPO_ROOT/Dell_iDRAC_fan_controller.sh" "$REPO_ROOT/healthcheck.sh" |
+    "$REPO_ROOT/Dell_iDRAC_fan_controller.sh" "$REPO_ROOT/healthcheck.sh" "$REPO_ROOT/supervisor.sh" |
     awk '{print $2}' | sort -u)
+}
+
+function test_the_docker_images_entrypoint_is_shipped_in_it() {
+  # The entrypoint is the one file whose absence makes the image start nothing at
+  # all, and it is the only script not reached by the "sourced at runtime" scan
+  # above : nothing sources it, the container execs it
+  if [ ! -f "$REPO_ROOT/Dockerfile" ]; then
+    skip_test "no Dockerfile next to the scripts"
+    return 0
+  fi
+
+  local -r DOCKERFILE_CONTENT=$(cat "$REPO_ROOT/Dockerfile")
+  local -r ENTRYPOINT_SCRIPT=$(grep -oE '^ENTRYPOINT \["\./[A-Za-z0-9_.-]+\.sh"' "$REPO_ROOT/Dockerfile" |
+    grep -oE '[A-Za-z0-9_.-]+\.sh')
+
+  assert_not_empty "$ENTRYPOINT_SCRIPT" "the Dockerfile must declare a script as its ENTRYPOINT" || return 1
+
+  if [ -f "$REPO_ROOT/$ENTRYPOINT_SCRIPT" ]; then
+    pass
+  else
+    fail "$ENTRYPOINT_SCRIPT is the image's ENTRYPOINT but does not exist"
+  fi
+
+  assert_matches "$DOCKERFILE_CONTENT" "(ADD|COPY) $ENTRYPOINT_SCRIPT " \
+    "$ENTRYPOINT_SCRIPT is the image's ENTRYPOINT, the Dockerfile must copy it into the image"
+  assert_matches "$DOCKERFILE_CONTENT" "chmod [0-7]+ .*/$ENTRYPOINT_SCRIPT" \
+    "$ENTRYPOINT_SCRIPT is exec'd by the container, the image must make it executable"
 }
 
 function test_the_test_context_starts_from_the_docker_images_defaults() {

--- a/tests/cases/95_supervisor.sh
+++ b/tests/cases/95_supervisor.sh
@@ -1,0 +1,235 @@
+#!/bin/bash
+
+# The supervisor, the container's PID 1. Its only job is to make sure the fans are handed back to Dell's
+# dynamic profile when the container stops, including in the cases where the monitoring process cannot do
+# it itself : the SIGTERM parse failure of issue #188, and the wedged shell of issue #249 that ignores the
+# signal entirely until docker's grace period runs out.
+#
+# It is driven here with stand-in commands rather than the real monitoring process, because the failures
+# it exists for are precisely the ones the real one cannot be made to produce on demand : a shell whose
+# parser is corrupted is a race, not a switch. The stand-ins reproduce what the supervisor actually sees —
+# a child that exits cleanly, one that exits without cleaning up, one that ignores the signal, one that
+# refused to start — which is all it has to decide on.
+
+# Write a stand-in for the monitoring process into the test's temporary directory, and print its path
+# Usage : MONITORED=$(write_stand_in_monitoring_process <<'EOF' ... EOF)
+function write_stand_in_monitoring_process() {
+  local -r STAND_IN="$TEST_TEMPORARY_DIRECTORY/stand_in_monitoring_process.sh"
+
+  cat > "$STAND_IN"
+  chmod +x "$STAND_IN"
+  printf '%s' "$STAND_IN"
+}
+
+# Run the supervisor against a stand-in, stop it with SIGTERM the way "docker stop" does, and print its
+# output. Its exit code is returned
+# Usage : OUTPUT=$(run_supervisor "$STAND_IN" [SECONDS_BEFORE_SIGNALLING])
+function run_supervisor() {
+  local -r STAND_IN="$1"
+  local -r SECONDS_BEFORE_SIGNALLING="${2:-0.4}"
+  local -r OUTPUT_FILE="$TEST_TEMPORARY_DIRECTORY/supervisor_output"
+
+  : > "$OUTPUT_FILE"
+
+  local EXIT_CODE=0
+  (
+    cd "$REPO_ROOT" || exit 1
+
+    bash ./supervisor.sh "$STAND_IN" > "$OUTPUT_FILE" 2>&1 &
+    SUPERVISOR_PID=$!
+
+    command -p sleep "$SECONDS_BEFORE_SIGNALLING"
+    kill -TERM "$SUPERVISOR_PID" 2> /dev/null
+    wait "$SUPERVISOR_PID"
+  ) || EXIT_CODE=$?
+
+  cat "$OUTPUT_FILE"
+  return "$EXIT_CODE"
+}
+
+# Run the supervisor the way the Dockerfile's ENTRYPOINT does -- with no argument at all, so it starts
+# the real monitoring process -- until the temperature table shows it is running, then stop it with
+# SIGTERM. Its output is printed and its exit code returned
+# Usage : OUTPUT=$(run_supervisor_with_no_argument)
+function run_supervisor_with_no_argument() {
+  local -r OUTPUT_FILE="$TEST_TEMPORARY_DIRECTORY/supervisor_output"
+  # 400 polls of 20ms : 8 seconds, only ever reached when nothing is printed at all, which is what the
+  # assertions then report
+  local -r MAXIMUM_POLLS=400
+
+  : > "$OUTPUT_FILE"
+
+  local EXIT_CODE=0
+  (
+    cd "$REPO_ROOT" || exit 1
+
+    bash ./supervisor.sh > "$OUTPUT_FILE" 2>&1 &
+    SUPERVISOR_PID=$!
+
+    POLLS=0
+    while [ "$POLLS" -lt "$MAXIMUM_POLLS" ]; do
+      kill -0 "$SUPERVISOR_PID" 2> /dev/null || break
+      grep -qE "$CONTROLLER_TEMPERATURE_LINE_PATTERN" "$OUTPUT_FILE" && break
+      command -p sleep 0.02
+      POLLS=$((POLLS + 1))
+    done
+
+    kill -TERM "$SUPERVISOR_PID" 2> /dev/null
+    wait "$SUPERVISOR_PID"
+  ) || EXIT_CODE=$?
+
+  cat "$OUTPUT_FILE"
+  return "$EXIT_CODE"
+}
+
+function test_the_supervisor_starts_the_monitoring_process_from_a_plain_checkout() {
+  # The monitoring process is tracked as a regular 644 file : only the image's "chmod 0777" makes it
+  # executable, so a supervisor running it directly dies with "Permission denied" and exit code 126
+  # before monitoring anything. Every other test case here passes its stand-in as an argument and made
+  # its own executable, which is precisely why none of them saw it
+  local OUTPUT
+  OUTPUT=$(run_supervisor_with_no_argument)
+  local -r EXIT_CODE=$?
+
+  assert_equals 0 "$EXIT_CODE" "the supervisor must not fail to start the monitoring process"
+  assert_not_contains "$OUTPUT" "Permission denied" \
+    "the monitoring process must be started in a way its file mode cannot break"
+  assert_matches "$OUTPUT" "$CONTROLLER_TEMPERATURE_LINE_PATTERN" \
+    "the monitoring process really ran, rather than the supervisor idling on nothing"
+  assert_equals "1" "$(count_ipmitool_calls_matching "raw 0x30 0x30 0x01 0x01")" \
+    "and its own graceful exit handed the fans back, without the supervisor having to"
+}
+
+function test_a_monitoring_process_that_stops_cleanly_is_left_to_do_its_own_job() {
+  # The normal case : graceful_exit() ran, the fans are already back on Dell's
+  # profile, and the supervisor must not send the command a second time nor say
+  # anything about it
+  local -r STAND_IN=$(write_stand_in_monitoring_process << 'EOF'
+#!/bin/bash
+trap 'exit 0' SIGTERM
+while true; do sleep 0.05; done
+EOF
+  )
+
+  local OUTPUT
+  OUTPUT=$(run_supervisor "$STAND_IN")
+  local -r EXIT_CODE=$?
+
+  assert_equals 0 "$EXIT_CODE"
+  assert_equals "0" "$(count_ipmitool_calls_matching "raw 0x30 0x30 0x01 0x01")" \
+    "the monitoring process handed the fans back itself"
+  assert_not_contains "$OUTPUT" "without handing the fans back"
+}
+
+function test_a_monitoring_process_killed_by_the_signal_gets_the_fans_handed_back_for_it() {
+  # What issue #188 produces : the trap failed to parse, so graceful_exit() never
+  # ran and the process died on the default action of the signal. The fans are
+  # still pinned at the user's static speed and only the supervisor can free them
+  local -r STAND_IN=$(write_stand_in_monitoring_process << 'EOF'
+#!/bin/bash
+while true; do sleep 0.05; done
+EOF
+  )
+
+  local OUTPUT
+  OUTPUT=$(run_supervisor "$STAND_IN")
+  local -r EXIT_CODE=$?
+
+  assert_equals 0 "$EXIT_CODE" "the container still stops cleanly"
+  assert_equals "1" "$(count_ipmitool_calls_matching "raw 0x30 0x30 0x01 0x01")" \
+    "the supervisor hands the fans back on the monitoring process's behalf"
+  assert_contains "$OUTPUT" "without handing the fans back" \
+    "and says so, rather than letting it pass unnoticed"
+}
+
+function test_a_wedged_monitoring_process_is_killed_and_the_fans_handed_back() {
+  # What issue #249 produces : the shell's parser is corrupted, it ignores the
+  # signal entirely and keeps looping. Docker would wait out its whole grace
+  # period and then SIGKILL it, with nothing left to hand the fans back
+  local -r STAND_IN=$(write_stand_in_monitoring_process << 'EOF'
+#!/bin/bash
+trap '' SIGTERM
+while true; do sleep 0.05; done
+EOF
+  )
+
+  local OUTPUT
+  OUTPUT=$(run_supervisor "$STAND_IN")
+  local -r EXIT_CODE=$?
+
+  assert_equals 0 "$EXIT_CODE"
+  assert_contains "$OUTPUT" "did not stop within" "the deadline is reported, not silently waited out"
+  assert_contains "$OUTPUT" "killing it"
+  assert_equals "1" "$(count_ipmitool_calls_matching "raw 0x30 0x30 0x01 0x01")" \
+    "a process that cannot be asked to stop still must not leave the fans pinned"
+}
+
+function test_a_monitoring_process_that_refused_to_start_is_not_sent_any_command() {
+  # The trap an EXIT trap fell into, and the reason the supervisor only ever acts
+  # on a signal it forwarded itself : a container that stops because the server is
+  # not a Dell, because CHECK_INTERVAL was unusable or because the iDRAC never
+  # answered must not have fan control commands fired at it on the way out
+  local -r STAND_IN=$(write_stand_in_monitoring_process << 'EOF'
+#!/bin/bash
+echo "/!\ Error /!\ Your server isn't a Dell product. Exiting."
+exit 1
+EOF
+  )
+
+  local OUTPUT
+  OUTPUT=$(run_supervisor "$STAND_IN" 0.6)
+  local -r EXIT_CODE=$?
+
+  assert_equals 1 "$EXIT_CODE" "the supervisor must not swallow a startup failure"
+  assert_contains "$OUTPUT" "isn't a Dell product" "the reason still reaches the logs"
+  assert_equals "0" "$(count_ipmitool_calls_matching "raw 0x30")" \
+    "not one command may reach a server the controller declined to touch"
+}
+
+function test_monitoring_only_mode_is_still_never_sent_a_fan_control_command() {
+  # The supervisor is a safety net for the fans, and in monitoring only mode there
+  # is deliberately nothing to catch : no profile was ever applied, so none has to
+  # be restored
+  export MONITORING_ONLY_MODE=true
+  local -r STAND_IN=$(write_stand_in_monitoring_process << 'EOF'
+#!/bin/bash
+while true; do sleep 0.05; done
+EOF
+  )
+
+  local OUTPUT
+  OUTPUT=$(run_supervisor "$STAND_IN")
+
+  assert_equals "0" "$(count_ipmitool_calls_matching "raw 0x30")" \
+    "monitoring only mode must stay read-only, even on the way out"
+  assert_contains "$OUTPUT" "no fan control profile was ever applied"
+}
+
+function test_the_supervisor_does_not_log_the_username_a_second_time() {
+  # It builds its own iDRAC login string so it can send the safety command without
+  # the monitoring process, and set_iDRAC_login_string() logs the username. The
+  # monitoring process logs it too, and one container start must not print it twice
+  local -r STAND_IN=$(write_stand_in_monitoring_process << 'EOF'
+#!/bin/bash
+trap 'exit 0' SIGTERM
+while true; do sleep 0.05; done
+EOF
+  )
+
+  local OUTPUT
+  OUTPUT=$(run_supervisor "$STAND_IN")
+
+  assert_not_contains "$OUTPUT" "iDRAC/IPMI username" \
+    "the supervisor's own login string setup must stay quiet"
+}
+
+function test_the_supervisor_runs_the_monitoring_process_by_default() {
+  # The Dockerfile's ENTRYPOINT passes no argument, so the default has to be the
+  # real monitoring process or the container starts nothing at all
+  local -r SUPERVISOR_SOURCE=$(cat "$REPO_ROOT/supervisor.sh")
+
+  assert_contains "$SUPERVISOR_SOURCE" './Dell_iDRAC_fan_controller.sh' \
+    "the default command must be the monitoring process"
+  assert_matches "$(cat "$REPO_ROOT/Dockerfile")" 'ENTRYPOINT \["\./supervisor\.sh"\]' \
+    "and the image must start the supervisor rather than the monitoring process directly"
+}

--- a/tests/cases/95_supervisor.sh
+++ b/tests/cases/95_supervisor.sh
@@ -230,6 +230,18 @@ function test_the_supervisor_runs_the_monitoring_process_by_default() {
 
   assert_contains "$SUPERVISOR_SOURCE" './Dell_iDRAC_fan_controller.sh' \
     "the default command must be the monitoring process"
+}
+
+function test_the_docker_image_starts_the_supervisor_and_not_the_monitoring_process() {
+  # Everything above is worth nothing if the image still execs the monitoring
+  # process directly : the supervisor would simply never run
+  if [ ! -f "$REPO_ROOT/Dockerfile" ]; then
+    # The suite is running inside the built image, which does not carry the
+    # Dockerfile that produced it
+    skip_test "no Dockerfile next to the scripts"
+    return 0
+  fi
+
   assert_matches "$(cat "$REPO_ROOT/Dockerfile")" 'ENTRYPOINT \["\./supervisor\.sh"\]' \
-    "and the image must start the supervisor rather than the monitoring process directly"
+    "the image must start the supervisor rather than the monitoring process directly"
 }


### PR DESCRIPTION
Closes #249.

## The problem

When `SIGTERM` lands while bash is expanding a `$( )`, the trap command string is parsed with the substitution's delimiter still open and `graceful_exit` never runs. #207 removes the reachable trigger, but two things remain:

- a residual of **2 crashes in 250 stops** was measured with a *single* substitution, and the controller cannot give up command substitution entirely;
- in **361 of the 1789** crashing runs of the controlled sweep, bash did not exit at all — it **wedged** and ignored the signal, so `docker stop` waits out its full 10 second grace period and then `SIGKILL`s, which no trap can catch.

Once that shell's parser is corrupted, nothing running *inside* it gets a say. The fix has to live in a different process.

## What this adds

`supervisor.sh` becomes the image's `ENTRYPOINT` and the container's PID 1. It starts the monitoring process, then spends effectively all of its life blocked in `wait`, with no command substitution in flight — precisely the state where a trap parses cleanly. It runs no loop, formats nothing and reads no sensor: everything it does happens once, at startup or on the way out.

On `SIGINT`/`SIGQUIT`/`SIGTERM` it:

1. forwards the signal to the monitoring process;
2. gives it `SUPERVISOR_GRACE_PERIOD_IN_SECONDS` (3s, comfortably inside docker's 10s) to run its own `graceful_exit()`;
3. `SIGKILL`s it if it is still there — a process whose trap never ran will not answer a second catchable signal either;
4. applies Dell's default dynamic fan control profile itself, **only if** the monitoring process did not exit cleanly.

Step 4 is deliberately conditional. In the normal case `graceful_exit()` ran, the fans are already back on Dell's profile, and the supervisor stays silent — applying the profile twice would be harmless, it is the same idempotent IPMI command, but saying so twice in the log would not be. When it does act, it mirrors `graceful_exit()` exactly, including the deliberate choice *not* to gate the third-party PCIe card cooling response reset on whether the server was seen to accept that command earlier.

### The two traps #249 asked to avoid

- **It must not fire IPMI at a server the controller refused to run on.** The supervisor acts only on a signal *it forwarded itself*. A container that stops because the server is not a Dell, because `FAN_SPEED` or `CHECK_INTERVAL` was unusable or because the iDRAC never answered exits without the supervisor signalling anything, so that branch is never reached — and the supervisor propagates the startup failure's exit code rather than swallowing it.
- **It must respect `MONITORING_ONLY_MODE`.** No profile was ever applied in that mode, so none is restored; the supervisor logs that and sends nothing.

`set_iDRAC_login_string` is called here too, since the supervisor needs to be able to send the safety command without the monitoring process. Its output is dropped so one container start does not print the username twice.

## Files

| File | Change |
| --- | --- |
| `supervisor.sh` | New. The whole of the above |
| `constants.sh` | `SUPERVISOR_GRACE_PERIOD_IN_SECONDS=3` |
| `Dockerfile` | Ships and `chmod`s `supervisor.sh`, `ENTRYPOINT` becomes `["./supervisor.sh"]` |
| `tests/cases/95_supervisor.sh` | New. 9 test cases |
| `tests/cases/10_shell_scripts.sh` | The shipped-files scan now covers `supervisor.sh`, plus a new check on the entrypoint itself |
| `tests/README.md` | The new suite in the coverage table |

## Tests

The supervisor is driven with **stand-in commands** rather than the real monitoring process, because the failures it exists for are exactly the ones that cannot be produced on demand — a corrupted parser is a race, not a switch. The stand-ins reproduce what the supervisor actually sees, which is all it has to decide on:

| Test case | Stand-in | Expected |
| --- | --- | --- |
| stops cleanly | traps `SIGTERM`, exits 0 | **0** Dell-default commands, nothing said |
| killed by the signal (#188) | no trap | **1** Dell-default command, and it says so |
| wedged (#249) | `trap '' SIGTERM` | deadline reported, killed, **1** Dell-default command |
| refused to start | prints "isn't a Dell product", exits 1 | **0** commands of any kind, exit code 1 preserved |
| monitoring only mode | never exits on its own | **0** commands, and the reason logged |
| username | traps `SIGTERM` | not logged a second time |
| default command | *(source check)* | the supervisor defaults to running the controller |
| image entrypoint | *(Dockerfile check)* | the image starts the supervisor, not the controller |
| **plain checkout** | *(no argument — the real controller)* | the table is printed, `graceful_exit` runs, **1** Dell-default command |

That last one is a regression test for a bug this PR hit while being built: the repository tracks `Dell_iDRAC_fan_controller.sh` as a regular `644` file, and only the image's `chmod 0777` makes it runnable. A supervisor executing it directly dies with `Permission denied` and exit code 126 before monitoring anything, everywhere except inside the built image. It is therefore started through `bash`, the same way the test harness's `run_controller` already does. Reverting that one line turns the test red with `expected: [0] / actual: [126]`.

The other tests all pass their stand-in as an argument and `chmod +x` it themselves, which is precisely why none of them saw it — hence the one that starts the supervisor exactly the way the `ENTRYPOINT` does.

The `10_shell_scripts.sh` addition closes the matching gap on the image side: the "every file sourced at runtime is shipped" scan only read the controller and the healthcheck, and nothing `source`s the entrypoint, so `supervisor.sh` was covered by neither. It is now checked to exist, to be `ADD`ed and to be `chmod`ed.

**222 test cases pass, 1 skipped (1377 assertions)** with master merged in, and **214 pass, 9 skipped** when run inside the built image, which carries the scripts but not the Dockerfile the image-side checks read.