### PR TITLE
Send a fan control profile when it changes, not on every cycle

### DIFF
--- a/Dell_iDRAC_fan_controller.sh
+++ b/Dell_iDRAC_fan_controller.sh
@@ -568,15 +568,25 @@ while true; do
     # No comment will be displayed on the change of this parameter since it is not related to the temperature of any device (CPU, GPU, etc...) but only to the settings made by the user when launching this Docker container
     if "$DISABLE_THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE"; then
       REQUESTED_THIRD_PARTY_PCIE_CARD_COOLING_RESPONSE="Disabled"
-      disable_third_party_PCIe_card_Dell_default_cooling_response
     else
       REQUESTED_THIRD_PARTY_PCIE_CARD_COOLING_RESPONSE="Enabled"
+    fi
+
+    # Its input is an environment variable, so the request is identical on every cycle : send it when it
+    # changes and on the periodic refresh, and keep reporting the state the server was left in otherwise
+    if ! should_send_PCIe_cooling_response "$REQUESTED_THIRD_PARTY_PCIE_CARD_COOLING_RESPONSE"; then
+      : # nothing to send, the status column keeps the value the last send left it
+    else
+    if "$DISABLE_THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE"; then
+      disable_third_party_PCIe_card_Dell_default_cooling_response
+    else
       enable_third_party_PCIe_card_Dell_default_cooling_response
     fi
     # The status of the command the branch above just ran
     THIRD_PARTY_PCIE_CARD_COOLING_RESPONSE_EXIT_CODE=$?
 
     if [ $THIRD_PARTY_PCIE_CARD_COOLING_RESPONSE_EXIT_CODE -eq 0 ]; then
+      record_sent_PCIe_cooling_response "$REQUESTED_THIRD_PARTY_PCIE_CARD_COOLING_RESPONSE"
       THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE_STATUS="$REQUESTED_THIRD_PARTY_PCIE_CARD_COOLING_RESPONSE"
 
       if "$MONITORING_ONLY_MODE"; then
@@ -592,6 +602,7 @@ while true; do
       # busy BMC, an answer this controller does not recognize. Report the cycle and try again on the next
       THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE_STATUS="Could not be applied on this cycle"
     fi
+    fi
   fi
 
   # Print temperatures, active fan control profile and comment if any change happened during last time interval
@@ -604,6 +615,10 @@ while true; do
   ((TABLE_HEADER_PRINT_COUNTER++))
 
   wait $SLEEP_PROCESS_PID
+
+  # A cycle has gone by, so the profile is that much closer to its periodic refresh
+  (( SECONDS_SINCE_FAN_CONTROL_PROFILE_SENT += CHECK_INTERVAL_IN_SECONDS ))
+  (( SECONDS_SINCE_PCIE_COOLING_RESPONSE_SENT += CHECK_INTERVAL_IN_SECONDS ))
 
   # Start timer in background for next cycle
   sleep "$CHECK_INTERVAL" &

--- a/constants.sh
+++ b/constants.sh
@@ -64,3 +64,15 @@ readonly COOLING_RESPONSE_COLUMN_WIDTH=51
 # before killing it outright. Docker's own grace period is 10 seconds by default, so this has to stay
 # comfortably inside it or the container is SIGKILLed as a whole before the supervisor gets to act
 readonly SUPERVISOR_GRACE_PERIOD_IN_SECONDS=3
+
+# How long a fan control profile may go without being re-sent to the BMC, in seconds.
+#
+# The profile only has to be sent when it changes : the commands are idempotent and the value is the
+# same on every cycle. Re-sending it is nonetheless kept, at a much lower rate, because some iDRAC and
+# BMC firmwares take fan control back on their own -- after an internal watchdog, a reset, or a firmware
+# update -- and nothing else would notice. Sending only on change would remove that safety net, and the
+# failure would be silent : fans louder than configured, no log line, nothing wrong on the surface.
+#
+# Bounded on its own terms rather than tied to CHECK_INTERVAL : the two answer different questions,
+# "how fast do I react to heat" and "how long may a BMC hold the fans before I correct it"
+readonly FAN_CONTROL_PROFILE_REFRESH_INTERVAL_IN_SECONDS=60

