### PR TITLE
Rebase the pull requests master leaves behind, instead of updating them by hand

### DIFF
--- a/.github/workflows/auto_update_pull_request_branches.yml
+++ b/.github/workflows/auto_update_pull_request_branches.yml
@@ -1,0 +1,159 @@
+name: Auto-update pull request branches
+
+# "Require branches to be up to date before merging" leaves every other open
+# pull request one commit behind master as soon as one of them is merged, and
+# each of them then needs its "Update branch" button pressed by hand. This
+# workflow presses it for them after every merge, for the pull requests that can
+# be updated without a conflict. The ones that do conflict are left alone :
+# resolving them is a decision only their author can make.
+#
+# GitHub's own answer to this problem is the merge queue, which tests and merges
+# pull requests against an up-to-date master without anyone updating anything.
+# It is not an option here : it requires a repository owned by an organization,
+# and this one belongs to a personal account.
+#
+# /!\ The update cannot be pushed with the default GITHUB_TOKEN. Nothing that
+# token pushes fires a "pull_request" event, so the "Tests" workflow would never
+# run on the head commit the update creates and the required checks would stay
+# at "Expected — Waiting for status to be reported", blocking the very merge
+# this workflow exists to unblock. It uses the PULL_REQUESTS_UPDATE_TOKEN secret
+# instead : a fine-grained personal access token, whose resource owner is this
+# account and whose repository access covers this repository, granting the
+# "Contents : read and write" and "Pull requests : read and write" repository
+# permissions. Create it in Settings > Developer settings > Personal access
+# tokens > Fine-grained tokens, then store it in Settings > Secrets and
+# variables > Actions > New repository secret
+
+on:
+  push:
+    branches: [master]
+  # Lets the whole set be caught up by hand, after the token expires and is
+  # renewed for instance
+  workflow_dispatch:
+
+# Everything is done with the personal access token, so the token of the run
+# itself needs nothing at all
+permissions: {}
+
+# Two merges landing one after the other would otherwise walk the same list of
+# pull requests at the same time, the second run racing the updates the first
+# one is still pushing. Queueing the runs rather than cancelling them is what
+# makes the last one see the final state of master
+concurrency:
+  group: auto-update-pull-request-branches
+  cancel-in-progress: false
+
+jobs:
+  update-pull-request-branches:
+    name: Update the pull requests master left behind
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Update every conflict-free pull request that is behind master
+        env:
+          GH_TOKEN: ${{ secrets.PULL_REQUESTS_UPDATE_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          MASTER_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::error::The PULL_REQUESTS_UPDATE_TOKEN secret is empty or missing, so nothing can be updated. The comment at the top of this workflow says which token to create and why the default one cannot be used."
+            exit 1
+          fi
+
+          # Draft pull requests are skipped. They are not waiting to be merged,
+          # and several of them live in forks where an unasked-for merge commit
+          # after each push to master would be noise rather than help.
+          # Pull requests based on another branch are skipped too : this run
+          # only knows that master moved
+          open_pull_requests="$(
+            gh pr list \
+              --repo "$REPOSITORY" \
+              --base master \
+              --state open \
+              --limit 100 \
+              --json number,isDraft
+          )"
+          mapfile -t pull_requests < <(
+            jq --raw-output '.[] | select(.isDraft | not) | .number' <<< "$open_pull_requests"
+          )
+
+          if [ "${#pull_requests[@]}" -eq 0 ]; then
+            echo "No open pull request targets master."
+            exit 0
+          fi
+
+          echo "Considering ${#pull_requests[@]} open pull request(s) against master $MASTER_SHA."
+
+          updated=0
+          for number in "${pull_requests[@]}"; do
+            # GitHub computes mergeability lazily, and the push that started
+            # this run invalidated it for every open pull request : the answer
+            # is "null" until the background job that recomputes it is done, so
+            # the first read is really what asks the question and the next ones
+            # wait for the answer
+            mergeable="null"
+            head_sha=""
+            for _ in 1 2 3 4 5; do
+              if ! pull_request="$(gh api "repos/$REPOSITORY/pulls/$number")"; then
+                break
+              fi
+              mergeable="$(jq --raw-output '.mergeable | tostring' <<< "$pull_request")"
+              head_sha="$(jq --raw-output '.head.sha' <<< "$pull_request")"
+              [ "$mergeable" != "null" ] && break
+              sleep 5
+            done
+
+            if [ -z "$head_sha" ]; then
+              echo "::warning::Pull request #$number could not be read, skipping it."
+              continue
+            fi
+
+            if [ "$mergeable" = "null" ]; then
+              echo "::warning::Pull request #$number : GitHub did not say in time whether it can be merged, skipping it. The next push to master will try again."
+              continue
+            fi
+
+            if [ "$mergeable" != "true" ]; then
+              echo "Pull request #$number conflicts with master, leaving it to its author."
+              continue
+            fi
+
+            # An open pull request has its head commit mirrored into this
+            # repository as refs/pull/<number>/head, so comparing by SHA works
+            # for a pull request opened from a fork too, and avoids having to
+            # put a branch name holding slashes in the URL.
+            # In "A...B", behind_by counts the commits A has and B does not :
+            # exactly how far behind master this pull request is
+            if ! behind_by="$(gh api "repos/$REPOSITORY/compare/$MASTER_SHA...$head_sha" --jq '.behind_by')" ||
+               ! [[ "$behind_by" =~ ^[0-9]+$ ]]; then
+              echo "::warning::Pull request #$number could not be compared with master, skipping it."
+              continue
+            fi
+
+            if [ "$behind_by" -eq 0 ]; then
+              echo "Pull request #$number is already up to date."
+              continue
+            fi
+
+            # expected_head_sha makes the update a no-op rather than a surprise
+            # if the author pushed to the branch since it was read above
+            if gh api \
+              --method PUT \
+              "repos/$REPOSITORY/pulls/$number/update-branch" \
+              --raw-field "expected_head_sha=$head_sha" \
+              --silent; then
+              echo "Pull request #$number was $behind_by commit(s) behind master and has been updated."
+              updated=$((updated + 1))
+            else
+              # A pull request opened from a fork can only be updated from here
+              # if its author left "Allow edits by maintainers" ticked, and the
+              # token must be allowed to write to the fork as well. Neither is
+              # something this repository can decide, so a refusal is reported
+              # and the run carries on with the next pull request
+              echo "::warning::Pull request #$number is $behind_by commit(s) behind master but could not be updated. If it comes from a fork, its author has to tick \"Allow edits by maintainers\" ; otherwise it has to be updated by hand."
+            fi
+          done
+
+          echo "Updated $updated pull request(s)." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/auto_update_pull_request_branches.yml
+++ b/.github/workflows/auto_update_pull_request_branches.yml
@@ -35,44 +35,42 @@ name: Auto-update pull request branches
 # swapping one click per pull request for another is not worth a workflow, so
 # the update has to come from an identity GitHub already trusts.
 #
-# That identity is the PULL_REQUESTS_UPDATE_TOKEN secret : a fine-grained
-# personal access token, whose resource owner is this account and whose
-# repository access covers this repository, granting three repository
-# permissions : "Contents : read and write", "Pull requests : read and write"
-# and "Workflows : read and write". Create it in Settings > Developer settings >
-# Personal access tokens > Fine-grained tokens, then store it in Settings >
-# Secrets and variables > Actions > New repository secret.
+# Two identities qualify, and both are wired up. Whichever is used needs the
+# same three repository permissions : "Contents : read and write", "Pull
+# requests : read and write" and "Workflows : read and write".
 #
-# The third one is not optional here, and it is the one easily forgotten :
+# That third one is the one easily forgotten, and leaving it out is a trap :
 # rebasing replays the branch's commits, and a branch that adds or edits
 # anything under .github/workflows is refused without it, with "refusing to
 # allow [...] to create or update workflow [...] without workflow scope
 # (updatePullRequestBranch)". This repository merges such pull requests
-# regularly, so a token missing it would work until precisely the pull request
-# that needed it most.
+# regularly, so a credential missing it would work until precisely the pull
+# request that needed it most.
 #
-# A GitHub App is the other identity that works, with the same three
-# permissions, and it is what GitHub itself points to for this case. Nothing
-# about it has to be renewed by hand, because the private key does not expire.
-# Its installation token does, after an hour, so it is not something to paste
-# into a secret : the private key goes into PULL_REQUESTS_UPDATE_APP_PRIVATE_KEY
-# and the App's identifier into the PULL_REQUESTS_UPDATE_APP_ID variable, and
-# the first step below mints a fresh token from them at the start of every run.
+# A GitHub App is what this repository uses, and what GitHub itself points to
+# for this case. Nothing about it has to be renewed by hand, because the private
+# key does not expire ; the installation token minted from it does, after an
+# hour, which is why the key rather than a token is what is stored. The key goes
+# into the PULL_REQUESTS_UPDATE_APP_PRIVATE_KEY secret and the App's identifier
+# into the PULL_REQUESTS_UPDATE_APP_ID variable, and the first step below mints
+# a fresh token from them at the start of every run.
 #
-# Both routes are wired up, and setting the App variable is the whole migration :
-# the minting step only runs once that variable exists, and the token falls back
-# to the personal access token whenever it does not. So the App can be adopted
-# later, or never, without this file changing over the token
+# A fine-grained personal access token in the PULL_REQUESTS_UPDATE_TOKEN secret
+# works too, and is quicker to set up : its resource owner has to be this
+# account and its repository access has to cover this repository. It is what the
+# credential falls back to when no App is configured, so either can be adopted,
+# or swapped for the other, without this file changing. It expires, though, and
+# has to be renewed by hand before it does
 
 on:
   push:
     branches: [master]
-  # Lets the whole set be caught up by hand, after the token expires and is
-  # renewed for instance
+  # Lets the whole set be caught up by hand : after a run failed on a credential
+  # that had lapsed, or simply to see the thing work without waiting for a merge
   workflow_dispatch:
 
-# Everything is done with the personal access token, so the token of the run
-# itself needs nothing at all
+# Everything is done with the credential above, so the token of the run itself
+# needs nothing at all
 permissions: {}
 
 # Two merges landing one after the other would otherwise walk the same list of

--- a/.github/workflows/auto_update_pull_request_branches.yml
+++ b/.github/workflows/auto_update_pull_request_branches.yml
@@ -36,12 +36,24 @@ name: Auto-update pull request branches
 #
 # That identity is the PULL_REQUESTS_UPDATE_TOKEN secret : a fine-grained
 # personal access token, whose resource owner is this account and whose
-# repository access covers this repository, granting the "Contents : read and
-# write" and "Pull requests : read and write" repository permissions. Create it
-# in Settings > Developer settings > Personal access tokens > Fine-grained
-# tokens, then store it in Settings > Secrets and variables > Actions > New
-# repository secret. A GitHub App installation token works here too and never
-# expires, at the cost of creating and installing the App
+# repository access covers this repository, granting three repository
+# permissions : "Contents : read and write", "Pull requests : read and write"
+# and "Workflows : read and write". Create it in Settings > Developer settings >
+# Personal access tokens > Fine-grained tokens, then store it in Settings >
+# Secrets and variables > Actions > New repository secret.
+#
+# The third one is not optional here, and it is the one easily forgotten :
+# rebasing replays the branch's commits, and a branch that adds or edits
+# anything under .github/workflows is refused without it, with "refusing to
+# allow [...] to create or update workflow [...] without workflow scope
+# (updatePullRequestBranch)". This repository merges such pull requests
+# regularly, so a token missing it would work until precisely the pull request
+# that needed it most.
+#
+# A GitHub App installation token is the other identity that works, with the
+# same three permissions, and nothing about it expires : the private key is
+# permanent and the token is minted per run. It is what GitHub itself points to
+# for this case. The cost is registering and installing the App once
 
 on:
   push:
@@ -235,11 +247,15 @@ jobs:
               echo "::notice::Pull request #$number could not be rebased ($rebase_error), so it has been updated with a merge commit instead."
               updated=$((updated + 1))
             else
-              # A pull request opened from a fork can only be updated from here
-              # if its author left "Allow edits by maintainers" ticked, and the
-              # token has to be allowed to write to the fork as well. Neither is
-              # something this repository can decide, so a refusal is reported
-              # and the run carries on with the next pull request
+              # A pull request opened from a fork is expected to land here : the
+              # update writes to the fork, and neither of the two identities
+              # this workflow can use reaches one. A fine-grained token only
+              # ever addresses resources owned by its own resource owner, and an
+              # App installation only the repositories it is installed on, so
+              # "Allow edits by maintainers" does not rescue either of them : it
+              # grants the maintainer, and only a classic token acts with that
+              # breadth. Those pull requests keep being updated by hand ; the
+              # refusal is reported and the run carries on with the next one
               echo "::warning::Pull request #$number is $behind_by commit(s) behind master but could not be updated, neither by rebase ($rebase_error) nor by merge ($update_error). If it comes from a fork, its author has to tick \"Allow edits by maintainers\" ; otherwise it has to be updated by hand."
             fi
           done

--- a/.github/workflows/auto_update_pull_request_branches.yml
+++ b/.github/workflows/auto_update_pull_request_branches.yml
@@ -26,11 +26,14 @@ name: Auto-update pull request branches
 # get new SHAs : the review comments already written on it are marked outdated,
 # and anyone holding a local copy of that branch has to reset onto it.
 #
-# /!\ The update cannot be pushed with the default GITHUB_TOKEN. Nothing that
-# token pushes fires a "pull_request" event, so the "Tests" workflow would never
-# run on the head commit the update creates and the required checks would stay
-# at "Expected — Waiting for status to be reported", blocking the very merge
-# this workflow exists to unblock. It uses the PULL_REQUESTS_UPDATE_TOKEN secret
+# /!\ The update cannot be pushed with the default GITHUB_TOKEN. An update that
+# token pushes does fire "pull_request : synchronize", but the runs it creates
+# are held in an approval-required state : the pull request shows an "Approve
+# workflows to run" banner that somebody with write access has to click before
+# the required checks even start. No repository setting turns that off, and
+# swapping one click per pull request for another is not worth a workflow, so
+# the update is made by an identity GitHub already trusts. It uses the
+# PULL_REQUESTS_UPDATE_TOKEN secret
 # instead : a fine-grained personal access token, whose resource owner is this
 # account and whose repository access covers this repository, granting the
 # "Contents : read and write" and "Pull requests : read and write" repository
@@ -67,7 +70,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.PULL_REQUESTS_UPDATE_TOKEN }}
           REPOSITORY: ${{ github.repository }}
