### PR TITLE
Fix message output line termination in logging (issue #169)

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -196,7 +196,6 @@ function validate_check_interval_parameter() {
 
   if [ "$VALUE_IN_SECONDS" -gt "$CHECK_INTERVAL_WARNING_THRESHOLD_IN_SECONDS" ]; then
     print_warning "$PARAMETER_NAME is \"$VALUE\", over $CHECK_INTERVAL_WARNING_THRESHOLD_IN_SECONDS seconds. Between two checks the fans stay pinned at the FAN_SPEED you configured, with Dell's dynamic fan control disabled, so the controller will take up to that long to react to a temperature spike"
-    printf "\n"
   fi
 }
 
@@ -924,8 +923,6 @@ function warn_if_unexpected_number_of_CPUs() {
   fi
 
   print_warning "${#DETECTED_CPU_ENTITY_IDS[@]} CPU temperature sensors is more than any Dell server has sockets. All of them will be monitored, but please open an issue at https://github.com/tigerblue77/Dell_iDRAC_fan_controller_Docker/issues with your server model and the output of the \"ipmitool sdr type temperature\" command"
-  # print_warning() emits no trailing newline
-  echo ""
 }
 
 # The widest content a CPU column must hold : a reading renders as "NNN°C" (5 columns), which every label
@@ -1366,26 +1363,30 @@ function print_configuration_error_and_exit() {
   exit 1
 }
 
+# Each of these terminates its own line. print_error() and print_warning() used not to, which was
+# deliberate only for the " Exiting." suffix of their _and_exit() variants : every standalone call left
+# the message unterminated, so it fused with the next thing printed. The realistic case is an iDRAC
+# rejecting the fan speed command, which errors on every cycle and prefixes every table row with ~180
+# characters, moving the timestamp out of column 1 and breaking any log parser keyed on it. The exit
+# variants print their line in full rather than depend on that omission, and keep their exact wording
 function print_error() {
   local -r ERROR_MESSAGE="$1"
-  printf "/!\ Error /!\ %s." "$ERROR_MESSAGE" >&2
+  printf "/!\ Error /!\ %s.\n" "$ERROR_MESSAGE" >&2
 }
 
 function print_error_and_exit() {
   local -r ERROR_MESSAGE="$1"
-  print_error "$ERROR_MESSAGE"
-  printf " Exiting.\n" >&2
+  printf "/!\ Error /!\ %s. Exiting.\n" "$ERROR_MESSAGE" >&2
   exit 1
 }
 
 function print_warning() {
   local -r WARNING_MESSAGE="$1"
-  printf "/!\ Warning /!\ %s." "$WARNING_MESSAGE"
+  printf "/!\ Warning /!\ %s.\n" "$WARNING_MESSAGE"
 }
 
 function print_warning_and_exit() {
   local -r WARNING_MESSAGE="$1"
-  print_warning "$WARNING_MESSAGE"
-  printf " Exiting.\n"
+  printf "/!\ Warning /!\ %s. Exiting.\n" "$WARNING_MESSAGE"
   exit 0
 }

--- a/supervisor.sh
+++ b/supervisor.sh
@@ -46,12 +46,10 @@ SIGNAL_WAS_FORWARDED=false
 function apply_Dell_default_fan_control_profile_on_behalf_of_the_monitoring_process() {
   if "$MONITORING_ONLY_MODE"; then
     print_warning "Monitoring process stopped without exiting cleanly. Monitoring only mode, so no fan control profile was ever applied and none is applied now"
-    printf "\n"
     return 0
   fi
 
   print_warning "Monitoring process stopped without handing the fans back. Applying Dell default dynamic fan control profile for safety"
-  printf "\n"
 
   apply_Dell_default_fan_control_profile
 
@@ -82,7 +80,6 @@ function stop_the_monitored_process() {
 
   if kill -0 "$MONITORED_PROCESS_PID" 2> /dev/null; then
     print_warning "Monitoring process did not stop within ${SUPERVISOR_GRACE_PERIOD_IN_SECONDS}s, killing it"
-    printf "\n"
     kill -KILL "$MONITORED_PROCESS_PID" 2> /dev/null
   fi
 }

--- a/tests/cases/10_shell_scripts.sh
+++ b/tests/cases/10_shell_scripts.sh
@@ -363,3 +363,40 @@ function test_no_boolean_parameter_is_dispatched_unquoted() {
     fi
   done
 }
+
+function test_no_call_site_terminates_a_message_line_itself() {
+  # print_error() and print_warning() close their own line (issue #169). A call
+  # site adding a second terminator prints a blank line after the message, and --
+  # worse -- hides the day the helpers lose their "\n" again : that one call site
+  # would keep looking right while every other one fused with the line printed
+  # next.
+  #
+  # This is not hypothetical, the trap caught three separate changes while #169
+  # sat open, each patching the missing newline where it was noticed rather than
+  # in the helper : validate_check_interval_parameter with a printf,
+  # warn_if_unexpected_number_of_CPUs with an echo under a comment stating the
+  # helper emitted none, and the supervisor with one printf per warning.
+  local SCRIPT CALL_LINE_NUMBER TERMINATOR_LINE OFFENDERS
+  for SCRIPT in "$REPO_ROOT"/*.sh; do
+    [ -f "$SCRIPT" ] || continue
+
+    OFFENDERS=""
+    # The _and_exit variants are excluded by the trailing space : they close the
+    # line and leave, so nothing of theirs can be terminated twice
+    for CALL_LINE_NUMBER in $(grep -nE "^[[:space:]]*print_(error|warning) " "$SCRIPT" | cut -d: -f1); do
+      TERMINATOR_LINE=$(sed -n "$((CALL_LINE_NUMBER + 1))p" "$SCRIPT")
+      # A statement doing nothing but ending a line, whitespace removed so that
+      # indentation and the two spellings both reduce to the same few strings
+      case "$(printf '%s' "$TERMINATOR_LINE" | tr -d '[:space:]')" in
+        'printf"\n"' | "printf'\n'" | 'echo""' | "echo''" | 'echo')
+          OFFENDERS+="$((CALL_LINE_NUMBER + 1)):$TERMINATOR_LINE"$'\n' ;;
+      esac
+    done
+
+    if [ -z "$OFFENDERS" ]; then
+      pass
+    else
+      fail "${SCRIPT#$REPO_ROOT/} terminates a message line a second time" "$OFFENDERS"
+    fi
+  done
+}

--- a/tests/cases/35_message_output.sh
+++ b/tests/cases/35_message_output.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+# How error and warning messages reach the container log. stdout and stderr are
+# both "docker logs", so a message that does not terminate its line fuses with
+# whatever is printed next -- and what the monitoring loop prints next, on every
+# cycle, is a row of the temperatures table (issue #169).
+#
+# Nothing about a message read on its own shows the defect : only the line after
+# it does. Every case here therefore prints something behind the message and
+# reads the junction between the two, which catches the opposite mistake in the
+# same assertion -- a line terminated twice, leaving a blank line in the log.
+
+# A row of the temperatures table, of the shape a log parser keys on : the
+# timestamp first, at column 1
+readonly A_TABLE_ROW="08-08-2026 08:35:44  21°C  34°C  45°C  46°C  5%  User static fan control profile (5%)  -"
+
+# The realistic path of issue #169 : an iDRAC that rejects the fan speed raw
+# command errors on every cycle, and the loop prints the table right after
+function report_a_rejected_fan_speed_then_print_a_table_row() {
+  print_error "Failed to set fan speed to 5%. ipmitool said: Unable to send RAW command (channel=0x0 netfn=0x30 lun=0x0 cmd=0x30 rsp=0xc1): Invalid command"
+  printf '%s\n' "$A_TABLE_ROW"
+}
+
+function warn_about_a_long_check_interval_then_print_a_table_row() {
+  validate_check_interval_parameter "CHECK_INTERVAL" "5m" "false"
+  printf '%s\n' "$A_TABLE_ROW"
+}
+
+function warn_about_too_many_CPUs_then_print_a_table_row() {
+  DETECTED_CPU_ENTITY_IDS=(1 2 3 4 5)
+  warn_if_unexpected_number_of_CPUs
+  printf '%s\n' "$A_TABLE_ROW"
+}
+
+function test_an_error_does_not_swallow_the_line_printed_after_it() {
+  capture_output report_a_rejected_fan_speed_then_print_a_table_row
+
+  assert_contains "$CAPTURED_OUTPUT" "Invalid command."$'\n'"$A_TABLE_ROW" \
+    "the row must start on its own line, at column 1, immediately after the error"
+}
+
+function test_the_check_interval_warning_does_not_swallow_the_line_printed_after_it() {
+  capture_output warn_about_a_long_check_interval_then_print_a_table_row
+
+  assert_contains "$CAPTURED_OUTPUT" "temperature spike."$'\n'"$A_TABLE_ROW" \
+    "this call site used to terminate the line itself with a printf"
+}
+
+function test_the_too_many_cpus_warning_does_not_swallow_the_line_printed_after_it() {
+  capture_output warn_about_too_many_CPUs_then_print_a_table_row
+
+  assert_contains "$CAPTURED_OUTPUT" "temperature\" command."$'\n'"$A_TABLE_ROW" \
+    "this call site used to terminate the line itself with an echo"
+}
+
+function test_the_exit_variants_keep_their_exact_wording() {
+  # These two build their line in full rather than appending " Exiting." to an
+  # unterminated message, so the wording is where that rewrite could show. The
+  # first is what a user running this on a non-Dell server reads, and the README
+  # quotes it; the second is printed on every "docker stop"
+  local OUTPUT
+
+  OUTPUT=$(print_error_and_exit "Your server isn't a Dell product" 2>&1)
+  assert_equals "/!\\ Error /!\\ Your server isn't a Dell product. Exiting." "$OUTPUT"
+
+  OUTPUT=$(print_warning_and_exit "Container stopped, Dell default dynamic fan control profile applied for safety" 2>&1)
+  assert_equals "/!\\ Warning /!\\ Container stopped, Dell default dynamic fan control profile applied for safety. Exiting." "$OUTPUT"
+}


### PR DESCRIPTION
## Summary
Fix a logging issue where error and warning messages were not properly terminated with newlines, causing them to fuse with subsequent output (particularly table rows in the monitoring loop). This broke log parsers that expect the timestamp at column 1.

## Key Changes
- **Modified `print_error()` and `print_warning()` functions** to include `\n` in their format strings, ensuring messages are properly line-terminated
- **Refactored `print_error_and_exit()` and `print_warning_and_exit()`** to build their complete message inline rather than composing it from helper functions, preserving exact wording while maintaining proper line termination
- **Removed redundant line terminators** from call sites that were adding their own `printf "\n"` or `echo ""` after calling the helpers:
  - Removed `printf "\n"` after `print_warning()` in `validate_check_interval_parameter()`
  - Removed `echo ""` after `print_warning()` in `warn_if_unexpected_number_of_CPUs()`
- **Added comprehensive test coverage** in new test file `tests/cases/35_message_output.sh` to verify:
  - Error messages don't swallow subsequent lines
  - Warning messages don't swallow subsequent lines
  - Exit variants maintain their exact wording
- **Added regression test** in `tests/cases/10_shell_scripts.sh` to detect if any call site adds a second line terminator after calling the message helpers

## Implementation Details
The root cause was that `print_error()` and `print_warning()` were intentionally omitting the trailing newline to support the `_and_exit()` variants appending " Exiting." However, this design caused all standalone calls to leave messages unterminated, which fused with the next output. The fix makes the helpers self-contained by having them terminate their own lines, and the exit variants now build their complete message directly rather than composing it from the base helpers.

https://claude.ai/code/session_013LvG5Zmxsd1qnCEBza9dBe