--- a/functions.sh
+++ b/functions.sh
@@ -11,16 +11,78 @@ function apply_Dell_default_fan_control_profile() {
   # message...") even when the command actually succeeds. Rather than discard stderr unconditionally (which
   # would also hide a genuine failure to apply this safety-critical profile), capture it and only surface it
   # if the command actually failed (non-zero exit code)
-  local ipmitool_stderr
-  ipmitool_stderr=$(ipmitool -I $IDRAC_LOGIN_STRING raw 0x30 0x30 0x01 0x01 2>&1 >/dev/null)
-  if [ $? -ne 0 ]; then
-    print_error "Failed to apply Dell default fan control profile. ipmitool said: $ipmitool_stderr"
-    # The table says what the server is actually doing, not what was attempted : this profile is the
-    # safety fallback, so claiming it while the command was refused is the one lie that matters here
-    CURRENT_FAN_CONTROL_PROFILE="Dell default dynamic fan control profile (not applied)"
-    return 1
+  if should_send_fan_control_profile "Dell"; then
+    local ipmitool_stderr
+    ipmitool_stderr=$(ipmitool -I $IDRAC_LOGIN_STRING raw 0x30 0x30 0x01 0x01 2>&1 >/dev/null)
+    if [ $? -ne 0 ]; then
+      print_error "Failed to apply Dell default fan control profile. ipmitool said: $ipmitool_stderr"
+      # The table says what the server is actually doing, not what was attempted : this profile is the
+      # safety fallback, so claiming it while the command was refused is the one lie that matters here
+      CURRENT_FAN_CONTROL_PROFILE="Dell default dynamic fan control profile (not applied)"
+      return 1
+    fi
+    record_sent_fan_control_profile "Dell"
   fi
   CURRENT_FAN_CONTROL_PROFILE="Dell default dynamic fan control profile"
+}
+
+# What was last actually sent to the BMC, and how long ago. Empty means nothing has been sent yet
+LAST_SENT_FAN_CONTROL_COMMAND=""
+SECONDS_SINCE_FAN_CONTROL_PROFILE_SENT=0
+
+# Same gating for the third-party PCIe card cooling response, on its own clock
+LAST_SENT_PCIE_COOLING_RESPONSE=""
+SECONDS_SINCE_PCIE_COOLING_RESPONSE_SENT=0
+
+# Returns 0 (true) if the PCIe cooling response has to be sent on this cycle, 1 (false) otherwise
+# Usage : should_send_PCIe_cooling_response "$REQUESTED_STATE"
+#
+# Its input is an environment variable, which cannot change while the container runs, so this command
+# was the purest of the redundant ones : the same request re-sent every cycle for the life of the
+# container. It keeps the same periodic refresh as the fan profile, for the same reason -- a BMC that
+# was reset comes back with its own default rather than the state the user asked for
+function should_send_PCIe_cooling_response() {
+  local -r REQUESTED_STATE="$1"
+
+  [ "$REQUESTED_STATE" != "$LAST_SENT_PCIE_COOLING_RESPONSE" ] && return 0
+  [ "$SECONDS_SINCE_PCIE_COOLING_RESPONSE_SENT" -ge "$FAN_CONTROL_PROFILE_REFRESH_INTERVAL_IN_SECONDS" ]
+}
+
+# Record that the PCIe cooling response has just reached the BMC, restarting its refresh delay
+# Usage : record_sent_PCIe_cooling_response "$REQUESTED_STATE"
+#
+# Only called on success, like its fan profile counterpart : a request that did not go through has not
+# earned a refresh interval, and a transient failure must be retried on the very next cycle
+function record_sent_PCIe_cooling_response() {
+  LAST_SENT_PCIE_COOLING_RESPONSE="$1"
+  SECONDS_SINCE_PCIE_COOLING_RESPONSE_SENT=0
+}
+
+# Returns 0 (true) if the given profile has to be sent to the BMC on this cycle, 1 (false) otherwise
+# Usage : should_send_fan_control_profile "$COMMAND_IDENTITY"
+#
+# A steady-state cycle used to cost 5 IPMI commands, 3 of which re-applied a setting that had not
+# changed since the previous cycle. At the default 5 second interval that is 36 redundant commands a
+# minute, forever, and it is the traffic that makes network mode sensitive to the iDRAC's session limit
+function should_send_fan_control_profile() {
+  local -r COMMAND_IDENTITY="$1"
+
+  # A different profile, or a different speed for the same profile, always goes out at once
+  [ "$COMMAND_IDENTITY" != "$LAST_SENT_FAN_CONTROL_COMMAND" ] && return 0
+
+  # Otherwise only the periodic refresh, so a BMC that took fan control back is corrected within a
+  # bounded delay instead of never
+  [ "$SECONDS_SINCE_FAN_CONTROL_PROFILE_SENT" -ge "$FAN_CONTROL_PROFILE_REFRESH_INTERVAL_IN_SECONDS" ]
+}
+
+# Record that the given profile has just reached the BMC, restarting its refresh delay
+# Usage : record_sent_fan_control_profile "$COMMAND_IDENTITY"
+#
+# Only called on success : a refused command must be retried on the very next cycle rather than wait
+# out a refresh interval it never earned
+function record_sent_fan_control_profile() {
+  LAST_SENT_FAN_CONTROL_COMMAND="$1"
+  SECONDS_SINCE_FAN_CONTROL_PROFILE_SENT=0
 }
 
 # This function applies a static fan control profile at the given speed