-          MASTER_SHA: ${{ github.sha }}
           # Whether a pull request whose rebase conflicts is updated with a
           # merge commit rather than left behind
           FALL_BACK_TO_MERGE: "true"
@@ -122,6 +124,14 @@ jobs:
             exit 1
           fi
 
+          # Master is asked for by name rather than taken from github.sha :
+          # that is master's tip under the push trigger, but under
+          # workflow_dispatch it is the tip of whichever ref the run was started
+          # from, and the ref picker offers every branch carrying this file.
+          # Measuring against the wrong base would report up-to-date pull
+          # requests as behind, and skip genuinely behind ones as up to date
+          master_sha="$(gh api "repos/$REPOSITORY/commits/master" --jq '.sha')"
+
           # Draft pull requests are skipped. They are not waiting to be merged,
           # and several of them live in forks where an unasked-for merge commit
           # after each push to master would be noise rather than help.
@@ -135,16 +145,24 @@ jobs:
               --limit 100 \
               --json number,isDraft
           )"
+          open_count="$(jq 'length' <<< "$open_pull_requests")"
           mapfile -t pull_requests < <(
             jq --raw-output '.[] | select(.isDraft | not) | .number' <<< "$open_pull_requests"
           )
 
+          # Told apart, because an empty list after the draft filter is not the
+          # same thing as an empty repository and saying so would be untrue
           if [ "${#pull_requests[@]}" -eq 0 ]; then
