### PR TITLE
Document what stopping the container does, and what defeats it

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
   <li><a href="#download-docker-image">Download Docker image</a></li>
   <li><a href="#usage">Usage</a></li>
   <li><a href="#parameters">Parameters</a></li>
+  <li><a href="#stopping-the-container">Stopping the container</a></li>
   <li><a href="#troubleshooting">Troubleshooting</a></li>
   <li><a href="#contributing">Contributing</a></li>
   <li><a href="#license">License</a></li>
@@ -231,6 +232,42 @@ All parameters are optional as they have default values (including default iDRAC
 - `MONITORING_ONLY_MODE` parameter is a boolean that allows to run the container in a read-only, monitoring-only mode: temperatures are still read and logged at each `CHECK_INTERVAL`, but no fan control profile (neither the user-defined one nor Dell's default) and no third-party PCIe card cooling response change is ever sent to the server. Useful to observe temperatures and validate your `FAN_SPEED`/`CPU_TEMPERATURE_THRESHOLD` values before letting the container actually take control of the fans. **Default** value is false.
 
 The three boolean parameters above accept **only the lowercase literals `true` and `false`**, and the container refuses to start on anything else — `True`, `TRUE`, `1`, `on` and `yes` included. This is not pickiness: these parameters are dispatched by running their value, so those spellings used to be taken as `false` without a word. `MONITORING_ONLY_MODE=True` would take control of the fans on a server you had explicitly asked the container to leave alone, while logging "Monitoring only mode: Disabled".
+
+<p align="right">(<a href="#top">back to top</a>)</p>
+
+<!-- STOPPING THE CONTAINER -->
+## Stopping the container
+
+While the container runs, the fans are held at your `FAN_SPEED` and the server's own thermal regulation is switched off. **Stopping the container is what gives it back**, so that is not a detail of the shutdown — it is the moment the server stops depending on this container to stay cool.
+
+On `docker stop`, `docker restart`, a host shutdown or a `docker compose down`, the container:
+
+1. applies Dell's default dynamic fan control profile, handing the fans back to the iDRAC;
+2. resets the third-party PCIe card cooling response to Dell's default, unless you set `KEEP_THIRD_PARTY_PCIE_CARD_COOLING_RESPONSE_STATE_ON_EXIT=true`;
+3. exits.
+
+It says so in the log, and that line is the one to look for when you stop it:
+
+```
+/!\ Warning /!\ Container stopped, Dell default dynamic fan control profile applied for safety. Exiting.
+```
+
+In `MONITORING_ONLY_MODE` nothing was ever applied, so nothing is restored and no command is sent.
+
+### Give it time to do it
+
+The container's PID 1 is a small supervisor whose only job is to make sure step 1 happens even if the monitoring process cannot do it itself. It forwards the stop signal, gives the monitoring process **3 seconds** to bow out cleanly, kills it if it has not, and then applies Dell's profile on its behalf.
+
+That needs Docker's stop timeout to be **longer than those 3 seconds**. The default is 10 seconds, so nothing has to be configured — but if you shorten it, you can cut the container off before it has handed the fans back:
+
+| Where | Keep it above 3 seconds |
+| --- | --- |
+| `docker stop -t <seconds>` | the default is 10 |
+| `docker run --stop-timeout <seconds>` | the default is 10 |
+| `stop_grace_period:` in `docker-compose.yml` | the default is 10s |
+| `terminationGracePeriodSeconds:` on Kubernetes | the default is 30 |
+
+Past that timeout the container is `SIGKILL`ed, which no program can catch or delay, and **the fans stay at your `FAN_SPEED` with nothing left to raise them**. The safety net is defeated precisely in the case it exists for, so if you have a reason to stop containers quickly, exclude this one.
 
 <p align="right">(<a href="#top">back to top</a>)</p>
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -31,6 +31,7 @@ It exits `0` when every test case passed, `1` otherwise.
 | `cases/26_boolean_parameter_validation.sh` | The boolean parameters, which are dispatched by running their value as a command |
 | `cases/27_configuration_error_format.sh` | The one shape every startup refusal reports in, so the reason survives a `docker logs` scroll |
 | `cases/30_idrac_login_string.sh` | Local (`/dev/ipmi0`) and network (`lanplus`) modes, password handling |
+| `cases/35_message_output.sh` | How error and warning messages reach the log, read at their junction with the line that follows |
 | `cases/40_temperature_parsing.sh` | Reading the sensors out of `ipmitool sdr type temperature` |
 | `cases/50_server_model_detection.sh` | Reading the manufacturer and model out of the FRU inventory, and refusing to run on an unreachable iDRAC |
 | `cases/55_enclosure_housed_servers.sh` | Blades and modular servers, whose fans belong to their enclosure |

--- a/tests/cases/10_shell_scripts.sh
+++ b/tests/cases/10_shell_scripts.sh
@@ -315,6 +315,30 @@ function test_the_env_example_offers_every_parameter_the_readme_documents() {
   done < <(grep -oE '^- `[A-Z_]+`' "$REPO_ROOT/README.md" | tr -d '`' | sed 's/^- //')
 }
 
+function test_the_readme_states_the_deadline_the_supervisor_actually_waits() {
+  # The README tells users to keep Docker's stop timeout above the supervisor's
+  # grace period, and states that period as a number. Nothing else in the project
+  # would notice the two disagreeing, and the consequence of the README being
+  # short is the one the supervisor exists to prevent : a container SIGKILLed
+  # while it was still about to hand the fans back
+  if [ ! -f "$REPO_ROOT/README.md" ]; then
+    # The suite is running inside the built image, which does not carry the
+    # README (excluded by .dockerignore)
+    skip_test "no README next to the scripts"
+    return 0
+  fi
+
+  assert_not_empty "$SUPERVISOR_GRACE_PERIOD_IN_SECONDS" \
+    "constants.sh should define the supervisor's grace period" || return 1
+
+  assert_matches "$(cat "$REPO_ROOT/README.md")" \
+    "\*\*$SUPERVISOR_GRACE_PERIOD_IN_SECONDS seconds\*\*" \
+    "the README should state the ${SUPERVISOR_GRACE_PERIOD_IN_SECONDS}s the supervisor really waits"
+  assert_matches "$(cat "$REPO_ROOT/README.md")" \
+    "above $SUPERVISOR_GRACE_PERIOD_IN_SECONDS seconds" \
+    "and ask for a stop timeout above that same value"
+}
+
 function test_the_suites_own_readme_lists_every_case_file() {
   # The three guards above watch the documentation the users read. This one
   # watches the documentation the contributors read : tests/README.md holds a


### PR DESCRIPTION
Closes #268.

The README had nine sections and none about stopping the container. It documented `KEEP_THIRD_PARTY_PCIE_CARD_COOLING_RESPONSE_STATE_ON_EXIT` — a parameter *about* the exit path — without the exit path being described anywhere.

That matters more than a missing section usually would: while the container runs, the fans are pinned at `FAN_SPEED` and the server's own regulation is off, so handing them back on stop is the moment the server stops depending on this container to stay cool. A user who does not know it happens cannot know it failed.

## The new section

**What happens on stop** — Dell's profile reapplied, the cooling response reset unless `KEEP_..._ON_EXIT=true`, exit — with the log line to look for:

```
/!\ Warning /!\ Container stopped, Dell default dynamic fan control profile applied for safety. Exiting.
```

and the `MONITORING_ONLY_MODE` exception, where nothing was applied so nothing is restored.

**That PID 1 is a supervisor**, what it is for, and the deadline it enforces — #251 changed the entrypoint and nothing in the documentation said so.

**The trap that came with that deadline.** The supervisor gives the monitoring process 3 seconds before killing it, so Docker's stop timeout has to stay above that:

| Where | Default |
| --- | --- |
| `docker stop -t <seconds>` | 10 |
| `docker run --stop-timeout <seconds>` | 10 |
| `stop_grace_period:` in `docker-compose.yml` | 10s |
| `terminationGracePeriodSeconds:` on Kubernetes | 30 |

Every default is comfortably above 3, so nothing is broken today and this changes no behaviour. But all four can be lowered, and past the timeout `SIGKILL` leaves the fans at `FAN_SPEED` with nothing left to raise them.

Worth being explicit about why this is worth a warning rather than a footnote: in the normal case the monitoring process exits in well under a second, so a short timeout costs nothing. The 3 seconds are only consumed when it is **wedged** — the case #249 filed and #251 was built for. A shortened timeout is therefore harmless right up until the safety net is the only thing left, and then it removes it.

## The guard

The section states a number that lives in `constants.sh`. `test_the_readme_states_the_deadline_the_supervisor_actually_waits` joins the three guards already comparing the README with the code, and checks both halves — the stated period and the "keep your timeout above it" figure — against `SUPERVISOR_GRACE_PERIOD_IN_SECONDS`.

Verified to bite: setting the constant to 7 without touching the README turns it red.

```
fail the readme states the deadline the supervisor actually waits
     the README should state the 7s the supervisor really waits
       regex: [\*\*7 seconds\*\*]
```

Being *short* is the failure mode that matters here — a README saying 3 while the supervisor waits 7 would send users to a timeout that cuts the container off — so the guard exists to make the number un-drift-able rather than merely tidy.

## Also here : the coverage table row master is currently red without

The first CI run of this branch was red, and not because of anything above. **`master` is red on its own right now**: #179 added `tests/cases/35_message_output.sh` without adding its row to `tests/README.md`, and the guard #262 introduced caught it. That is the guard working — this is the first drift it has caught since it landed — but master stays red until the row exists, and every pull request merging with it inherits the failure.

The row is added here rather than in a pull request of its own: it is the same file and the same kind of change as the rest of this branch, and it unblocks master in one merge instead of two.

## Tests

With master merged in:

- **296 test cases pass** (1681 assertions)
- **286 pass, 10 skipped** with the top-level documentation absent, the configuration the suite runs in inside the built image

Documentation, one coverage-table row and one test — no shipped script changes.