@@ -49,23 +111,30 @@ function apply_static_fan_control_profile() {
   # fan control away from Dell's own dynamic profile, the second sets the speed. Failing the first and
   # succeeding the second is not a partial success but the worst case -- the fans are still Dell's to
   # drive -- so either failure means the profile was not applied
-  local ipmitool_stderr
-  local IS_PROFILE_APPLIED=true
+  # The speed is part of the identity : the same profile at a different percentage is a different
+  # command and has to go out at once rather than wait for the next refresh
+  local -r COMMAND_IDENTITY="static:$HEXADECIMAL_SPEED"
 
-  ipmitool_stderr=$(ipmitool -I $IDRAC_LOGIN_STRING raw 0x30 0x30 0x01 0x00 2>&1 >/dev/null)
-  if [ $? -ne 0 ]; then
-    print_error "Failed to enable manual fan control. ipmitool said: $ipmitool_stderr"
-    IS_PROFILE_APPLIED=false
-  fi
-  ipmitool_stderr=$(ipmitool -I $IDRAC_LOGIN_STRING raw 0x30 0x30 0x02 0xff $HEXADECIMAL_SPEED 2>&1 >/dev/null)
-  if [ $? -ne 0 ]; then
-    print_error "Failed to set fan speed to $DECIMAL_SPEED%. ipmitool said: $ipmitool_stderr"
-    IS_PROFILE_APPLIED=false
-  fi
+  if should_send_fan_control_profile "$COMMAND_IDENTITY"; then
+    local ipmitool_stderr
+    local IS_PROFILE_APPLIED=true
 
-  if ! $IS_PROFILE_APPLIED; then
-    CURRENT_FAN_CONTROL_PROFILE="$PROFILE_NAME ($DECIMAL_SPEED%) (not applied)"
-    return 1
+    ipmitool_stderr=$(ipmitool -I $IDRAC_LOGIN_STRING raw 0x30 0x30 0x01 0x00 2>&1 >/dev/null)
+    if [ $? -ne 0 ]; then
+      print_error "Failed to enable manual fan control. ipmitool said: $ipmitool_stderr"
+      IS_PROFILE_APPLIED=false
+    fi
+    ipmitool_stderr=$(ipmitool -I $IDRAC_LOGIN_STRING raw 0x30 0x30 0x02 0xff $HEXADECIMAL_SPEED 2>&1 >/dev/null)
+    if [ $? -ne 0 ]; then
+      print_error "Failed to set fan speed to $DECIMAL_SPEED%. ipmitool said: $ipmitool_stderr"
+      IS_PROFILE_APPLIED=false
+    fi
+
+    if ! $IS_PROFILE_APPLIED; then
+      CURRENT_FAN_CONTROL_PROFILE="$PROFILE_NAME ($DECIMAL_SPEED%) (not applied)"
+      return 1
+    fi
+    record_sent_fan_control_profile "$COMMAND_IDENTITY"
   fi
   CURRENT_FAN_CONTROL_PROFILE="$PROFILE_NAME ($DECIMAL_SPEED%)"
 }