-            echo "No open pull request targets master."
+            if [ "$open_count" -eq 0 ]; then
+              echo "No open pull request targets master."
+            else
+              echo "The $open_count open pull request(s) targeting master are all drafts, which this workflow leaves alone."
+            fi
+            echo "Updated 0 pull request(s)." >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
 
-          echo "Considering ${#pull_requests[@]} open pull request(s) against master $MASTER_SHA."
+          echo "Considering ${#pull_requests[@]} open pull request(s) against master $master_sha."
 
           updated=0
           for number in "${pull_requests[@]}"; do
@@ -183,13 +201,12 @@ jobs:
               continue
             fi
 
-            # An open pull request has its head commit mirrored into this
-            # repository as refs/pull/<number>/head, so comparing by SHA works
-            # for a pull request opened from a fork too, and avoids having to
-            # put a branch name holding slashes in the URL.
+            # Comparing by SHA is what lets this work for a pull request opened
+            # from a fork : its branch names nothing in this repository, but its
+            # head commit is mirrored here as refs/pull/<number>/head.
             # In "A...B", behind_by counts the commits A has and B does not :
             # exactly how far behind master this pull request is
-            if ! behind_by="$(gh api "repos/$REPOSITORY/compare/$MASTER_SHA...$head_sha" --jq '.behind_by')" ||
+            if ! behind_by="$(gh api "repos/$REPOSITORY/compare/$master_sha...$head_sha" --jq '.behind_by')" ||
                ! [[ "$behind_by" =~ ^[0-9]+$ ]]; then
               echo "::warning::Pull request #$number could not be compared with master, skipping it."
               continue

