### PR TITLE
Wait out an empty sdr answer instead of taking it for a server without a CPU

### DIFF
--- a/Dell_iDRAC_fan_controller.sh
+++ b/Dell_iDRAC_fan_controller.sh
@@ -160,6 +160,7 @@ SLEEP_PROCESS_PID=$!
 # Detect the CPU temperature sensors before entering the monitoring loop, the table header being built
 # from them. The loop then keeps watching for CPUs showing up later, so a partial set read here is not
 # final.
+WAITING_FOR_TEMPERATURE_SENSORS_CYCLES=0
 # The target server may be powered off when the container starts. No sensor can be read then, so keep
 # waiting instead of giving up : this container is expected to outlive its target server being powered
 # off, and exiting there would just make it restart in a loop.
@@ -178,6 +179,29 @@ while true; do
     detect_CPU_temperature_sensors "$SDR_TEMPERATURE_DATA"
     if [ ${#DETECTED_CPU_ENTITY_IDS[@]} -gt 0 ]; then
       break
+    fi
+
+    # An empty answer is not an answer : ipmitool returned no sensor line at all, which a busy BMC, a
+    # partial response or an iDRAC still coming up all produce, and which says nothing about what the
+    # server has. It belongs with "not answering yet" below, not with the verdict underneath : the
+    # refusal is about a server that listed its sensors and had no CPU among them
+    if [ -z "$SDR_TEMPERATURE_DATA" ]; then
+      apply_Dell_default_fan_control_profile
+
+      # Repeated on the rhythm the monitoring loop reprints its table header rather than once, so a
+      # container waiting on an iDRAC that never returns anything cannot be mistaken for a hung one
+      if (( WAITING_FOR_TEMPERATURE_SENSORS_CYCLES % TABLE_HEADER_PRINT_INTERVAL == 0 )); then
+        set_log_timestamp TIMESTAMP
+        printf "%19s  No temperature sensor could be read at all, Dell default dynamic fan control profile applied for safety while waiting...\n" "$TIMESTAMP"
+      fi
+      ((WAITING_FOR_TEMPERATURE_SENSORS_CYCLES++))
+
+      wait $SLEEP_PROCESS_PID
+
+      # Start timer in background for next attempt
+      sleep "$CHECK_INTERVAL" &
+      SLEEP_PROCESS_PID=$!
+      continue
     fi
 
     # The server answers, and answers that it has no readable CPU temperature sensor. Every PowerEdge

--- a/tests/cases/55_enclosure_housed_servers.sh
+++ b/tests/cases/55_enclosure_housed_servers.sh
@@ -255,3 +255,39 @@ function test_the_refusal_never_prints_the_idrac_password() {
   assert_not_contains "$OUTPUT" "$IDRAC_PASSWORD" "the password must never reach the logs"
   assert_contains "$OUTPUT" "<iDRAC password>" "the command is shown with a placeholder instead"
 }
+
+function test_a_transiently_empty_sdr_read_is_waited_out_not_refused() {
+  # ipmitool returning no sensor line at all says nothing about what the server
+  # has : a busy BMC, a partial response or an iDRAC still coming up all produce
+  # it. Concluding "this server has no CPU" on it turns a hiccup at startup into
+  # a container that will not start
+  export MOCK_IPMITOOL_FRU_OUTPUT
+  MOCK_IPMITOOL_FRU_OUTPUT="$(make_fru_output --model "PowerEdge R730")"
+  export MOCK_IPMITOOL_SDR_OUTPUT=""
+  export MOCK_IPMITOOL_SDR_SECOND_OUTPUT MOCK_IPMITOOL_SDR_SWITCH_AFTER_CALLS
+  MOCK_IPMITOOL_SDR_SECOND_OUTPUT=$(make_sdr_output --cpus 2 --cpu-temperatures "44 46")
+  MOCK_IPMITOOL_SDR_SWITCH_AFTER_CALLS=2
+
+  local -r OUTPUT=$(run_controller "44°C")
+
+  assert_not_contains "$OUTPUT" "could be read from" \
+    "an empty answer must never be taken for a server without a CPU"
+  assert_contains "$OUTPUT" "No temperature sensor could be read at all" \
+    "the container says what it is waiting on instead of going quiet"
+  assert_contains "$OUTPUT" "2 CPU temperature sensors detected (entities 3.1 3.2)." \
+    "and picks the CPUs up on the cycle they answer"
+  assert_contains "$OUTPUT" "44°C" "then monitors them normally"
+}
+
+function test_the_refusal_still_fires_on_a_server_that_did_answer_with_sensors() {
+  # The counterpart : the verdict is about a server that listed its sensors and
+  # had no CPU among them, which stays a fault to report on the first answer
+  simulate_enclosure_management_controller "PowerEdge M1000e"
+
+  local OUTPUT
+  OUTPUT=$(run_controller "could be read from")
+  local -r EXIT_CODE=$?
+
+  assert_equals 1 "$EXIT_CODE"
+  assert_contains "$OUTPUT" "No CPU temperature sensor could be read from DELL PowerEdge M1000e"
+}


### PR DESCRIPTION
Closes #250. Regression from #227, which I asked for and reviewed.

## The defect

#227 refuses to start on a server reporting no readable CPU temperature sensor. That is right for **a server that listed its sensors and had no CPU among them** — an iDRAC exposing no processor entity exposes none on every check.

It decides on *"no processor entity was detected"* rather than on *"the server answered with sensors and none was a CPU"*, so it fires just as readily when `ipmitool` returned **nothing at all**. An empty answer says nothing about what the server has: a busy BMC, a partial response, an iDRAC still coming up all produce one. It belongs with "not answering yet", which the loop already waits on.

Measured against `881bd78^1` — the commit immediately before the #227 merge — on an R730 fixture whose first `sdr` call returns nothing and whose second returns two CPUs:

| tree | outcome |
|---|---|
| before #227 | no refusal, **temperatures table printed**, container carried on |
| `master` | refusal, **no table**, exit 1 |

A transient IPMI hiccup at startup became a container that will not start.

## The change

An empty `SDR_TEMPERATURE_DATA` applies the Dell default fan control profile and waits, instead of falling through to the verdict:

```bash
if [ -z "$SDR_TEMPERATURE_DATA" ]; then
  apply_Dell_default_fan_control_profile
  # ... logged every TABLE_HEADER_PRINT_INTERVAL cycles, then continue
fi
```

It says so on the rhythm the monitoring loop reprints its table header rather than once — a container waiting on an iDRAC that never returns anything must not be mistaken for a hung one, which was the whole point of #221:

```
08-08-2026 18:44:02  No temperature sensor could be read at all, Dell default dynamic fan control profile applied for safety while waiting...
```

**The verdict is unchanged for every server that does answer**, chassis controller included. `test_the_refusal_still_fires_on_a_server_that_did_answer_with_sensors` pins that, and #227's own four cases pass untouched.

## Tests

Two cases in `tests/cases/55_enclosure_housed_servers.sh`. The regression test fails against master's entrypoint and passes with this one — checked by putting master's file back under it:

```
$ git checkout origin/master -- Dell_iDRAC_fan_controller.sh
$ ./tests/run_tests.sh -f "transiently_empty_sdr|refusal_still_fires"
1 test cases failed, 1 passed
```

**204 test cases, 1 skipped, 1277 assertions**, all passing.

## Relation to #239

#239 was rebuilt on top of #227 and now only exempts `MONITORING_ONLY_MODE` from the refusal — it no longer carries the guard that fixes this. The two are complementary and touch adjacent lines of the same block, so whichever lands second will want a trivial rebase. No overlap in behaviour: #239 is about a mode that drives no fan, this is about an answer that says nothing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HpEjf2GP5EGE2BHr7jCtua)_