### PR TITLE
Cover the socket counts the R930 and R530 reports confirmed

### DIFF
--- a/tests/cases/60_cpu_topologies.sh
+++ b/tests/cases/60_cpu_topologies.sh
@@ -67,6 +67,24 @@ function test_a_quad_cpu_server_detects_its_cpus_whatever_the_order_they_come_in
   assert_equals "41;40;39;38" "$CPUS_TEMPERATURES" "each reading stays with its own CPU"
 }
 
+function test_a_three_cpu_server_reports_its_three_cpus() {
+  # Three populated sockets on a four socket board, which is a configuration a quad
+  # socket server really ships in, and the count left as an open question in issue
+  # #91. Every other socket count is walked by a test of its own ; this one was only
+  # ever reached obliquely, through the sparse set a depopulated socket leaves
+  export MOCK_IPMITOOL_SDR_OUTPUT
+  MOCK_IPMITOOL_SDR_OUTPUT=$(make_sdr_output --cpus 3 --cpu-temperatures "41 40 39" --cpu-sensor-id-base 9)
+
+  detect_then_retrieve_temperatures
+
+  assert_equals "3" "${#DETECTED_CPU_ENTITY_IDS[@]}"
+  assert_equals "3.1 3.2 3.3" "${DETECTED_CPU_ENTITY_IDS[*]}"
+  assert_equals "CPU 1 CPU 2 CPU 3" "${DETECTED_CPU_LABELS[*]}"
+  assert_equals "41;40;39" "$CPUS_TEMPERATURES"
+  assert_equals "3 CPU temperature sensors detected (entities 3.1 3.2 3.3)" \
+    "$(format_detected_CPU_temperature_sensors)"
+}
+
 function test_an_empty_second_socket_is_not_counted_as_a_detected_cpu() {
   # A dual socket server sold with one CPU lists the second sensor as disabled :
   # counting it would add a column the header does not have
@@ -77,6 +95,27 @@ function test_an_empty_second_socket_is_not_counted_as_a_detected_cpu() {
 
   assert_equals "1" "${#DETECTED_CPU_ENTITY_IDS[@]}"
   assert_equals "44" "$CPUS_TEMPERATURES"
+}
+
+function test_the_detection_excludes_an_unreadable_socket_on_its_own() {
+  # The test above reaches the detection through retrieve_sdr_temperature_data(), which pipes ipmitool
+  # through "grep degrees" : the depopulated socket is already gone by the time the detection sees the
+  # rows, so what that test pins is the grep, not the guard the detection applies to the reading column
+  # itself. Taking that guard out leaves the whole suite green while the function alone starts counting
+  # sockets Dell reports as "Disabled" -- one column per empty socket, reading "-" forever, and the fans
+  # handed to Dell for good by the reading that never comes.
+  #
+  # So it is called here with rows the grep has not been over, which is the only way the two defences are
+  # held apart. "No Reading" is in there next to "Disabled" because an iDRAC uses both wordings
+  local -r SDR_DATA="$(make_sdr_line "Temp" "0Eh" "ok" "3.1" "40 degrees C")
+$(make_sdr_line "Temp" "0Fh" "ns" "3.2" "Disabled")
+$(make_sdr_line "Temp" "10h" "ns" "3.3" "No Reading")
+$(make_sdr_line "Temp" "11h" "ok" "3.4" "43 degrees C")"
+
+  detect_CPU_temperature_sensors "$SDR_DATA"
+
+  assert_equals "3.1 3.4" "${DETECTED_CPU_ENTITY_IDS[*]}" "only the sockets carrying a reading are counted"
+  assert_equals "CPU 1 CPU 2" "${DETECTED_CPU_LABELS[*]}" "the columns stay numbered from 1"
 }
 
 function test_a_gap_between_two_readable_sockets_does_not_truncate_the_list() {
@@ -212,6 +251,18 @@ function test_the_header_of_a_quad_cpu_server() {
     Date & time      Inlet  CPU 1  CPU 2  CPU 3  CPU 4  Exhaust                 Active fan speed profile                 Third-party PCIe card Dell default cooling response  Comment"
 
   assert_equals "$EXPECTED_HEADER" "$(build_header 5 "CPU 1" "CPU 2" "CPU 3" "CPU 4")"
+}
+
+function test_the_header_of_a_three_cpu_server() {
+  # The last socket count left without a header of its own, 1, 2 and 4 each having one.
+  # An odd number of CPU columns lands the banner on an odd width, where the frame has
+  # no half dash to give and the extra one goes left -- the convention
+  # center_column_heading() follows too. Both even counts come out symmetrical, so that
+  # rounding only ever shows on this table and on the single CPU one
+  local -r EXPECTED_HEADER="                     ----------- Temperatures ----------
+    Date & time      Inlet  CPU 1  CPU 2  CPU 3  Exhaust                 Active fan speed profile                 Third-party PCIe card Dell default cooling response  Comment"
+
+  assert_equals "$EXPECTED_HEADER" "$(build_header 5 "CPU 1" "CPU 2" "CPU 3")"
 }
 
 function test_the_header_grows_with_the_cpu_count() {
@@ -449,6 +500,30 @@ function comment_column_start_in_header() {
 readonly COMMENT_HEADING="Comment"
 readonly COMMENT_MARKER="COMMENT-MARKER"
 
+# 1-based position of the last character of the Nth occurrence of a token in a line, or -1 when the line
+# holds fewer than N of them.
+#
+# awk rather than bash string surgery : the token this locates repeats along the line, and "${LINE%%token*}"
+# only ever finds the first one. Positions are counted in characters, so the caller has to hand over a line
+# the degree sign has already been taken out of -- see display_width() for why it would otherwise count two
+function end_position_of_occurrence() {
+  local -r LINE="$1"
+  local -r TOKEN="$2"
+  local -r OCCURRENCE="$3"
+
+  awk -v line="$LINE" -v token="$TOKEN" -v occurrence="$OCCURRENCE" 'BEGIN {
+    position = 0
+    start = 1
+    for (found = 1; found <= occurrence; found++) {
+      offset = index(substr(line, start), token)
+      if (offset == 0) { print -1; exit }
+      position = start + offset - 1
+      start = position + 1
+    }
+    print position + length(token) - 1
+  }'
+}
+
 function assert_the_table_columns_line_up() {
   local -r IS_MONITORING_ONLY_MODE="$1"
   local -r FAN_CONTROL_PROFILE="$2"
@@ -483,6 +558,44 @@ function test_the_table_columns_line_up_whatever_the_profile_and_the_mode() {
     "Disabled (not applied: monitoring only mode)"
   assert_the_table_columns_line_up true "User static fan control profile (100%) (monitoring only, not applied)" \
     "Enabled (not applied: monitoring only mode)"
+}
+
+function test_every_cpu_heading_sits_over_the_reading_it_labels() {
+  # The test above measures a total : where the "Comment" column starts, on a table hardcoded to two CPUs.
+  # That catches the right-hand columns drifting as a block, but not the CPU columns drifting among
+  # themselves -- a header cell is printed by one printf ("' %*s '") and a row cell by another ("\" %s°C \""),
+  # so the two can disagree while the widths still add up to the same total and the comment column never
+  # moves. A reading sitting under the wrong socket's heading is what issue #91 looked like in the logs, and
+  # a table of one or four CPUs, the two @ctark reported on, was never checked for alignment at all.
+  #
+  # Both cells end on their own trailing space, so the heading and the reading it labels have to end on the
+  # same column. The readings are located by their "°C" rather than by their digits, which the timestamp
+  # would otherwise collide with : the first one is the inlet's, so CPU N carries the (N + 1)th
+  local CPU_COUNT CPU_NUMBER COLUMN_WIDTH HEADER_COLUMNS_LINE ROW ROW_IN_SINGLE_BYTE_CHARACTERS
+  local -a CPU_LABELS
+  local CPU_TEMPERATURES
+
+  for CPU_COUNT in 1 2 3 4; do
+    CPU_LABELS=()
+    CPU_TEMPERATURES=""
+    for ((CPU_NUMBER = 1; CPU_NUMBER <= CPU_COUNT; CPU_NUMBER++)); do
+      CPU_LABELS+=("CPU $CPU_NUMBER")
+      CPU_TEMPERATURES+="${CPU_TEMPERATURES:+;}$((40 + CPU_NUMBER))"
+    done
+
+    COLUMN_WIDTH=$(compute_CPU_column_content_width "${CPU_LABELS[@]}")
+    HEADER_COLUMNS_LINE=$(build_header "$COLUMN_WIDTH" "${CPU_LABELS[@]}" | tail -1)
+    ROW=$(print_temperature_array_line "$COLUMN_WIDTH" "21" "$CPU_TEMPERATURES" "34" \
+      "Dell default dynamic fan control profile" "Enabled" "$COMMENT_MARKER")
+    ROW_IN_SINGLE_BYTE_CHARACTERS="${ROW//°/o}"
+
+    for ((CPU_NUMBER = 1; CPU_NUMBER <= CPU_COUNT; CPU_NUMBER++)); do
+      assert_equals \
+        "$(end_position_of_occurrence "$HEADER_COLUMNS_LINE" "CPU $CPU_NUMBER" 1)" \
+        "$(end_position_of_occurrence "$ROW_IN_SINGLE_BYTE_CHARACTERS" "oC" $((CPU_NUMBER + 1)))" \
+        "$CPU_COUNT CPU table : the \"CPU $CPU_NUMBER\" heading must end on the column CPU $CPU_NUMBER's reading ends on"
+    done
+  done
 }
 
 function test_no_fan_control_profile_can_outgrow_the_column_reserved_for_it() {

--- a/tests/cases/90_integration.sh
+++ b/tests/cases/90_integration.sh
@@ -177,6 +177,33 @@ function test_the_controller_reports_a_quad_cpu_server() {
   assert_contains "$OUTPUT" " 41°C   40°C   39°C   38°C" "the readings must not be shifted by the two-digit sensor IDs"
 }
 
+function test_the_controller_reports_a_single_cpu_server_without_an_exhaust_sensor() {
+  # Reported on an R530 (issue #91), and a combination the suite otherwise only tests apart : one CPU on
+  # a server that does have an exhaust sensor, a missing exhaust sensor on a server that does have two
+  # CPUs. The R530 is a dual socket board, so its lone CPU also has to survive the second socket being
+  # listed and disabled -- counting that one would take the singular wording away and add a column.
+  #
+  # It is on top of that the narrowest table the controller ever draws with a CPU in it, which is the one
+  # width where the banner comes out odd : 4 dashes on the left and 3 on the right, the extra one going
+  # left. Every wider table the other cases cover is either symmetrical or wide enough to hide a rounding
+  # that went the wrong way
+  simulate_server "PowerEdge R530" --cpus 2 --cpu2-disabled --cpu-temperatures "50" --inlet 26 --no-exhaust
+
+  local -r OUTPUT=$(run_controller)
+
+  assert_contains "$OUTPUT" "1 CPU temperature sensor detected (entity 3.1)."
+  assert_contains "$OUTPUT" "No exhaust temperature sensor detected."
+  assert_contains "$OUTPUT" "                     ---- Temperatures ---"
+  assert_contains "$OUTPUT" "Inlet  CPU 1  Exhaust" "the empty second socket gets no column"
+  assert_not_contains "$OUTPUT" "CPU 2 "
+  assert_contains "$OUTPUT" " 26°C   50°C      -°C" \
+    "the exhaust column holds its placeholder instead of collapsing and shifting the row"
+  assert_contains "$OUTPUT" "CPU temperature is now OK" "a server down to one CPU is written in the singular"
+  assert_not_contains "$OUTPUT" "All CPU temperatures"
+  assert_contains "$OUTPUT" "User static fan control profile (5%)" \
+    "a missing exhaust sensor must not stop the fan control"
+}
+
 function test_the_controller_reports_a_server_without_an_exhaust_sensor() {
   simulate_server "PowerEdge R720" --cpus 2 --no-exhaust
 


### PR DESCRIPTION
Closes #298. Follows @ctark's logs in #91.

## The confirmation first

I replayed both of @ctark's transcripts through the code. They match what the controller produces **byte for byte** — the 4-socket work is confirmed on real hardware:

- **R930, 4 sockets** — `4 CPU temperature sensors detected (entities 3.1 3.2 3.3 3.4).`, four columns, all four compared to the threshold, the two-digit `09h` sensor IDs that started #91 shifting nothing.
- **R530, 1 socket** — singular wording (`1 CPU temperature sensor detected (entity 3.1).`), one column, `No exhaust temperature sensor detected.` and the exhaust column holding its `-°C` placeholder rather than collapsing.

One caveat worth recording: his run predates `master`. `FAN_CONTROL_PROFILE_COLUMN_WIDTH` went 40 → 54 in 8a75245 earlier today, so his profile column is 14 characters narrower than what `master` prints now. The CPU columns — the part #91 is about — are identical.

## What the suite was missing

Reproducing the above took a throwaway script, because the suite pins the pieces separately and never the shapes those two servers actually produce. Five guards, none of them a bug report — I checked all five against the current code first, and every one passes.

**The detection's own readable-reading guard was untested.** Every caller reaches `detect_CPU_temperature_sensors()` through `retrieve_sdr_temperature_data()`, which pipes ipmitool through `grep degrees`. A depopulated socket is therefore already gone before the detection sees the rows, so `test_an_empty_second_socket_is_not_counted_as_a_detected_cpu` was pinning the grep, not the guard. I deleted the guard and **all 318 cases stayed green**, while the function on its own started counting sockets Dell reports `Disabled` — one dead column per empty socket, reading `-` forever, and the fans handed to Dell for good by the reading that never comes. It is now called with unfiltered rows, which is the only way the two defences are held apart.

**Per-CPU alignment was unguarded.** `test_the_table_columns_line_up_whatever_the_profile_and_the_mode` measures where the `Comment` column starts, on a table hardcoded to two CPUs — a total, which the CPU columns can drift *within*. The header cell (`' %*s '`) and the row cell (`" %s°C "`) come from two different `printf` calls; shifting one against the other by a space leaves both that assertion and the profile width guard green while every heading sits a column off its reading, which is exactly how #91 was reported. Each column is now checked against the reading it labels, for 1 to 4 CPUs.

**Three more, closing what the transcripts exposed:** the R530's combination of a lone CPU and no exhaust sensor, tested apart until now and the narrowest table the controller draws with a CPU in it (so the only odd-width banner besides the 3-CPU one, 4 dashes left and 3 right); an exact header pin for three columns; and three readable sockets end to end — the count left open in #91, reached until now only through a sparse set.

## Mutation-tested

A test that cannot fail is worth nothing, so each guard was run against a deliberately broken controller. The interesting one, which isolates what the new alignment check adds:

| Mutation | Existing suite | New guard |
|---|---|---|
| CPU header cell padding moved left, **total width unchanged** | 🟢 passes | 🔴 `expected: [55] actual: [54]` |
| CPU header cell loses its trailing space | 🔴 catches it | 🔴 catches it |
| Readable-reading guard removed from the detection | 🟢 all 318 pass | 🔴 `expected: [3.1 3.4] actual: [3.1 3.2 3.3 3.4]` |

## Result

`331 test cases passed (1838 assertions)`, up from 318. Tests only — no change to any shipped script.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QBocFTjavzfaR4YMtFAeLn)_