### PR TITLE
Hold the suite's coverage table to the directory it describes

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -20,16 +20,19 @@ It exits `0` when every test case passed, `1` otherwise.
 
 | File | What it checks |
 | --- | --- |
-| `cases/10_shell_scripts.sh` | Syntax of every script, files shipped in the Docker image, healthcheck |
+| `cases/10_shell_scripts.sh` | Syntax of every script, files shipped in the Docker image, drift between the code and what documents it, healthcheck |
+| `cases/12_github_workflows.sh` | The two publishing workflows no pull request ever runs : the release build and the base image refresh |
 | `cases/15_test_runner.sh` | The runner itself : the ways it used to stay green while nothing had been verified |
 | `cases/20_fan_speed_conversions.sh` | `FAN_SPEED` given as a percentage or as a hexadecimal byte |
+| `cases/21_fan_speed_validation.sh` | `FAN_SPEED` values that would reach `ipmitool` as an unintended duty cycle, refused before the first command |
 | `cases/22_cpu_temperature_threshold.sh` | `CPU_TEMPERATURE_THRESHOLD`, and reading "auto" off the CPUs with `lm-sensors` |
 | `cases/23_cpu_temperature_source.sh` | `CPU_TEMPERATURE_SOURCE`, and reading the CPUs from `lm-sensors` when the iDRAC reports none |
 | `cases/25_check_interval_validation.sh` | `CHECK_INTERVAL` values the monitoring loop can actually be paced by, and the reaction time bounds above them |
 | `cases/26_boolean_parameter_validation.sh` | The boolean parameters, which are dispatched by running their value as a command |
+| `cases/27_configuration_error_format.sh` | The one shape every startup refusal reports in, so the reason survives a `docker logs` scroll |
 | `cases/30_idrac_login_string.sh` | Local (`/dev/ipmi0`) and network (`lanplus`) modes, password handling |
 | `cases/40_temperature_parsing.sh` | Reading the sensors out of `ipmitool sdr type temperature` |
-| `cases/50_server_model_detection.sh` | Identifying the server, and detecting Gen 14 or newer |
+| `cases/50_server_model_detection.sh` | Reading the manufacturer and model out of the FRU inventory, and refusing to run on an unreachable iDRAC |
 | `cases/55_enclosure_housed_servers.sh` | Blades and modular servers, whose fans belong to their enclosure |
 | `cases/60_cpu_topologies.sh` | 1, 2 and 4 socket servers, missing sensors, table layout |
 | `cases/70_fan_control_profiles.sh` | The raw commands sent to the server, and their rejections |

--- a/tests/cases/10_shell_scripts.sh
+++ b/tests/cases/10_shell_scripts.sh
@@ -264,6 +264,47 @@ function test_the_env_example_offers_every_parameter_the_readme_documents() {
   done < <(grep -oE '^- `[A-Z_]+`' "$REPO_ROOT/README.md" | tr -d '`' | sed 's/^- //')
 }
 
+function test_the_suites_own_readme_lists_every_case_file() {
+  # The three guards above watch the documentation the users read. This one
+  # watches the documentation the contributors read : tests/README.md holds a
+  # "What is covered" table with one row per case file, and it is what somebody
+  # adding a test consults to decide where the test goes.
+  #
+  # Nothing compared the table with the directory, so it silently fell three
+  # files behind -- and a coverage table that omits a file is worse than no
+  # table, since it reads as "this is everything" while it is not. The runner
+  # discovers case files on its own, so an unlisted file still runs : the drift
+  # is invisible until somebody notices the table is short
+  if [ ! -f "$TESTS_DIRECTORY/README.md" ]; then
+    skip_test "no README next to the test cases"
+    return 0
+  fi
+
+  # Space padded on both ends so a file name can be matched whole
+  local LISTED_FILES=" "
+  local LINE
+  while IFS= read -r LINE; do
+    LISTED_FILES+="$LINE "
+  done < <(grep -oE 'cases/[0-9A-Za-z_]+\.sh' "$TESTS_DIRECTORY/README.md" | sort -u)
+
+  local CASE_FILE
+  for CASE_FILE in "$TESTS_DIRECTORY"/cases/*.sh; do
+    [ -f "$CASE_FILE" ] || continue
+
+    assert_contains "$LISTED_FILES" " cases/$(basename "$CASE_FILE") " \
+      "cases/$(basename "$CASE_FILE") runs in every suite, the README's coverage table should say what it checks"
+  done
+
+  local LISTED_FILE
+  for LISTED_FILE in $LISTED_FILES; do
+    if [ -f "$TESTS_DIRECTORY/$LISTED_FILE" ]; then
+      pass
+    else
+      fail "the README's coverage table lists $LISTED_FILE, which does not exist"
+    fi
+  done
+}
+
 function test_the_healthcheck_succeeds_when_the_sensors_can_be_read() {
   local OUTPUT
   OUTPUT=$(bash "$REPO_ROOT/healthcheck.sh" 2>&1)


### PR DESCRIPTION
Closes #261.

`tests/README.md` lists one row per case file. Nothing compared it with `tests/cases/`, and it had drifted in both directions.

## What was wrong

**Three files missing**, all added by merged pull requests that did not touch the table:

| Case file | Test cases | Added by |
| --- | --- | --- |
| `cases/12_github_workflows.sh` | 1 | #194 |
| `cases/21_fan_speed_validation.sh` | 10 | #164 |
| `cases/27_configuration_error_format.sh` | 9 | #258 |

**One row wrong.** `cases/50_server_model_detection.sh` was still described as "Identifying the server, and detecting Gen 14 or newer" — a behaviour #195 removed, replacing it with asking the server directly. The file's own header already says the model name decides nothing any more, so the table contradicted the file it described.

Nothing was untested: the runner discovers case files on its own, so all three ran in every suite. What the table did was read as an exhaustive list while being short by three, and advertise coverage of a behaviour that no longer exists.

## The change

The table is brought back in line, and a fourth guard joins the three in `cases/10_shell_scripts.sh` that already compare documentation with code:

| Guard | What it compares |
| --- | --- |
| `test_the_readme_documents_the_defaults_the_image_actually_ships` | README's defaults vs the Dockerfile's |
| `test_the_env_example_offers_every_parameter_the_image_declares` | `.env.example` vs the Dockerfile |
| `test_the_env_example_offers_every_parameter_the_readme_documents` | `.env.example` vs the README |
| **`test_the_suites_own_readme_lists_every_case_file`** | **the coverage table vs `tests/cases/`** |

The first three watch what users read. This one watches what contributors read — the table somebody consults to decide where a new test goes.

It asserts **both directions**: every file in `cases/` appears in the table, and every file the table names exists. The first catches the file somebody forgot to add; the second catches the row a rename or a deletion left behind, which an existence check in one direction would miss.

It skips when there is no README next to the test cases, exactly like the three guards above, so the run inside the built image is unaffected.

## Verification

Against `master` the guard fails with the three missing files named one by one — that is how they were found, not the other way round. With the table corrected:

- **283 test cases pass** (1615 assertions)
- **275 pass, 8 skipped** with the top-level documentation absent, the configuration the suite runs in inside the built image

## Why a guard and not just the edit

All four defects came from merged pull requests that added or changed a case file and left the table alone — including one of my own (#195, the stale row) and one adding a whole case file (#251 added `95_supervisor.sh` and its row only because the table happened to be open in that diff). That will keep happening as long as nothing asks.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KYig22vJGjq4UbFDPDCwDB)_