--- a/.github/workflows/auto_update_pull_request_branches.yml
+++ b/.github/workflows/auto_update_pull_request_branches.yml
@@ -12,6 +12,20 @@ name: Auto-update pull request branches
 # It is not an option here : it requires a repository owned by an organization,
 # and this one belongs to a personal account.
 #
+# The update is done by rebase, which is why it goes through the GraphQL
+# mutation rather than the REST "update a pull request branch" endpoint : that
+# endpoint only knows how to merge the base branch into the pull request. A
+# rebase replays the commits of the branch one by one, so it can hit a conflict
+# on an intermediate commit even on a pull request GitHub reports as mergeable,
+# because "mergeable" only ever answers for the merge. FALL_BACK_TO_MERGE below
+# decides what happens then : updating with a merge commit keeps the pull
+# request unblocked, which is the whole point, at the cost of a merge commit on
+# that one. Set it to "false" to leave those pull requests alone instead.
+#
+# Rebasing force-pushes the branch, so the commits of an updated pull request
+# get new SHAs : the review comments already written on it are marked outdated,
+# and anyone holding a local copy of that branch has to reset onto it.
+#
 # /!\ The update cannot be pushed with the default GITHUB_TOKEN. Nothing that
 # token pushes fires a "pull_request" event, so the "Tests" workflow would never
 # run on the head commit the update creates and the required checks would stay