--- a/tests/cases/70_fan_control_profiles.sh
+++ b/tests/cases/70_fan_control_profiles.sh
@@ -273,3 +273,116 @@ function test_an_applied_profile_still_reports_itself_as_applied() {
   assert_equals "0" "$EXIT_CODE"
   assert_equals "User static fan control profile (5%)" "$CURRENT_FAN_CONTROL_PROFILE"
 }
+
+function fan_commands_sent() {
+  printf '%s' "$(( $(count_ipmitool_calls_matching "raw 0x30 0x30 0x01 0x00") \
+    + $(count_ipmitool_calls_matching "raw 0x30 0x30 0x02 0xff") \
+    + $(count_ipmitool_calls_matching "raw 0x30 0x30 0x01 0x01") ))"
+}
+
+function test_an_unchanged_profile_is_not_re_sent_every_cycle() {
+  # The commands are idempotent and the value is identical on every cycle, so
+  # re-sending it is pure IPMI traffic -- the traffic that makes network mode
+  # sensitive to the iDRAC's session limit
+  DECIMAL_FAN_SPEED=5
+  HEXADECIMAL_FAN_SPEED="0x05"
+
+  apply_user_fan_control_profile
+  local -r AFTER_FIRST=$(fan_commands_sent)
+  assert_equals "2" "$AFTER_FIRST" "the first cycle has to send both commands"
+
+  apply_user_fan_control_profile
+  apply_user_fan_control_profile
+  apply_user_fan_control_profile
+
+  assert_equals "$AFTER_FIRST" "$(fan_commands_sent)" \
+    "an unchanged profile must cost no IPMI command at all"
+  assert_equals "User static fan control profile (5%)" "$CURRENT_FAN_CONTROL_PROFILE" \
+    "the table still names the profile every cycle, only the command is skipped"
+}
+
+function test_a_changed_profile_is_sent_at_once() {
+  # Waiting out a refresh interval before acting on a real change would leave the
+  # fans on the wrong profile for up to a minute, which is the opposite of the point
+  DECIMAL_FAN_SPEED=5
+  HEXADECIMAL_FAN_SPEED="0x05"
+
+  apply_user_fan_control_profile
+  local -r AFTER_USER=$(fan_commands_sent)
+
+  apply_Dell_default_fan_control_profile
+  assert_equals "$((AFTER_USER + 1))" "$(fan_commands_sent)" \
+    "switching to Dell's profile must go out immediately"
+
+  apply_user_fan_control_profile
+  assert_equals "$((AFTER_USER + 3))" "$(fan_commands_sent)" \
+    "and switching back must too"
+}
+
+function test_a_changed_speed_is_sent_at_once() {
+  # Same profile, different percentage : still a different command
+  DECIMAL_FAN_SPEED=5
+  HEXADECIMAL_FAN_SPEED="0x05"
+  apply_user_fan_control_profile
+  local -r AFTER_FIRST=$(fan_commands_sent)
+
+  DECIMAL_FAN_SPEED=30
+  HEXADECIMAL_FAN_SPEED="0x1e"
+  apply_user_fan_control_profile
+
+  assert_equals "$((AFTER_FIRST + 2))" "$(fan_commands_sent)" \
+    "a new speed is a new command, whatever the profile is called"
+}
+
+function test_the_profile_is_re_sent_once_the_refresh_interval_has_elapsed() {
+  # The safety net : some BMC firmwares take fan control back on their own, and
+  # nothing else in the container would notice
+  DECIMAL_FAN_SPEED=5
+  HEXADECIMAL_FAN_SPEED="0x05"
+
+  apply_user_fan_control_profile
+  local -r AFTER_FIRST=$(fan_commands_sent)
+
+  SECONDS_SINCE_FAN_CONTROL_PROFILE_SENT=$FAN_CONTROL_PROFILE_REFRESH_INTERVAL_IN_SECONDS
+  apply_user_fan_control_profile
+
+  assert_equals "$((AFTER_FIRST + 2))" "$(fan_commands_sent)" \
+    "an elapsed refresh interval must put the profile back on the wire"
+  assert_equals "0" "$SECONDS_SINCE_FAN_CONTROL_PROFILE_SENT" \
+    "and restart the delay"
+}
+
+function test_a_refused_profile_is_retried_on_the_very_next_cycle() {
+  # A command that was refused never reached the BMC, so it has not earned the
+  # refresh interval : deferring the retry would leave the fans unmanaged for it
+  DECIMAL_FAN_SPEED=5
+  HEXADECIMAL_FAN_SPEED="0x05"
+  export MOCK_IPMITOOL_RAW_FAIL_PATTERN="0x30 0x30 0x02"
+  export MOCK_IPMITOOL_RAW_FAIL_STDERR="$REJECTED_BY_FIRMWARE_STDERR"
+
+  apply_user_fan_control_profile 2>/dev/null
+  local -r AFTER_FIRST=$(fan_commands_sent)
+
+  apply_user_fan_control_profile 2>/dev/null
+
+  assert_equals "$((AFTER_FIRST + 2))" "$(fan_commands_sent)" \
+    "a refused profile must be retried at once, not deferred to the next refresh"
+}
+
+function test_the_pcie_cooling_response_is_not_re_sent_every_cycle() {
+  # Its input is an environment variable, which cannot change while the container
+  # runs : this was the purest of the redundant commands, the same request re-sent
+  # for the life of the container
+  DISABLE_THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE=false
+
+  should_send_PCIe_cooling_response "Enabled" && record_sent_PCIe_cooling_response "Enabled"
+  assert_command_fails "an unchanged request must not be re-sent" \
+    should_send_PCIe_cooling_response "Enabled"
+
+  assert_command_succeeds "a changed request goes out at once" \
+    should_send_PCIe_cooling_response "Disabled"
+
+  SECONDS_SINCE_PCIE_COOLING_RESPONSE_SENT=$FAN_CONTROL_PROFILE_REFRESH_INTERVAL_IN_SECONDS
+  assert_command_succeeds "and the refresh puts it back on the wire" \
+    should_send_PCIe_cooling_response "Enabled"
+}

