### PR TITLE
Watch for comparisons made against an operand nothing resolved yet

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -31,6 +31,7 @@ It exits `0` when every test case passed, `1` otherwise.
 | `cases/25_check_interval_validation.sh` | `CHECK_INTERVAL` values the monitoring loop can actually be paced by, and the reaction time bounds above them |
 | `cases/26_boolean_parameter_validation.sh` | The boolean parameters, which are dispatched by running their value as a command |
 | `cases/27_configuration_error_format.sh` | The one shape every startup refusal reports in, so the reason survives a `docker logs` scroll |
+| `cases/28_comparison_operands.sh` | That no accepted configuration makes bash complain about a comparison operand |
 | `cases/30_idrac_login_string.sh` | Local (`/dev/ipmi0`) and network (`lanplus`) modes, password handling |
 | `cases/35_message_output.sh` | How error and warning messages reach the log, read at their junction with the line that follows |
 | `cases/40_temperature_parsing.sh` | Reading the sensors out of `ipmitool sdr type temperature` |

--- a/tests/cases/28_comparison_operands.sh
+++ b/tests/cases/28_comparison_operands.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+
+# A numeric comparison whose operand is empty, or not yet resolved, does not
+# fail loudly : bash prints "integer expression expected" on stderr and "[" exits
+# 2, which every caller here reads as "false". A guard written to refuse a
+# configuration, or to trip a safety fallback, then silently stops guarding.
+#
+# It has landed three times (#149, #165, #291), twice as an ordering mistake
+# rather than a missing validation -- the value was checked, just not yet,
+# because the comparison sat above the line resolving it. shellcheck cannot see
+# it, and the unit tests call the predicates with values already set, which is
+# exactly the state the bug is not in.
+#
+# So this watches the real entry point across configurations that must all be
+# accepted, and asserts none of them makes bash complain about an operand. A
+# smoke test rather than a proof : it catches the reachable cases, which is what
+# all three were.
+
+function assert_no_comparison_error() {
+  local -r DESCRIPTION="$1"
+  local -r OUTPUT="$2"
+
+  local PATTERN
+  for PATTERN in "integer expression expected" "unary operator expected" "invalid integer constant"; do
+    if [[ "$OUTPUT" == *"$PATTERN"* ]]; then
+      fail "$DESCRIPTION made bash complain about a comparison operand" \
+        "$(printf '%s\n' "$OUTPUT" | grep -F "$PATTERN" | head -3)"
+      return 1
+    fi
+  done
+
+  pass
+}
+
+function test_the_default_configuration_compares_only_resolved_operands() {
+  simulate_server "PowerEdge R740" --cpus 2 --cpu-temperatures "42 44"
+
+  assert_no_comparison_error "the default configuration" "$(run_controller)"
+}
+
+function test_an_automatic_cpu_threshold_is_resolved_before_it_is_compared() {
+  # "auto" is the default, and it is a literal string until lm-sensors or the
+  # fallback replaces it. Every comparison against it has to sit below that
+  # resolution -- #291 put one above it
+  export CPU_TEMPERATURE_THRESHOLD=auto
+  simulate_server "PowerEdge R740" --cpus 2 --cpu-temperatures "42 44"
+
+  assert_no_comparison_error "an automatic CPU temperature threshold" "$(run_controller)"
+}
+
+function test_a_numeric_cpu_threshold_compares_cleanly() {
+  export CPU_TEMPERATURE_THRESHOLD=50
+  simulate_server "PowerEdge R740" --cpus 2 --cpu-temperatures "42 44"
+
+  assert_no_comparison_error "a numeric CPU temperature threshold" "$(run_controller)"
+}
+
+function test_a_hexadecimal_fan_speed_compares_cleanly() {
+  # The decimal form is derived from the hexadecimal one, so anything comparing
+  # against it depends on that conversion having run -- #165 compared above it
+  export FAN_SPEED=0x1e
+  simulate_server "PowerEdge R740" --cpus 2 --cpu-temperatures "42 44"
+
+  assert_no_comparison_error "a hexadecimal fan speed" "$(run_controller)"
+}
+
+function test_an_overheating_cpu_compares_cleanly() {
+  # The branch #149 was about : the overheating comparison itself
+  export CPU_TEMPERATURE_THRESHOLD=50
+  simulate_server "PowerEdge R740" --cpus 2 --cpu-temperatures "95 44"
+
+  assert_no_comparison_error "an overheating CPU" "$(run_controller)"
+}
+
+function test_an_unreadable_cpu_reading_compares_cleanly() {
+  # An unreadable reading must reach the fail-safe, not a bash error
+  simulate_server "PowerEdge R740" --cpus 2 --cpu-temperatures "42 44"
+  export MOCK_IPMITOOL_SDR_SECOND_OUTPUT
+  MOCK_IPMITOOL_SDR_SECOND_OUTPUT=$(make_sdr_output --cpus 2 --cpu-temperatures "42 44" | grep -v ' 3\.2 ')
+  export MOCK_IPMITOOL_SDR_SWITCH_AFTER_CALLS=1
+
+  assert_no_comparison_error "an unreadable CPU reading" "$(run_controller)"
+}
+
+function test_monitoring_only_mode_compares_cleanly() {
+  export MONITORING_ONLY_MODE=true
+  simulate_server "PowerEdge R740" --cpus 2 --cpu-temperatures "42 44"
+
+  assert_no_comparison_error "monitoring only mode" "$(run_controller)"
+}
+
+function test_a_powered_off_server_compares_cleanly() {
+  simulate_server "PowerEdge R740" --cpus 2
+  export MOCK_IPMITOOL_POWER_STATUS="Chassis Power is off"
+
+  assert_no_comparison_error "a powered off server" \
+    "$(run_controller "Target server is powered off")"
+}


