### PR TITLE
Remove the placeholder the intake air range left behind

### DIFF
--- a/Dell_iDRAC_fan_controller.sh
+++ b/Dell_iDRAC_fan_controller.sh
@@ -17,8 +17,6 @@ trap 'graceful_exit' SIGINT SIGQUIT SIGTERM
 
 # Prepare, format and define initial variables
 
-# readonly DELL_FRESH_AIR_COMPLIANCE=45
-
 # The boolean parameters are dispatched by running their value as a command ("if $MONITORING_ONLY_MODE"),
 # an idiom that is only safe once the value is known to be one of the two literals it expects : anything
 # else is read as false without a word, or run as whatever command it happens to name. Validate them


### PR DESCRIPTION
Closes #300.

`Dell_iDRAC_fan_controller.sh:20` has carried a commented-out constant since 2023:

```bash
# readonly DELL_FRESH_AIR_COMPLIANCE=45
```

45 °C is Dell's Fresh Air rating — the intake temperature a compliant PowerEdge tolerates for up to 1 % of annual operating hours — and the line was reserved for the hot end of the intake air range. #49 was reconstructed around it, quoting it as the evidence of what that issue's truncated 2023 title had meant.

That axis is now declined: **#49, #284 and the implementation in #165 are all closed as not planned**, along with the matching bullets of #120. Nothing will ever consume the constant.

It was also the last artefact in the repository implying air-temperature-driven control was still coming. `git grep FRESH_AIR` returns exactly one hit — this line — and nothing in `functions.sh`, `constants.sh`, `.env.example`, the `Dockerfile`, the tests or the README references it or the idea. A commented-out constant reads as "not implemented yet", which is the wrong signal once the decision has been made.

Removing it is not reopening that decision, it finishes it: the rationale stays on #49 and #120, which are the durable record.

## The change

```diff
 # Prepare, format and define initial variables
 
-# readonly DELL_FRESH_AIR_COMPLIANCE=45
-
 # The boolean parameters are dispatched by running their value as a command ("if $MONITORING_ONLY_MODE"),
```

One line and its blank separator. No behaviour change, no parameter, no documentation to update — nothing referenced it.

## Testing

`tests/run_tests.sh` — **326 test cases, 1811 assertions, all passing.** `shellcheck -x` clean on the five scripts CI lints. The suite is run to show the branch is clean rather than because removing a comment could break it.

## Note on the branch

Opened from `claude/issue-300-fresh-air-placeholder` rather than the branch used for #295, which is still open and green — adding an unrelated commit to it would have muddied a pull request that is ready to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GX7yJSLFzGBAZcR6V212ew

---
_Generated by [Claude Code](https://claude.ai/code/session_01GX7yJSLFzGBAZcR6V212ew)_