### PR TITLE
Find the intake sensor under the name iDRAC6 gives it

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -1129,6 +1129,19 @@ function retrieve_temperatures() {
   # Parse inlet temperature data, the sensor being located by its name
   INLET_TEMPERATURE=$(retrieve_temperature_by_sensor_name "$DATA" "Inlet")
 
+  # 11th generation servers (iDRAC6 : R610, R710, R510, T610...) call that very sensor "Ambient Temp".
+  # "Inlet Temp" only appears from the 12th generation on, so on every 11G server -- all of which the
+  # catalogue lists as supported -- the intake column showed the "-" placeholder for a sensor that was
+  # answering perfectly well under a name nobody asked it for.
+  #
+  # Deliberately not paired with a "Planar" fallback for the exhaust, although 11G reports one on the
+  # same entity 7.1 : "Planar Temp" is the system board's own temperature, not the air leaving the
+  # chassis. Putting it in the exhaust column would fill it with a number the heading does not describe,
+  # which is worse than leaving it empty. 11G has no exhaust sensor, and "-" is the honest answer
+  if [ -z "$INLET_TEMPERATURE" ]; then
+    INLET_TEMPERATURE=$(retrieve_temperature_by_sensor_name "$DATA" "Ambient")
+  fi
+
   # Parse exhaust temperature data, the sensor being located by its name like the inlet one.
   # It is read on every cycle rather than once, an empty value meaning "nothing on this cycle" rather
   # than "no such sensor" : the presence flag this used to consult was decided from a single pre-loop

--- a/tests/cases/40_temperature_parsing.sh
+++ b/tests/cases/40_temperature_parsing.sh
@@ -67,6 +67,62 @@ function test_the_sign_survives_the_whole_read_not_just_the_extraction() {
   assert_equals "-40;-5" "$CPUS_TEMPERATURES"
 }
 
+function test_the_intake_sensor_is_found_under_its_eleventh_generation_name() {
+  # iDRAC6 (11G : R610, R710, R510, T610...) calls the chassis intake "Ambient Temp". "Inlet Temp"
+  # only exists from 12G on, so looking for that name alone left the intake column showing "-" on
+  # every 11G server -- all of which the catalogue lists as supported
+  export MOCK_IPMITOOL_SDR_OUTPUT
+  MOCK_IPMITOOL_SDR_OUTPUT=$(make_sdr_output --cpus 2 --eleventh-generation-sensor-names --inlet 21)
+
+  retrieve_temperatures
+
+  assert_equals "21" "$INLET_TEMPERATURE" "an 11G intake reading must be found under the name iDRAC6 gives it"
+}
+
+function test_the_system_board_sensor_is_never_reported_as_the_exhaust() {
+  # 11G reports "Planar Temp" on entity 7.1, the same entity the intake uses, and it is the only
+  # other temperature the chassis exposes -- which makes it the obvious thing to mistake for an
+  # exhaust reading. It is the system board's own temperature, not the air leaving the chassis, so
+  # the empty value the display layer renders as "-" is the honest answer here
+  export MOCK_IPMITOOL_SDR_OUTPUT
+  MOCK_IPMITOOL_SDR_OUTPUT=$(make_sdr_output --cpus 2 --eleventh-generation-sensor-names --inlet 21)
+
+  retrieve_temperatures
+
+  assert_empty "$EXHAUST_TEMPERATURE" "11G has no exhaust sensor, and its system board sensor is not one"
+  assert_not_equals "36" "$INLET_TEMPERATURE" "the system board reading must not answer for the intake either"
+}
+
+function test_the_twelfth_generation_intake_still_wins_over_the_fallback() {
+  # The fallback must not become the answer on a server that has both names -- the intake column
+  # has to keep showing the sensor Dell means by "Inlet" wherever one exists
+  local -r SDR_DATA=$(printf '%s\n%s\n' \
+    "$(make_sdr_line "Inlet Temp" "04h" "ok" "7.1" "23 degrees C")" \
+    "$(make_sdr_line "Ambient Temp" "0Eh" "ok" "7.1" "18 degrees C")")
+
+  export MOCK_IPMITOOL_SDR_OUTPUT
+  MOCK_IPMITOOL_SDR_OUTPUT="$SDR_DATA"
+
+  retrieve_temperatures
+
+  assert_equals "23" "$INLET_TEMPERATURE" "\"Inlet Temp\" is what Dell means by the intake when it exists"
+}
+
+function test_a_power_supply_intake_never_answers_for_the_chassis_intake() {
+  # The name is matched at the start of the line for this reason (issue #231), and the 11G fallback
+  # must not reopen the hole : 11G reports two power supply sensors of its own on entity 10.x
+  local -r SDR_DATA=$(printf '%s\n%s\n' \
+    "$(make_sdr_line "PSU1 Inlet Temp" "68h" "ok" "10.1" "29 degrees C")" \
+    "$(make_sdr_line "PSU2 Inlet Temp" "69h" "ok" "10.2" "30 degrees C")")
+
+  export MOCK_IPMITOOL_SDR_OUTPUT
+  MOCK_IPMITOOL_SDR_OUTPUT="$SDR_DATA"
+
+  retrieve_temperatures
+
+  assert_empty "$INLET_TEMPERATURE" "a power supply's own intake is not the chassis air intake"
+}
+
 function test_the_hexadecimal_sensor_id_is_not_mistaken_for_a_temperature() {
   # An R930 numbers its CPU sensors 09h, 0Ah... : the "09" used to be picked up
   # as a reading of its own (issue #91)

--- a/tests/lib/fixtures.sh
+++ b/tests/lib/fixtures.sh
@@ -75,6 +75,12 @@ function make_sdr_line() {
 #                              like a second socket left empty
 #   --with-extra-sensors       add the non-CPU, non-inlet, non-exhaust temperature
 #                              sensors bigger servers report (board, PCIe risers)
+#   --eleventh-generation-sensor-names
+#                              name the chassis sensors the way iDRAC6 does on 11G
+#                              servers (R610, R710, R510, T610...) : "Ambient Temp"
+#                              for the intake, a "Planar Temp" system board sensor on
+#                              the same entity 7.1, and no exhaust sensor at all.
+#                              "Inlet Temp" and "Exhaust Temp" only exist from 12G on
 function make_sdr_output() {
   local CPU_COUNT=2
   local CPU_TEMPERATURES=""
@@ -85,6 +91,7 @@ function make_sdr_output() {
   local WITH_EXHAUST=true
   local CPU2_DISABLED=false
   local WITH_EXTRA_SENSORS=false
+  local ELEVENTH_GENERATION_SENSOR_NAMES=false
 
   while [ $# -gt 0 ]; do
     case "$1" in
@@ -97,16 +104,28 @@ function make_sdr_output() {
       --no-exhaust) WITH_EXHAUST=false; shift ;;
       --cpu2-disabled) CPU2_DISABLED=true; shift ;;
       --with-extra-sensors) WITH_EXTRA_SENSORS=true; shift ;;
+      --eleventh-generation-sensor-names) ELEVENTH_GENERATION_SENSOR_NAMES=true; shift ;;
       *) printf 'make_sdr_output: unknown option "%s"\n' "$1" >&2; return 1 ;;
     esac
   done
 
   # Inlet and exhaust are both reported as entity 7.1: only their name tells them apart
-  if $WITH_INLET; then
-    make_sdr_line "Inlet Temp" "04h" "ok" "7.1" "$INLET_TEMPERATURE degrees C"
-  fi
-  if $WITH_EXHAUST; then
-    make_sdr_line "Exhaust Temp" "01h" "ok" "7.1" "$EXHAUST_TEMPERATURE degrees C"
+  if $ELEVENTH_GENERATION_SENSOR_NAMES; then
+    # Sensor names and hexadecimal IDs taken from a real R710 "ipmitool sdr elist". iDRAC6 reports
+    # no exhaust sensor at all: "Planar Temp" shares entity 7.1 with the intake but is the system
+    # board, not the air leaving the chassis, so it is emitted here precisely so that anything
+    # tempted to read it as an exhaust reading is caught by a test
+    if $WITH_INLET; then
+      make_sdr_line "Ambient Temp" "0Eh" "ok" "7.1" "$INLET_TEMPERATURE degrees C"
+    fi
+    make_sdr_line "Planar Temp" "0Fh" "ok" "7.1" "36 degrees C"
+  else
+    if $WITH_INLET; then
+      make_sdr_line "Inlet Temp" "04h" "ok" "7.1" "$INLET_TEMPERATURE degrees C"
+    fi
+    if $WITH_EXHAUST; then
+      make_sdr_line "Exhaust Temp" "01h" "ok" "7.1" "$EXHAUST_TEMPERATURE degrees C"
+    fi
   fi
 
   local -a REQUESTED_CPU_TEMPERATURES=($CPU_TEMPERATURES)


### PR DESCRIPTION
Closes #294.

## The problem

The intake is located by name, because it shares entity 7.1 with the exhaust and only the name tells them apart. The name looked for is `Inlet`, which **only exists from the 12th generation on** — iDRAC6 (11G: R610, R710, R510, T610, T710) calls that same sensor `Ambient Temp`.

The lookup anchors the name at the start of the line, rightly so — that is what stops `PSU1 Inlet Temp` from answering for the chassis (#231). So on 11G it matched nothing, and the intake column showed `-` for a sensor that was answering perfectly well under another name. Both R610 and R710 are listed as `supported` in the catalogue.

From a real R710 `ipmitool sdr elist`:

```
Ambient Temp     | 0Eh | ok  |  7.1 | 21 degrees C
Planar Temp      | 0Fh | ok  |  7.1 | 36 degrees C
```

## The change

One fallback, tried only when the 12G+ name found nothing:

```bash
if [ -z "$INLET_TEMPERATURE" ]; then
  INLET_TEMPERATURE=$(retrieve_temperature_by_sensor_name "$DATA" "Ambient")
fi
```

Ordered so `Inlet` keeps winning wherever it exists — the fallback can only fill a column that was going to be empty.

## What this deliberately does not do

**`Planar Temp` is not used as an exhaust fallback.** It is on the same entity 7.1 and is the only other chassis temperature 11G exposes, which makes it the obvious thing to reach for — and it is the **system board's** temperature, not the air leaving the chassis. Putting it in the exhaust column would print a number the heading does not describe, which is worse than leaving it empty. 11G reports no exhaust sensor, and `-` is the honest answer there, as it already is on a T330 or a blade.

There is a test asserting exactly that, so the shortcut cannot be taken later by accident.

## Tests

`make_sdr_output` gains `--eleventh-generation-sensor-names`, which emits the iDRAC6 layout — `Ambient Temp` at `0Eh`, a `Planar Temp` at `0Fh`, no exhaust — with the names and hexadecimal IDs taken from the R710 dump. `Planar Temp` is emitted **on purpose**, so that anything tempted to read it as an exhaust reading trips a test.

Four cases added:

| Case | What it pins |
|---|---|
| the intake sensor is found under its eleventh generation name | the fix itself — **fails on `master`** |
| the system board sensor is never reported as the exhaust | `Planar` stays out of the exhaust column, and out of the intake one too |
| the twelfth generation intake still wins over the fallback | ordering: `Inlet` wins when both names are present |
| a power supply intake never answers for the chassis intake | the fallback does not reopen #231 |

Only the first fails without the change; the other three are guards against the ways this could be got wrong later.

**322 test cases, 1805 assertions, all passing.** Verified the first case genuinely fails on the unpatched function (`1 test cases failed, 321 passed`) rather than passing vacuously. `shellcheck -x` clean on the five scripts CI lints.

## Scope

Does not touch the C-series naming (`MLB TEMP`, `FCB Ambient`, `Processor 1 Temp`), which is a third namespace again and has never been reported by a user of this container. Noted in #294 rather than guessed at here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GX7yJSLFzGBAZcR6V212ew

---
_Generated by [Claude Code](https://claude.ai/code/session_01GX7yJSLFzGBAZcR6V212ew)_