@@ -49,13 +63,59 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - name: Update every conflict-free pull request that is behind master
+      - name: Rebase every conflict-free pull request that is behind master
         env:
           GH_TOKEN: ${{ secrets.PULL_REQUESTS_UPDATE_TOKEN }}
           REPOSITORY: ${{ github.repository }}
           MASTER_SHA: ${{ github.sha }}
+          # Whether a pull request whose rebase conflicts is updated with a
+          # merge commit rather than left behind
+          FALL_BACK_TO_MERGE: "true"
         run: |
           set -euo pipefail
+
+          # Updates one pull request, by rebase or by merge. The mutation is the
+          # one "gh pr update-branch" itself calls ; it is used directly here
+          # because gh does not expose expectedHeadOid, which is what keeps the
+          # update from landing on a commit the author pushed in the meantime.
+          # A GraphQL error comes back inside a 200 response, so the body has to
+          # be looked at rather than only the exit status
+          update_error=""
+          update_pull_request() {
+            local update_method="$1" pull_request_id="$2" expected_head_oid="$3"
+            local response
+
+            if ! response="$(
+              gh api graphql \
+                --raw-field "pullRequestId=$pull_request_id" \
+                --raw-field "expectedHeadOid=$expected_head_oid" \
+                --raw-field "updateMethod=$update_method" \
+                --raw-field 'query=
+                  mutation(
+                    $pullRequestId: ID!,
+                    $expectedHeadOid: GitObjectID!,
+                    $updateMethod: PullRequestBranchUpdateMethod!
+                  ) {
+                    updatePullRequestBranch(input: {
+                      pullRequestId: $pullRequestId,
+                      expectedHeadOid: $expectedHeadOid,
+                      updateMethod: $updateMethod
+                    }) {
+                      pullRequest { headRefOid }
+                    }
+                  }' 2>&1
+            )"; then
+              update_error="$(tr '\n' ' ' <<< "$response")"
+              return 1
+            fi
+
+            if jq --exit-status 'has("errors")' <<< "$response" > /dev/null 2>&1; then
+              update_error="$(jq --raw-output '[.errors[].message] | join(" ; ")' <<< "$response")"
+              return 1
+            fi
+
+            return 0
+          }
 
           if [ -z "$GH_TOKEN" ]; then
             echo "::error::The PULL_REQUESTS_UPDATE_TOKEN secret is empty or missing, so nothing can be updated. The comment at the top of this workflow says which token to create and why the default one cannot be used."
@@ -95,12 +155,15 @@ jobs:
             # wait for the answer
             mergeable="null"
             head_sha=""
+            node_id=""
             for _ in 1 2 3 4 5; do
               if ! pull_request="$(gh api "repos/$REPOSITORY/pulls/$number")"; then
                 break
               fi
               mergeable="$(jq --raw-output '.mergeable | tostring' <<< "$pull_request")"
               head_sha="$(jq --raw-output '.head.sha' <<< "$pull_request")"
+              # The GraphQL mutation addresses the pull request by node ID
+              node_id="$(jq --raw-output '.node_id' <<< "$pull_request")"
               [ "$mergeable" != "null" ] && break
               sleep 5
             done
@@ -137,22 +200,28 @@ jobs:
               continue
             fi
 
-            # expected_head_sha makes the update a no-op rather than a surprise
-            # if the author pushed to the branch since it was read above
-            if gh api \
-              --method PUT \
-              "repos/$REPOSITORY/pulls/$number/update-branch" \
-              --raw-field "expected_head_sha=$head_sha" \
-              --silent; then
-              echo "Pull request #$number was $behind_by commit(s) behind master and has been updated."
+            if update_pull_request REBASE "$node_id" "$head_sha"; then
+              echo "Pull request #$number was $behind_by commit(s) behind master and has been rebased on top of it."
+              updated=$((updated + 1))
+              continue
+            fi
+            rebase_error="$update_error"
+
+            if [ "$FALL_BACK_TO_MERGE" != "true" ]; then
+              echo "::warning::Pull request #$number is $behind_by commit(s) behind master and could not be rebased : $rebase_error"
+              continue
+            fi
+
+            if update_pull_request MERGE "$node_id" "$head_sha"; then
+              echo "::notice::Pull request #$number could not be rebased ($rebase_error), so it has been updated with a merge commit instead."
               updated=$((updated + 1))
             else
               # A pull request opened from a fork can only be updated from here
               # if its author left "Allow edits by maintainers" ticked, and the
-              # token must be allowed to write to the fork as well. Neither is
+              # token has to be allowed to write to the fork as well. Neither is
               # something this repository can decide, so a refusal is reported
               # and the run carries on with the next pull request
-              echo "::warning::Pull request #$number is $behind_by commit(s) behind master but could not be updated. If it comes from a fork, its author has to tick \"Allow edits by maintainers\" ; otherwise it has to be updated by hand."
+              echo "::warning::Pull request #$number is $behind_by commit(s) behind master but could not be updated, neither by rebase ($rebase_error) nor by merge ($update_error). If it comes from a fork, its author has to tick \"Allow edits by maintainers\" ; otherwise it has to be updated by hand."
             fi
           done
 