--- a/tests/cases/90_integration.sh
+++ b/tests/cases/90_integration.sh
@@ -245,10 +245,14 @@ function test_a_transient_ipmi_failure_does_not_disable_the_cooling_response_for
     "the server recovered, so the setting must be applied and reported again"
   assert_not_contains "$OUTPUT" "Not supported by this server" \
     "one glitch is not a verdict"
-  if [ "$(count_ipmitool_calls_matching "raw 0x30 0xce")" -ge 4 ]; then
+  # The retry is what matters, not how many times the command is repeated afterwards.
+  # A request that did not go through is not recorded as sent, so it goes out again on
+  # the very next cycle ; once it lands, it is only repeated on the periodic refresh
+  # rather than on every cycle
+  if [ "$(count_ipmitool_calls_matching "raw 0x30 0xce")" -ge 2 ]; then
     pass
   else
-    fail "the controller must keep sending the command after a transient refusal" \
+    fail "the controller must send the command again after a transient refusal" \
       "calls: $(recorded_ipmitool_calls)"
   fi
 }


### PR DESCRIPTION
Closes #267. **Second of two**: based on #165. Both restructure how a fan speed is sent, so stacking them avoids a guaranteed conflict. **Merge #165 first.**

## What was happening

A steady-state cycle cost **5 IPMI commands, 3 of which re-applied a setting that had not changed**: enabling manual fan control, setting the speed, and the third-party PCIe cooling response. At the default 5 second interval that is **36 redundant commands a minute**, forever.

