### PR TITLE
List 35_message_output.sh in the suite's README, turning master green again

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -31,6 +31,7 @@ It exits `0` when every test case passed, `1` otherwise.
 | `cases/26_boolean_parameter_validation.sh` | The boolean parameters, which are dispatched by running their value as a command |
 | `cases/27_configuration_error_format.sh` | The one shape every startup refusal reports in, so the reason survives a `docker logs` scroll |
 | `cases/30_idrac_login_string.sh` | Local (`/dev/ipmi0`) and network (`lanplus`) modes, password handling |
+| `cases/35_message_output.sh` | How errors and warnings reach `docker logs`, read at their junction with the line that follows |
 | `cases/40_temperature_parsing.sh` | Reading the sensors out of `ipmitool sdr type temperature` |
 | `cases/50_server_model_detection.sh` | Reading the manufacturer and model out of the FRU inventory, and refusing to run on an unreachable iDRAC |
 | `cases/55_enclosure_housed_servers.sh` | Blades and modular servers, whose fans belong to their enclosure |


### PR DESCRIPTION
**`master` is currently red, and so is every open pull request built on it.** One row of documentation fixes it.

#179 added `tests/cases/35_message_output.sh` without the matching row in the suite's coverage table. `10_shell_scripts.sh` asserts that every case file has one:

```
fail the suites own readme lists every case file
     cases/35_message_output.sh runs in every suite, the README's coverage table should say what it checks
       substring: [ cases/35_message_output.sh ]
```

That case runs in every suite, so the failure follows master into any branch that merges it.

## The fix

One row, describing what the file says about itself — that it reads a message at its junction with the line printed after it, the defect of #169 being invisible on the message alone.

The assertion is doing its job rather than being in the way: the table is how someone finds which file to open, and a case file missing from it is one nobody reads.

## Verification

295 cases / 1678 assertions, green. On `master` at `25c87ee`: 1 failed, 294 passed.

Nothing else changed — this touches `tests/README.md` only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B859ZYhzcw8s15TLrgRtbf)_