### PR TITLE
Offer CPU_TEMPERATURE_SOURCE in the usage examples, and guard the omission

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ docker run -d \
   -e IDRAC_HOST=local \
   -e FAN_SPEED=<decimal or hexadecimal fan speed> \
   -e CPU_TEMPERATURE_THRESHOLD=<decimal temperature threshold, or auto> \
+  -e CPU_TEMPERATURE_SOURCE=<auto, ipmi or lm-sensors> \
   -e CHECK_INTERVAL=<seconds between each check> \
   -e DISABLE_THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE=<true or false> \
   -e KEEP_THIRD_PARTY_PCIE_CARD_COOLING_RESPONSE_STATE_ON_EXIT=<true or false> \
@@ -101,6 +102,7 @@ docker run -d \
   -e IDRAC_PASSWORD=<iDRAC password> \
   -e FAN_SPEED=<decimal or hexadecimal fan speed> \
   -e CPU_TEMPERATURE_THRESHOLD=<decimal temperature threshold, or auto> \
+  -e CPU_TEMPERATURE_SOURCE=<auto, ipmi or lm-sensors> \
   -e CHECK_INTERVAL=<seconds between each check> \
   -e DISABLE_THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE=<true or false> \
   -e KEEP_THIRD_PARTY_PCIE_CARD_COOLING_RESPONSE_STATE_ON_EXIT=<true or false> \
@@ -124,6 +126,7 @@ services:
       - IDRAC_HOST=local
       - FAN_SPEED=<decimal or hexadecimal fan speed>
       - CPU_TEMPERATURE_THRESHOLD=<decimal temperature threshold, or auto>
+      - CPU_TEMPERATURE_SOURCE=<auto, ipmi or lm-sensors>
       - CHECK_INTERVAL=<seconds between each check>
       - DISABLE_THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE=<true or false>
       - KEEP_THIRD_PARTY_PCIE_CARD_COOLING_RESPONSE_STATE_ON_EXIT=<true or false>
@@ -148,6 +151,7 @@ services:
       - IDRAC_PASSWORD=<iDRAC password>
       - FAN_SPEED=<decimal or hexadecimal fan speed>
       - CPU_TEMPERATURE_THRESHOLD=<decimal temperature threshold, or auto>
+      - CPU_TEMPERATURE_SOURCE=<auto, ipmi or lm-sensors>
       - CHECK_INTERVAL=<seconds between each check>
       - DISABLE_THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE=<true or false>
       - KEEP_THIRD_PARTY_PCIE_CARD_COOLING_RESPONSE_STATE_ON_EXIT=<true or false>

--- a/tests/cases/10_shell_scripts.sh
+++ b/tests/cases/10_shell_scripts.sh
@@ -209,6 +209,57 @@ function test_the_env_example_offers_every_parameter_the_image_declares() {
   done < <(grep -E '^ENV [A-Z_]+=' "$REPO_ROOT/Dockerfile" | sed 's/^ENV //' | cut -d= -f1)
 }
 
+function test_the_usage_examples_offer_every_parameter_the_image_declares() {
+  # The README's "Usage" section is the first thing a user copies, well before the
+  # "Parameters" list below it or the .env.example beside it. A parameter missing
+  # from those four blocks is one most users never learn exists : the two guards
+  # above watch .env.example and the documented defaults, and CPU_TEMPERATURE_SOURCE
+  # still shipped documented everywhere except in the commands people actually run.
+  # This is the guard against that drift
+  if [ ! -f "$REPO_ROOT/Dockerfile" ] || [ ! -f "$REPO_ROOT/README.md" ]; then
+    # The suite is running inside the built image, which carries neither
+    skip_test "no Dockerfile and README next to the scripts"
+    return 0
+  fi
+
+  # The configuration examples are the fenced blocks of the "Usage" section that
+  # set IDRAC_HOST : the two "docker run" ones and the two docker-compose ones.
+  # Found by what they contain rather than by their position, so that reordering
+  # them, or adding a fifth, needs no change here
+  local -r USAGE_SECTION=$(awk '/^## Usage$/ {inside = 1; next} /^## / {inside = 0} inside' "$REPO_ROOT/README.md")
+
+  local -a USAGE_EXAMPLES=()
+  local BLOCK="" IS_INSIDE_BLOCK=false LINE
+  while IFS= read -r LINE; do
+    if [[ "$LINE" == '```'* ]]; then
+      if $IS_INSIDE_BLOCK; then
+        [[ "$BLOCK" == *IDRAC_HOST* ]] && USAGE_EXAMPLES+=("$BLOCK")
+        BLOCK=""
+      fi
+      $IS_INSIDE_BLOCK && IS_INSIDE_BLOCK=false || IS_INSIDE_BLOCK=true
+      continue
+    fi
+    $IS_INSIDE_BLOCK && BLOCK+="$LINE"$'\n'
+  done < <(printf '%s\n' "$USAGE_SECTION")
+
+  # Without this the loop below would pass by having nothing to iterate over,
+  # which is the failure mode these guards exist to prevent in the first place
+  if (( ${#USAGE_EXAMPLES[@]} < 4 )); then
+    fail "only ${#USAGE_EXAMPLES[@]} usage examples were found in the README, expected at least 4"
+    return 1
+  fi
+
+  local KEY EXAMPLE EXAMPLE_NUMBER
+  while IFS= read -r KEY; do
+    EXAMPLE_NUMBER=1
+    for EXAMPLE in "${USAGE_EXAMPLES[@]}"; do
+      assert_contains "$EXAMPLE" "$KEY" \
+        "$KEY is declared by the Dockerfile, usage example $EXAMPLE_NUMBER should show users how to set it"
+      ((EXAMPLE_NUMBER++))
+    done
+  done < <(grep -E '^ENV [A-Z_]+=' "$REPO_ROOT/Dockerfile" | sed 's/^ENV //' | cut -d= -f1)
+}
+
 function test_the_env_example_offers_every_parameter_the_readme_documents() {
   # The test above can only see what the Dockerfile declares, and the Dockerfile
   # declares no ENV for IDRAC_USERNAME and IDRAC_PASSWORD : they are credentials,


### PR DESCRIPTION
Closes #254.

#219 added `CPU_TEMPERATURE_SOURCE` and documented it in the "Parameters" list, in the troubleshooting section and in `.env.example` — and not in the four blocks of the "Usage" section, which is what users actually copy. Every other parameter the image declares is in all four.

## The guard

Three guards already watch this documentation — the README's stated defaults against the Dockerfile's, and `.env.example` against both the Dockerfile and the README. None of them looks at the usage examples, which is exactly the hole this parameter fell through, so it is closed here rather than only patched.

The examples are located by what they contain — a fenced block of the "Usage" section that sets `IDRAC_HOST` — rather than by their position, so reordering them or adding a fifth needs no change to the test. Their count is asserted too: a matcher that found none would otherwise pass by having nothing to iterate over, which is the failure mode these guards exist to prevent in the first place.

Verified it fails on the drift it is meant to catch: removing the new line from a single `docker run` block turns the run red, naming the parameter and which example is missing it.

```
fail the usage examples offer every parameter the image declares
     CPU_TEMPERATURE_SOURCE is declared by the Dockerfile, usage example 1 should show users how to set it
```

261 passed, 0 skipped, 0 failed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H5XXXgiBcPcBbi7j8KZNEW)_