### PR DESCRIPTION
Closes #296. Test-only: one new case file, plus its row in the suite's coverage table. **No production change.**

## The failure it watches for

```bash
[ "$SOMETHING" -gt "$THRESHOLD" ]
```

When an operand is empty or not an integer, bash prints `integer expression expected` on stderr and `[` **exits 2** — which every caller here reads as "false". A guard written to refuse a configuration, or to trip a safety fallback, then silently stops guarding. One stderr line among the startup output is the only sign.

## It has landed three times

| | comparison | right operand at that point | consequence |
|---|---|---|---|
| #149 | `CPU_TEMPERATURE_THRESHOLD` | user text, never validated | overheating fallback never fired |
| #165 | `DECIMAL_FAN_SPEED` | empty, conversion sat *below* the guard | "may only lower the speed" stopped rejecting a raised one |
| #291 | `CPU_TEMPERATURE_THRESHOLD` | still the literal `auto` | cold-CPU guard accepted a contradictory config |

Twice it was an **ordering** mistake rather than a missing validation: the value *was* validated, just not yet. The entry point already carries a `/!\ This resolution must stay ahead of everything that reads CPU_TEMPERATURE_THRESHOLD as a number /!\` comment for exactly that reason — and #291 happened a few lines above it anyway.

## Why neither existing safety net catches it

- **`shellcheck`** (in CI since #286) has no way to know a variable is unresolved at a given line.
- **The unit tests** call the predicates with their values already set, which is precisely the state the bug is not in. #291 notes this directly: `LOW_CPU_TEMPERATURE_THRESHOLD` had only ever been exercised by calling `is_server_too_cold` directly, never through the entry point, which is why the suite passed.

## What this adds

Eight cases running the **real entry point** across configurations that must all be accepted, asserting none makes bash complain about an operand — `integer expression expected`, `unary operator expected`, `invalid integer constant`.

Covered: the defaults · an automatic `CPU_TEMPERATURE_THRESHOLD` · a numeric one · a hexadecimal `FAN_SPEED` · an overheating CPU · a reading that stops being readable mid-run · monitoring-only mode · a powered-off server.

## Verified to fail, and on which shape exactly

Reintroducing the **#291 shape** — a comparison against `CPU_TEMPERATURE_THRESHOLD` placed above the block that turns `auto` into a number — makes the automatic-threshold case report it:

```
fail an automatic cpu threshold is resolved before it is compared
```

That is the ordering class, the one that recurred twice and that nothing else sees.

I also tried to force the **#149 shape** (an unguarded *reading* operand) and could not make it fire through configuration — because `is_any_CPU_overheating` on `master` now explicitly guards both operands, with a comment saying so. That class is closed at the source; this test covers the one that is not.

## Scope, honestly

A smoke test, not a proof. It catches what a configuration can reach, which is what all three occurrences were. Making `[` failures loud at runtime — a comparison helper refusing a non-integer operand — is the stronger version and a much larger change; noted on #296 if this ever recurs a fourth time.

**326 test cases pass** (1811 assertions).

---
_Generated by [Claude Code](https://claude.ai/code/session_01QMeaUJ7JXpBwizZjrkFkDP)_