--- a/.github/workflows/auto_update_pull_request_branches.yml
+++ b/.github/workflows/auto_update_pull_request_branches.yml
@@ -32,14 +32,16 @@ name: Auto-update pull request branches
 # workflows to run" banner that somebody with write access has to click before
 # the required checks even start. No repository setting turns that off, and
 # swapping one click per pull request for another is not worth a workflow, so
-# the update is made by an identity GitHub already trusts. It uses the
-# PULL_REQUESTS_UPDATE_TOKEN secret
-# instead : a fine-grained personal access token, whose resource owner is this
-# account and whose repository access covers this repository, granting the
-# "Contents : read and write" and "Pull requests : read and write" repository
-# permissions. Create it in Settings > Developer settings > Personal access
-# tokens > Fine-grained tokens, then store it in Settings > Secrets and
-# variables > Actions > New repository secret
+# the update has to come from an identity GitHub already trusts.
+#
+# That identity is the PULL_REQUESTS_UPDATE_TOKEN secret : a fine-grained
+# personal access token, whose resource owner is this account and whose
+# repository access covers this repository, granting the "Contents : read and
+# write" and "Pull requests : read and write" repository permissions. Create it
+# in Settings > Developer settings > Personal access tokens > Fine-grained
+# tokens, then store it in Settings > Secrets and variables > Actions > New
+# repository secret. A GitHub App installation token works here too and never
+# expires, at the cost of creating and installing the App
 
 on:
   push:

--- a/.github/workflows/auto_update_pull_request_branches.yml
+++ b/.github/workflows/auto_update_pull_request_branches.yml
@@ -55,10 +55,14 @@ name: Auto-update pull request branches
 # permissions, and it is what GitHub itself points to for this case. Nothing
 # about it has to be renewed by hand, because the private key does not expire.
 # Its installation token does, after an hour, so it is not something to paste
-# into the secret : the private key goes there instead, and a step such as
-# actions/create-github-app-token mints a fresh token at the start of every run.
-# That step, which this workflow does not currently carry, plus registering and
-# installing the App, is what the App route costs over the token
+# into a secret : the private key goes into PULL_REQUESTS_UPDATE_APP_PRIVATE_KEY
+# and the App's identifier into the PULL_REQUESTS_UPDATE_APP_ID variable, and
+# the first step below mints a fresh token from them at the start of every run.
+#
+# Both routes are wired up, and setting the App variable is the whole migration :
+# the minting step only runs once that variable exists, and the token falls back
+# to the personal access token whenever it does not. So the App can be adopted
+# later, or never, without this file changing over the token
 
 on:
   push:
@@ -85,9 +89,25 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+      # Only runs once the App route is configured : without the variable there
+      # is nothing to mint from, the step is skipped, and the token below falls
+      # back to the personal access token. Setting the variable is the whole
+      # migration, and it needs no change to this file
+      - name: Mint an installation token, if a GitHub App is configured
+        id: app-token
+        if: vars.PULL_REQUESTS_UPDATE_APP_ID != ''
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.PULL_REQUESTS_UPDATE_APP_ID }}
+          private-key: ${{ secrets.PULL_REQUESTS_UPDATE_APP_PRIVATE_KEY }}
+
       - name: Rebase every conflict-free pull request that is behind master
         env:
-          GH_TOKEN: ${{ secrets.PULL_REQUESTS_UPDATE_TOKEN }}
+          # The App's token when there is one, the personal access token
+          # otherwise. Whichever it is, it needs the three permissions the
+          # header describes
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.PULL_REQUESTS_UPDATE_TOKEN }}
+          UPDATING_AS: ${{ vars.PULL_REQUESTS_UPDATE_APP_ID != '' && 'the GitHub App' || 'the personal access token' }}
           REPOSITORY: ${{ github.repository }}
           # Whether a pull request whose rebase conflicts is updated with a
           # merge commit rather than left behind
@@ -144,9 +164,13 @@ jobs:
           }
 
           if [ -z "$GH_TOKEN" ]; then
-            echo "::error::The PULL_REQUESTS_UPDATE_TOKEN secret is empty or missing, so nothing can be updated. The comment at the top of this workflow says which token to create and why the default one cannot be used."
+            echo "::error::No credential is configured, so nothing can be updated. Set either the PULL_REQUESTS_UPDATE_TOKEN secret or the PULL_REQUESTS_UPDATE_APP_ID variable together with the PULL_REQUESTS_UPDATE_APP_PRIVATE_KEY secret. The comment at the top of this workflow says what each one needs and why the default token is not enough."
             exit 1
           fi
