### PR TITLE
Stop a backwards clock from making the JUnit report unparseable

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -23,6 +23,7 @@ It exits `0` when every test case passed, `1` otherwise.
 | `cases/10_shell_scripts.sh` | Syntax of every script, files shipped in the Docker image, drift between the code and what documents it, healthcheck |
 | `cases/12_github_workflows.sh` | The two publishing workflows no pull request ever runs : the release build and the base image refresh |
 | `cases/15_test_runner.sh` | The runner itself : the ways it used to stay green while nothing had been verified |
+| `cases/17_reports.sh` | The JUnit XML and Markdown reports, whose consumer is a parser rather than a reader |
 | `cases/20_fan_speed_conversions.sh` | `FAN_SPEED` given as a percentage or as a hexadecimal byte |
 | `cases/21_fan_speed_validation.sh` | `FAN_SPEED` values that would reach `ipmitool` as an unintended duty cycle, refused before the first command |
 | `cases/22_cpu_temperature_threshold.sh` | `CPU_TEMPERATURE_THRESHOLD`, and reading "auto" off the CPUs with `lm-sensors` |

--- a/tests/cases/17_reports.sh
+++ b/tests/cases/17_reports.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+
+# The JUnit XML and Markdown reports. Nothing covered them until a malformed
+# duration reached the publisher and turned a run red with every test case
+# passing :
+#
+#   ValueError: could not convert string to float: '0.-992'
+#
+# The reports are the only part of the suite whose output is consumed by
+# something other than a human, so "it looked fine in the terminal" is not a
+# check. These cases hold the two properties a parser depends on : every number
+# is a number, and the document is well formed.
+
+# The runner reads its case files as text to list them in declaration order, so
+# a definition merely quoted in this file would be discovered and run as part of
+# the outer suite. The probe below therefore names its test cases through this
+# prefix, exactly as cases/15_test_runner.sh does for the same reason -- under
+# its own name, both files being sourced into the same shell
+readonly REPORT_PROBE_PREFIX="test"
+
+# Run the real runner over a throwaway case file, in a repository of symbolic
+# links to the real scripts, and have it write a JUnit report. The report's path
+# is printed
+function write_a_junit_report_from_a_probe_run() {
+  local -r PROBE_REPOSITORY="$TEST_TEMPORARY_DIRECTORY/report_probe"
+  local -r REPORT="$PROBE_REPOSITORY/report.xml"
+
+  rm -rf "$PROBE_REPOSITORY"
+  mkdir -p "$PROBE_REPOSITORY/tests/cases"
+
+  # The runner derives the repository root from its own path
+  local REPOSITORY_FILE
+  for REPOSITORY_FILE in "$REPO_ROOT"/*.sh "$REPO_ROOT/Dockerfile"; do
+    [ -e "$REPOSITORY_FILE" ] && ln -s "$REPOSITORY_FILE" "$PROBE_REPOSITORY/"
+  done
+  cp "$TESTS_DIRECTORY/run_tests.sh" "$PROBE_REPOSITORY/tests/"
+  cp -r "$TESTS_DIRECTORY/lib" "$TESTS_DIRECTORY/mocks" "$PROBE_REPOSITORY/tests/"
+
+  # One of each outcome, so the report has a failure and a skip to carry
+  {
+    printf 'function %s_that_passes() { assert_equals "1" "1" ; }\n' "$REPORT_PROBE_PREFIX"
+    printf 'function %s_that_fails() { assert_equals "1" "2" "a message the report carries" ; }\n' "$REPORT_PROBE_PREFIX"
+    printf 'function %s_that_is_skipped() { skip_test "nothing to run here" ; }\n' "$REPORT_PROBE_PREFIX"
+  } > "$PROBE_REPOSITORY/tests/cases/50_probe.sh"
+
+  bash "$PROBE_REPOSITORY/tests/run_tests.sh" --junit "$REPORT" --no-color > /dev/null 2>&1
+
+  printf '%s' "$REPORT"
+}
+
+function test_a_duration_is_formatted_as_seconds_and_milliseconds() {
+  assert_equals "0.000" "$(format_duration 0)"
+  assert_equals "0.001" "$(format_duration 1)"
+  assert_equals "0.999" "$(format_duration 999)"
+  assert_equals "1.000" "$(format_duration 1000)"
+  assert_equals "1.234" "$(format_duration 1234)"
+  assert_equals "12.050" "$(format_duration 12050)"
+  assert_equals "3600.000" "$(format_duration 3600000)"
+}
+
+function test_a_duration_the_clock_made_negative_is_reported_as_zero() {
+  # The durations are wall clock differences, and a wall clock may step
+  # backwards -- a CI runner syncing its time between the two reads is enough.
+  #
+  # Bash truncates integer division towards zero and gives the remainder the
+  # sign of the dividend, so -992 used to print as "0.-992" : each field correct
+  # on its own, the string they compose not a number. The JUnit publisher parses
+  # every "time" attribute as a float, so that one value aborted the entire
+  # report and failed the workflow while every test case had passed
+  assert_equals "0.000" "$(format_duration -1)" "the shape that produced 0.-001"
+  assert_equals "0.000" "$(format_duration -992)" "the value actually observed in CI"
+  assert_equals "0.000" "$(format_duration -1500)" "more than a second backwards"
+}
+
+function test_every_duration_a_report_can_hold_parses_as_a_number() {
+  # The property the publisher actually depends on, checked over the formatter's
+  # whole range rather than on a chosen value : a "time" it cannot read as a
+  # float costs the report, not the reading
+  local DURATION FORMATTED
+  for DURATION in -100000 -992 -1 0 1 7 999 1000 1001 59999 86400000; do
+    FORMATTED=$(format_duration "$DURATION")
+
+    assert_matches "$FORMATTED" '^[0-9]+\.[0-9]{3}$' \
+      "format_duration $DURATION should be a plain decimal number"
+  done
+}
+
+function test_the_junit_report_is_well_formed_and_carries_every_outcome() {
+  # End to end on the document rather than on one attribute : the real runner is
+  # driven over a throwaway case file and the report it writes is read back
+  local -r REPORT=$(write_a_junit_report_from_a_probe_run)
+
+  if [ ! -s "$REPORT" ]; then
+    fail "the runner should have written a JUnit report"
+    return 1
+  fi
+
+  local -r REPORT_CONTENT=$(cat "$REPORT")
+
+  assert_contains "$REPORT_CONTENT" "<testsuites " "the report should have a root element"
+  assert_contains "$REPORT_CONTENT" 'tests="3"' "the three probe test cases should be counted"
+  assert_contains "$REPORT_CONTENT" 'failures="1"'
+  assert_contains "$REPORT_CONTENT" 'skipped="1"'
+  assert_contains "$REPORT_CONTENT" "a message the report carries" \
+    "a failure's message should reach the report"
+
+  local -r MALFORMED_TIMES=$(grep -c 'time="[^"]*[^0-9."][^"]*"' "$REPORT" || true)
+  assert_equals "0" "$MALFORMED_TIMES" "every time attribute should be a plain decimal number"
+
+  # Well formedness, from whichever XML parser the machine has. Neither is a
+  # dependency of this suite, so their absence skips the check rather than
+  # failing it
+  local XML_ERRORS
+  if command -v python3 > /dev/null 2>&1; then
+    if XML_ERRORS=$(python3 -c 'import sys,xml.etree.ElementTree as E; E.parse(sys.argv[1])' "$REPORT" 2>&1); then
+      pass
+    else
+      fail "the JUnit report should be well formed XML" "$XML_ERRORS"
+    fi
+  elif command -v xmllint > /dev/null 2>&1; then
+    if XML_ERRORS=$(xmllint --noout "$REPORT" 2>&1); then
+      pass
+    else
+      fail "the JUnit report should be well formed XML" "$XML_ERRORS"
+    fi
+  fi
+}

--- a/tests/lib/reports.sh
+++ b/tests/lib/reports.sh
@@ -58,9 +58,23 @@ function current_time_in_milliseconds() {
   printf '%s' "$(($(date +%s) * 1000))"
 }
 
-# "1234" -> "1.234", the duration format both reports use
+# "1234" -> "1.234", the duration format both reports use.
+#
+# A negative input is clamped to zero rather than formatted. Bash truncates
+# integer division towards zero and gives the remainder the sign of the
+# dividend, so -992 would come out as "0.-992" : both fields are individually
+# correct and the string they compose is not a number. Nothing downstream
+# survives that -- the JUnit publisher parses every "time" attribute as a float
+# and a malformed one aborts the whole report, turning a green run red.
+#
+# The durations are wall clock differences, and a wall clock is allowed to go
+# backwards : a CI runner that syncs its clock between the two reads produces
+# exactly the small negative value above. Zero is what to report then, a test
+# case having taken an unknown but certainly not negative amount of time
 function format_duration() {
-  printf '%d.%03d' "$(($1 / 1000))" "$(($1 % 1000))"
+  local -r DURATION_IN_MILLISECONDS=$(($1 > 0 ? $1 : 0))
+
+  printf '%d.%03d' "$((DURATION_IN_MILLISECONDS / 1000))" "$((DURATION_IN_MILLISECONDS % 1000))"
 }
 
 # Replace the characters XML gives a meaning to, and drop the control characters

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -283,7 +283,13 @@ for TEST_CASE in "${SELECTED_TEST_CASES[@]}"; do
     cd "$REPO_ROOT" || exit 1
     "$TEST_CASE_NAME"
   ) > "$TEST_TEMPORARY_DIRECTORY/output" 2>&1 || TEST_CASE_EXIT_CODE=$?
+  # Clamped here as well as in format_duration : this value is also summed per
+  # suite and for the whole run, and one negative member drags those totals below
+  # what the test cases actually took
   TEST_CASE_DURATION=$(($(current_time_in_milliseconds) - TEST_CASE_STARTED_AT))
+  if [ "$TEST_CASE_DURATION" -lt 0 ]; then
+    TEST_CASE_DURATION=0
+  fi
 
   TEST_CASE_ASSERTIONS=$(wc -c < "$TEST_ASSERTIONS_FILE" | tr -d ' ')
   TOTAL_ASSERTIONS=$((TOTAL_ASSERTIONS + TEST_CASE_ASSERTIONS))


### PR DESCRIPTION
Closes #275. **This is what is failing the `Tests` workflow on `master` right now.**

The suite is not what fails. Both suite jobs are green; the **Publish the test results** job crashes reading what they wrote:

```
ValueError: could not convert string to float: '0.-992'
```

## `0.-992`

`format_duration` printed the two halves of a duration separately:

```bash
printf '%d.%03d' "$(($1 / 1000))" "$(($1 % 1000))"
```

Bash truncates integer division towards zero and gives the remainder the sign of the dividend, so `-992` becomes `0` and `-992` → `0.-992`. Each field correct on its own, the string they compose not a number. The publisher parses every `time` attribute as a float, so **one** such value aborts the whole report and fails the workflow after every test case has passed.

## Why a duration goes negative

Each test case is timed as a wall clock difference, and `EPOCHREALTIME` is `CLOCK_REALTIME` — not monotonic. A runner syncing its clock between the two reads steps it backwards.

That explains the shape of the failure: intermittent, no change to the reporting code preceding it, no local reproduction. Three consecutive pushes to `master` are red from it (`fad0e69`, `25c87ee`, `fb5d2af`).

## The fix

Clamped in **two** places:

- **`format_duration`** — no input can produce a string that is not a number;
- **where the duration is measured** — the value is also summed per suite and per run, so one negative member would drag those totals below what the test cases really took, even with the formatter safe.

Zero is the honest value: the clock moved, the real duration is unknown, and a test case did not take negative time.

## Tests, which this file had none of

`tests/lib/reports.sh` had **no coverage at all** — and it is the one part of the suite whose consumer is a parser rather than a reader, so "the terminal output looked fine" was never a check on it. It looked fine on every red run.

`cases/17_reports.sh` adds four cases:

| Test case | What it holds |
| --- | --- |
| a duration is formatted as seconds and milliseconds | the normal range, 0 to an hour |
| a duration the clock made negative is reported as zero | `-1`, `-992` (the value seen in CI), `-1500` |
| every duration a report can hold parses as a number | the formatter's whole range against `^[0-9]+\.[0-9]{3}$` — the property the publisher depends on |
| the junit report is well formed and carries every outcome | end to end: the real runner over a probe case file, then the report read back |

The last one runs the real runner in a repository of symlinks, with one passing, one failing and one skipped probe case, then checks the counts, the failure message, that no `time` attribute holds a non-numeric character, and hands the document to an XML parser.

Verified to fail against the formatter as it was:

```
fail a duration the clock made negative is reported as zero
     the value actually observed in CI
       expected: [0.000]
       actual:   [0.-992]
```

The probe names its test cases through a prefix variable rather than writing `test_` literally — the runner discovers case files by reading them as text, so a quoted definition would otherwise join the outer run. `cases/15_test_runner.sh` does the same, under its own variable name since both files are sourced into one shell.

## Result

**300 test cases pass** (1712 assertions), the report it writes has zero malformed `time` attributes, and `xml.etree` parses it cleanly.

`cases/17_reports.sh` is listed in the coverage table, as the guard from #262 requires.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KYig22vJGjq4UbFDPDCwDB)_