### PR TITLE
List the message output cases in the suite's coverage table

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -31,6 +31,7 @@ It exits `0` when every test case passed, `1` otherwise.
 | `cases/26_boolean_parameter_validation.sh` | The boolean parameters, which are dispatched by running their value as a command |
 | `cases/27_configuration_error_format.sh` | The one shape every startup refusal reports in, so the reason survives a `docker logs` scroll |
 | `cases/30_idrac_login_string.sh` | Local (`/dev/ipmi0`) and network (`lanplus`) modes, password handling |
+| `cases/35_message_output.sh` | Where an error or a warning ends its line, the log being shared with the temperatures table |
 | `cases/40_temperature_parsing.sh` | Reading the sensors out of `ipmitool sdr type temperature` |
 | `cases/50_server_model_detection.sh` | Reading the manufacturer and model out of the FRU inventory, and refusing to run on an unreachable iDRAC |
 | `cases/55_enclosure_housed_servers.sh` | Blades and modular servers, whose fans belong to their enclosure |


### PR DESCRIPTION
Closes #273. **`master` is currently red** — this turns it green again. One line.

## What broke

Two pull requests merged minutes apart, neither able to see the other:

- **#258** added `test_the_suites_own_readme_lists_every_case_file`, which walks `tests/cases/*.sh` and requires every file to have a row in the "What is covered" table of `tests/README.md`.
- **#179** added `tests/cases/35_message_output.sh`, written before that guard existed, so it added no row.

Each branch was green against its own base. The guard only sees the other branch's file once both are on `master`, so nothing could go red until the second merge landed.

```
shell scripts
  fail the suites own readme lists every case file
       cases/35_message_output.sh runs in every suite, the README's coverage table should say what it checks

1 test cases failed, 292 passed
```

## Why it is worth fixing now rather than in the next branch

Test suite only — no shipped script is involved and the container behaves identically. But a red `master` hands every pull request opened from now on a failing check that has nothing to do with it, and `build_and_publish_docker_image.yml` gates publishing the image on this suite.

## Verification

```
before : 1 test cases failed, 292 passed (1667 assertions)
after  : 293 test cases passed (1668 assertions)
```

---
_Generated by [Claude Code](https://claude.ai/code/session_013LvG5Zmxsd1qnCEBza9dBe)_