+
+          # Named in the log because the two identities fail differently, and
+          # knowing which one ran is the first thing wanted when one of them does
+          echo "Updating as $UPDATING_AS."
 
           # Master is asked for by name rather than taken from github.sha :
           # that is master's tip under the push trigger, but under

--- a/.github/workflows/auto_update_pull_request_branches.yml
+++ b/.github/workflows/auto_update_pull_request_branches.yml
@@ -26,11 +26,12 @@ name: Auto-update pull request branches
 # get new SHAs : the review comments already written on it are marked outdated,
 # and anyone holding a local copy of that branch has to reset onto it.
 #
-# /!\ The update cannot be pushed with the default GITHUB_TOKEN. An update that
-# token pushes does fire "pull_request : synchronize", but the runs it creates
-# are held in an approval-required state : the pull request shows an "Approve
-# workflows to run" banner that somebody with write access has to click before
-# the required checks even start. No repository setting turns that off, and
+# /!\ The default GITHUB_TOKEN can push the update, it just gains nothing by it.
+# An update that token pushes does fire "pull_request : synchronize", but the
+# runs it creates are held in an approval-required state : the pull request
+# shows an "Approve workflows to run" banner that somebody with write access has
+# to click before the required checks even start. No repository setting turns
+# that off, and
 # swapping one click per pull request for another is not worth a workflow, so
 # the update has to come from an identity GitHub already trusts.
 #
@@ -50,10 +51,14 @@ name: Auto-update pull request branches
 # regularly, so a token missing it would work until precisely the pull request
 # that needed it most.
 #
-# A GitHub App installation token is the other identity that works, with the
-# same three permissions, and nothing about it expires : the private key is
-# permanent and the token is minted per run. It is what GitHub itself points to
-# for this case. The cost is registering and installing the App once
+# A GitHub App is the other identity that works, with the same three
+# permissions, and it is what GitHub itself points to for this case. Nothing
+# about it has to be renewed by hand, because the private key does not expire.
+# Its installation token does, after an hour, so it is not something to paste
+# into the secret : the private key goes there instead, and a step such as
+# actions/create-github-app-token mints a fresh token at the start of every run.
+# That step, which this workflow does not currently carry, plus registering and
+# installing the App, is what the App route costs over the token
 
 on:
   push:
@@ -90,10 +95,15 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Updates one pull request, by rebase or by merge. The mutation is the
-          # one "gh pr update-branch" itself calls ; it is used directly here
-          # because gh does not expose expectedHeadOid, which is what keeps the
-          # update from landing on a commit the author pushed in the meantime.
+          # Updates one pull request, by rebase or by merge, through the same
+          # updatePullRequestBranch mutation that "gh pr update-branch" wraps.
+          # expectedHeadOid pins the update to the head commit read just above,
+          # so it cannot land on a commit the author pushed in the meantime.
+          # The mutation is called directly rather than through gh for the error
+          # message : gh reports any failure as "Cannot update PR branch due to
+          # conflicts", which would misdiagnose a token missing the Workflows
+          # permission as a conflict and send the reader hunting the wrong
+          # thing. The log below quotes what GitHub actually said instead.
           # A GraphQL error comes back inside a 200 response, so the body has to
           # be looked at rather than only the exit status
           update_error=""


### PR DESCRIPTION
Closes #312.

Requiring branches to be up to date before merging means every merge into master puts every other open pull request one commit behind, and each of them then has to have its "Update branch" button pressed by hand before it can be merged in turn. With a dozen pull requests open at once, merging one costs a round of clicking on all the others.

This adds a workflow that does that round automatically after each push to master, by rebase.

## What it does

On every push to master (and on demand via `workflow_dispatch`), it walks the open pull requests targeting master and rebases the ones that need it. It skips:

- **the ones GitHub reports as conflicting** — resolving those is their author's call;
- **the ones already containing master's tip**, checked with `behind_by` on the compare endpoint;
- **drafts** — they are not waiting to be merged, and several of them live in forks where a commit after every push to master would be noise. Removing the `select(.isDraft | not)` includes them.

Master's tip is asked for by name rather than taken from `github.sha`. Under the push trigger the two are the same, but under `workflow_dispatch` `github.sha` is the tip of whichever ref the run was started from, and the ref picker offers every branch carrying the workflow file. Measuring against the wrong base would report up-to-date pull requests as behind and, worse, silently skip genuinely behind ones as up to date.

Merging a pull request invalidates the mergeability GitHub had computed for every other one, and it is recomputed in the background, so each pull request is read up to five times until GitHub stops answering `null`. One left undecided is skipped with a warning and picked up by the next push rather than being updated blindly.

Runs are serialised on a `concurrency` group, without cancelling: two merges landing one after the other would otherwise walk the same list at once, the second racing the updates the first is still pushing.

## Why GraphQL rather than the REST endpoint

