### PR TITLE
Report the missing IPMI device as a configuration error too

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -257,7 +257,13 @@ function set_iDRAC_login_string() {
       # A device path holds no space, so joining on the separator is enough to enumerate them the way
       # the error always has : "/dev/ipmi0 or /dev/ipmi/0 or /dev/ipmidev/0"
       local -r IPMI_DEVICE_PATHS_ENUMERATION="${IPMI_DEVICE_PATHS[*]}"
-      print_error_and_exit "Could not open device at ${IPMI_DEVICE_PATHS_ENUMERATION// / or }, check that you added the device to your Docker container or stop using local mode"
+      # IDRAC_HOST is what is named, it being the parameter that makes the device mandatory : the
+      # device itself is not a parameter the user can be told to correct, only to add
+      print_configuration_error_and_exit "IDRAC_HOST" "$IDRAC_HOST" \
+        "local mode needs the host's IPMI device inside the container. Could not open device at ${IPMI_DEVICE_PATHS_ENUMERATION// / or }, none of them being visible from here" \
+        "Add \"--device=${IPMI_DEVICE_PATHS[0]}\" to your \"docker run\" command, or a \"devices:\" section to
+your docker-compose.yml, then start the container again. Alternatively, set IDRAC_HOST to
+your iDRAC's address to use network mode instead."
     fi
     IDRAC_LOGIN_STRING='open'
   else
@@ -1333,17 +1339,27 @@ function build_fan_control_fallback_comment() {
 # to start is only useful if the reason survives a "docker logs" scroll, hence the block form rather
 # than one line among the startup output -- the user has to be able to see, without reading the source,
 # which parameter is wrong, what it currently is, what is accepted, and where to change it
+#
+# The closing sentence is overridable because not every configuration mistake is made in the same
+# place : almost all of them are environment variables, but exposing the host's IPMI device is a
+# "--device" argument, and sending that user to "-e" would be worse than saying nothing. It defaults
+# to the environment variable wording, which is what every parameter validator wants
 function print_configuration_error_and_exit() {
   local -r PARAMETER_NAME="$1"
   local -r VALUE="$2"
   local -r EXPECTED="$3"
+  local -r WHERE_TO_FIX_IT="${4:-Fix it in the \"-e\" arguments of your \"docker run\" command, or in the \"environment\"
+section of your docker-compose.yml, then start the container again.}"
 
   printf "\n/!\\ Error /!\\ Invalid configuration, the container will not start.\n\n" >&2
   printf "  Parameter : %s\n" "$PARAMETER_NAME" >&2
   printf "  Value     : \"%s\"\n" "$VALUE" >&2
   printf "  Expected  : %s\n\n" "$EXPECTED" >&2
-  printf "  Fix it in the \"-e\" arguments of your \"docker run\" command, or in the \"environment\"\n" >&2
-  printf "  section of your docker-compose.yml, then start the container again.\n\n" >&2
+  # Indented line by line so a closing sentence written across several lines keeps the block's margin
+  printf "%s\n" "$WHERE_TO_FIX_IT" | while IFS= read -r LINE; do
+    printf "  %s\n" "$LINE" >&2
+  done
+  printf "\n" >&2
 
   exit 1
 }

--- a/tests/cases/27_configuration_error_format.sh
+++ b/tests/cases/27_configuration_error_format.sh
@@ -119,6 +119,34 @@ function test_a_failed_ipmi_connection_reports_as_a_configuration_error() {
   assert_contains "$OUTPUT" "docker-compose.yml" "the error should say where to fix it"
 }
 
+function test_a_missing_ipmi_device_reports_as_a_configuration_error() {
+  # Local mode without the host's IPMI device exposed to the container. IPMI_DEVICE_PATHS
+  # is pointed at paths that cannot exist rather than at /dev, which is machine-global
+  local OUTPUT
+  OUTPUT=$(
+    IPMI_DEVICE_PATHS=("$TEST_TEMPORARY_DIRECTORY/absent-ipmi0" "$TEST_TEMPORARY_DIRECTORY/absent-ipmi1")
+    set_iDRAC_login_string "local" "root" "calvin" 2>&1
+  )
+  local -r EXIT_CODE=$?
+
+  assert_reported_as_a_configuration_error "IDRAC_HOST" "local" "$EXIT_CODE" "$OUTPUT"
+}
+
+function test_the_missing_device_error_points_at_device_rather_than_at_e() {
+  # The reason this refusal was held back from #258 : its fix is in "--device", so the
+  # closing sentence every other parameter shares would send the user to the wrong place
+  local -r OUTPUT=$(
+    IPMI_DEVICE_PATHS=("$TEST_TEMPORARY_DIRECTORY/absent-ipmi0")
+    set_iDRAC_login_string "local" "root" "calvin" 2>&1
+  )
+
+  assert_contains "$OUTPUT" "--device=" "the fix is a device argument, and should be spelled out"
+  assert_contains "$OUTPUT" "devices:" "the compose equivalent should be named too"
+  assert_contains "$OUTPUT" "network mode" "the other way out is to stop asking for local mode"
+  assert_not_contains "$OUTPUT" "\"-e\" arguments" \
+    "the environment variable wording would send the user to the wrong place here"
+}
+
 function test_no_configuration_refusal_is_left_reporting_as_a_single_line() {
   # The point of the block is that it is the only form a refused parameter takes.
   # A refusal added later and wired to print_error_and_exit out of habit is exactly
@@ -127,10 +155,13 @@ function test_no_configuration_refusal_is_left_reporting_as_a_single_line() {
   #
   # Matched on the parameter names rather than on one spelling of the call, a refusal
   # naming its parameter in a variable and one naming it literally being the same
-  # mistake. The device error is the documented exception : it is a configuration
-  # mistake in "--device", where the block's closing sentence about "-e" would send
-  # the user to the wrong place
-  local -r PARAMETERS="FAN_SPEED|CHECK_INTERVAL|CPU_TEMPERATURE_THRESHOLD|CPU_TEMPERATURE_SOURCE|MONITORING_ONLY_MODE|DISABLE_THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE|KEEP_THIRD_PARTY_PCIE_CARD_COOLING_RESPONSE_STATE_ON_EXIT|PARAMETER_NAME"
+  # mistake.
+  #
+  # "Could not open device" is listed separately because it is the one refusal whose
+  # message names no parameter at all -- adding IDRAC_HOST to the list below does not
+  # reach it, so a revert to the single-line form would slip past a names-only match.
+  # The two cases above cover that revert behaviourally ; this keeps the grep honest
+  local -r PARAMETERS="FAN_SPEED|CHECK_INTERVAL|CPU_TEMPERATURE_THRESHOLD|CPU_TEMPERATURE_SOURCE|IDRAC_HOST|MONITORING_ONLY_MODE|DISABLE_THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE|KEEP_THIRD_PARTY_PCIE_CARD_COOLING_RESPONSE_STATE_ON_EXIT|PARAMETER_NAME|Could not open device"
 
   local OFFENDERS
   OFFENDERS=$(grep -nE "print_error_and_exit .*($PARAMETERS)" \

--- a/tests/cases/30_idrac_login_string.sh
+++ b/tests/cases/30_idrac_login_string.sh
@@ -49,7 +49,7 @@ function test_local_mode_stops_the_controller_when_no_ipmi_device_is_exposed() {
   local -r EXIT_CODE=$?
 
   assert_equals 1 "$EXIT_CODE" "local mode without an IPMI device should stop the controller"
-  assert_contains "$OUTPUT" "stop using local mode" "the error should tell the user how to recover"
+  assert_contains "$OUTPUT" "network mode" "the error should tell the user how to recover"
 }
 
 function test_the_error_enumerates_every_path_that_was_looked_for() {


### PR DESCRIPTION
Closes #260.

#258 routed every refused configuration parameter through `print_configuration_error_and_exit()` and left exactly one behind: local mode started without the host's IPMI device exposed to the container. It was held back for a reason — the block's closing sentence sends the user to `-e` and to the compose `environment:` section, while this mistake is in `--device` and `devices:`. That reason argues for a footer of its own, not for leaving the refusal on a single line.

## Before / after

```
- /!\ Error /!\ Could not open device at /dev/ipmi0 or /dev/ipmi/0 or /dev/ipmidev/0, check that you added the device to your Docker container or stop using local mode. Exiting.
```
```
+ /!\ Error /!\ Invalid configuration, the container will not start.
+
+   Parameter : IDRAC_HOST
+   Value     : "local"
+   Expected  : local mode needs the host's IPMI device inside the container. Could not open device at /dev/ipmi0 or /dev/ipmi/0 or /dev/ipmidev/0, none of them being visible from here
+
+   Add "--device=/dev/ipmi0" to your "docker run" command, or a "devices:" section to
+   your docker-compose.yml, then start the container again. Alternatively, set IDRAC_HOST to
+   your iDRAC's address to use network mode instead.
```

## How

`print_configuration_error_and_exit()` takes an optional fourth argument carrying the closing sentence, defaulting to the environment variable wording. **No existing call site changes, and the default output is byte for byte what it was** — verified by running the block before and after.

`IDRAC_HOST` is what the `Parameter :` row names, it being the parameter that makes the device mandatory. The device itself is not something the user can be told to correct, only to add, so the footer states both ways out: expose it, or use network mode.

The path enumeration keeps its `or` separator, which the error has always used and which `30_idrac_login_string.sh` asserts on. An earlier draft of this change quietly switched it to commas; the existing test caught it.

## The guard case needed widening twice over

`27_configuration_error_format.sh` ends on a case that greps both scripts for a `print_error_and_exit` naming a configuration parameter. Adding `IDRAC_HOST` to that list **does not reach this refusal at all** — master's message names no parameter, so a revert to the single-line form would slip straight past a names-only match. I checked rather than assumed, by running the grep against `master`: it found nothing.

It now also matches `Could not open device`, and fails on `master` as it should. The comment saying so is in the test, because the next person to widen that list will hit the same trap.

Two behavioural cases back it up, so a revert fails on the output and not only on the grep.

## Verification

285 cases / 1617 assertions, green (282 / 1575 on `master`).

- `30_idrac_login_string.sh`: one assertion followed, `stop using local mode` → `network mode`, the recovery being worded differently. Its two others — the exit code and the path enumeration — pass untouched.
- New in `27_configuration_error_format.sh`: the refusal reports as the block, and its footer names `--device=`, `devices:` and network mode while *not* containing the `"-e" arguments` wording that would misdirect.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B859ZYhzcw8s15TLrgRtbf)_