### PR TITLE
Stop granting world-write permissions to the shipped scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ADD healthcheck.sh /app/healthcheck.sh
 ADD Dell_iDRAC_fan_controller.sh /app/Dell_iDRAC_fan_controller.sh
 ADD supervisor.sh /app/supervisor.sh
 
-RUN chmod 0777 /app/functions.sh /app/healthcheck.sh /app/Dell_iDRAC_fan_controller.sh /app/supervisor.sh
+RUN chmod 0755 /app/functions.sh /app/healthcheck.sh /app/Dell_iDRAC_fan_controller.sh /app/supervisor.sh
 
 WORKDIR /app
 


### PR DESCRIPTION
Closes #287.

## Summary
The Dockerfile ran `chmod 0777` on the four shipped scripts, granting read/write/execute to owner, group, **and every other user** inside the container. They only need to be read and executed (sourced or exec'd, never written to at runtime), so `0755` (owner rwx, group/other rx) keeps the same read/execute access without letting any other user inside the container modify them.

Low-severity on its own — the container already runs as root with no `USER` directive, so this isn't exploitable via a privilege boundary today — but a no-behavior-change hardening fix worth making anyway.

## Testing
- Full suite still passes: 318 cases, 1793 assertions (`tests/cases/10_shell_scripts.sh`'s entrypoint check only asserts the pattern `chmod [0-7]+ .*/<entrypoint>`, so it doesn't pin the exact mode).
- No Docker daemon available in this sandbox to do a live `docker build`/`run`, so this wasn't verified against an actual built image. The change is mechanical (same set of files, only the mode bits change) and I traced which invocation path needs the execute bit for each file (`supervisor.sh` is exec'd directly as the entrypoint, `healthcheck.sh` is exec'd directly by `HEALTHCHECK`, `Dell_iDRAC_fan_controller.sh` is invoked via `bash ./Dell_iDRAC_fan_controller.sh` per `supervisor.sh`'s own comment, `functions.sh`/`constants.sh` are only ever sourced) — `0755` covers all of them the same way `0777` did, minus the unneeded write bit for non-owners.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C99hufKg147ydGvBFd3RNK)_