The REST "update a pull request branch" endpoint only knows how to merge the base branch into the pull request. Rebasing goes through the `updatePullRequestBranch` GraphQL mutation, which takes an `updateMethod` — the same mutation `gh pr update-branch --rebase` wraps.

`expectedHeadOid` pins the update to the head commit the run just read, so it cannot land on a commit the author replaced in the meantime. (`gh` sends that field too, from the head OID it reads itself — it simply has no flag for it.)

The mutation is called directly rather than through `gh` for the error message. `gh` reports every failure as "Cannot update PR branch due to conflicts", which would misdiagnose a token missing the `Workflows` permission — see below — as a conflict, and send whoever reads the log hunting the wrong thing. Calling the mutation directly is what lets the log quote what GitHub actually said.

## Why there is a fallback to merge

`mergeable` only ever answers for the merge. A rebase replays the commits of the branch one at a time, so it can conflict on an intermediate commit even on a pull request GitHub reports as mergeable. When that happens the pull request is updated with a merge commit instead, and the log says so along with the message the rebase failed on — leaving it behind would put it right back in the state this workflow exists to avoid. `FALL_BACK_TO_MERGE: "false"` turns that off.

## Why not the default GITHUB_TOKEN

The default `GITHUB_TOKEN` can push the update — it just gains nothing by it. The push does fire `pull_request: synchronize`, but the runs it creates are held in an approval-required state: the pull request shows an "Approve workflows to run" banner, and the required checks do not start until somebody with write access clicks it. No repository setting turns that off; the approval settings GitHub exposes cover fork and outside-contributor runs, not this. Swapping one "Update branch" click per pull request for one "Approve workflows to run" click per pull request is not worth a workflow, so the update has to come from an identity GitHub already trusts.

## What has to be set up before this does anything

**Merging this pull request is not enough on its own.** A credential has to exist, or the workflow fails loudly on its first run rather than silently doing nothing. It cannot be created from a pull request — it is a few clicks in this account's settings.

**Both routes are wired up**, so this is not a decision to make now. The minting step only runs once the App variable exists, and the credential falls back to the personal access token whenever it does not — so the repository can start on the token and move to the App later, or never, with this file untouched.

| | set | expires |
|---|---|---|
| **Personal access token** — quickest | `PULL_REQUESTS_UPDATE_TOKEN` secret | yes, renew by hand |
| **GitHub App** — what GitHub points to for this case | `PULL_REQUESTS_UPDATE_APP_ID` variable + `PULL_REQUESTS_UPDATE_APP_PRIVATE_KEY` secret | no, the private key is permanent |

Either identity needs the **same three repository permissions**: `Contents: read and write`, `Pull requests: read and write`, and `Workflows: read and write`.

That third one is easily left out, and leaving it out is a trap: rebasing replays the branch's commits, and a branch that adds or edits anything under `.github/workflows` is refused without it — `refusing to allow [...] to create or update workflow [...] without workflow scope (updatePullRequestBranch)`. This repository merges such pull requests regularly, and the one adding this very file is one of them, so a credential granted only the first two would work right up until the pull request that needed it most.

Which identity ran is printed in the log, because the two fail differently.

Worth noting too that, like any workflow triggered by a push to master, this one only starts working once it is on master — it will not run for this pull request.

## Notes

- **Pull requests opened from forks are not covered, and cannot be.** The update writes to the contributor's fork, and neither identity above reaches one: a fine-grained token only ever addresses resources owned by its own resource owner, and an App installation only the repositories it is installed on. "Allow edits by maintainers" does not rescue either, because it grants the maintainer as a user and only a classic token acts with that breadth — a much wider credential than this job deserves. Those pull requests keep being updated by hand; the refusal is reported as a warning and the run carries on.
- Rebasing force-pushes the branch, so the commits of an updated pull request get new SHAs: review comments already written on it are marked outdated, and anyone holding a local copy of that branch has to reset onto it.
- Comparing by SHA rather than by branch name is what lets the same code address a fork's pull request at all: a fork's branch names nothing in this repository, but its head commit is mirrored here as `refs/pull/NUMBER/head`.
- The listing is capped at 100 open pull requests per run, which is well above what this repository carries; past that, the surplus would wait for the next push.
- A run that finds only drafts says so, rather than reporting that nothing targets master.
- GitHub's built-in answer to all of this is the merge queue, which needs no credential at all, but it is only offered on repositories owned by an organization.

## Testing

The workflow itself can only really run once it is on master. What was checked here: the YAML parses and the step script passes `bash -n`; a fork pull request's head SHA does resolve from this repository, so the compare call works for forks; the four paths of the update helper were exercised against a stubbed `gh` — success, a GraphQL error returned inside a 200 response, several errors at once, and `gh` itself exiting non-zero — confirming the messages surface and that `set -e` does not cut the run short on the first failure; and the listing was exercised over an empty repository, an all-drafts repository, a mixed one and a no-drafts one, confirming each reports what is actually there.