That is the traffic that makes network mode sensitive to the iDRAC's session limit — the same limit whose exhaustion #151 describes as making the power state check start failing, which then silences temperature monitoring entirely.

## What looked like a guard was not one

```bash
apply_user_fan_control_profile          # sends 2 IPMI commands, unconditionally

# Check if user fan control profile is applied then apply it if not
if $IS_DELL_DEFAULT_FAN_CONTROL_PROFILE_APPLIED || $IS_FIRST_MONITORING_CYCLE; then
  ...
  COMMENT="..."                         # only the comment was conditional
fi
```

The comment above it described behavior the code did not have.

The PCIe cooling response was the purest case: its input is an **environment variable**, which cannot change while the container runs, yet the same request went out every cycle for the container's whole life.

## The fix, and why re-sending is kept

Both are sent when their **identity** changes — the fan speed being part of that identity, so the same profile at a different percentage still goes out at once.

Re-sending is **kept at a much lower rate rather than dropped**. Some iDRAC and BMC firmwares take fan control back on their own — after an internal watchdog, a reset, or a firmware update — and nothing else in the container would notice. Sending only on change would remove that safety net, and the failure would be *silent*: fans louder than configured, no log line, nothing wrong on the surface.

`FAN_CONTROL_PROFILE_REFRESH_INTERVAL_IN_SECONDS` bounds how long a BMC may hold the fans before being corrected. It is deliberately **not tied to `CHECK_INTERVAL`**: the two answer different questions — "how fast do I react to heat" and "how long may a BMC hold the fans".

> **The 60 second default is a judgement call, not a measurement.** It is the one number here worth arguing about, and it is a one-line change in `constants.sh`.

A refused command is **not** recorded as sent, so it is retried on the very next cycle rather than waiting out a refresh interval it never earned.

## Result, measured

Over 5 steady-state cycles against the stubbed `ipmitool`:

```
cycles=5   power=6   sdr=5   fan=2   pcie=2
```

The fan and PCIe commands are one-time costs now, not per-cycle ones. A cycle is down to **2 IPMI commands** — the power state check and the sensor read, the two that genuinely have to happen every time.

## One existing test changed, and why

`test_a_transient_ipmi_failure_does_not_disable_the_cooling_response_for_good` asserted the command was sent **at least 4 times over 4 cycles**, which encoded the redundant cadence as a requirement. Its intent is that a transient refusal must not permanently disable the setting, so it now asserts the **retry** rather than the repetition — and was checked to still fail when the retry is removed, so it did not lose its teeth.

## Verification

**333 test cases pass** (1864 assertions). New cases counting the commands actually sent:

- an unchanged profile costs **no** IPMI command, while the table still names it every cycle;
- a changed profile goes out immediately, and so does switching back;
- a changed *speed* goes out immediately, same profile name or not;
- an elapsed refresh interval puts the profile back on the wire and restarts the delay;
- a **refused** profile is retried at once rather than deferred;
- the same three properties for the PCIe request.

**Both directions were checked to fail when broken**: removing the gate makes the saving test fail, removing the refresh makes the safety-net test fail. A test proving only one of the two would have been worth little here.