### PR TITLE
Publish the release note only once the image is pushed

### DIFF
--- a/.github/workflows/build_and_publish_docker_image.yml
+++ b/.github/workflows/build_and_publish_docker_image.yml
@@ -54,11 +54,6 @@ jobs:
           # other tag, which the default single-commit fetch does not bring along
           fetch-depth: 0
 
-      - name: Generate release note
-        uses: softprops/action-gh-release@v3
-        with:
-          generate_release_notes: true
-
       - name: Calculate final Docker image name
         id: docker_image_name
         run: |
@@ -100,18 +95,33 @@ jobs:
       # an image published here has to carry it too : without it that workflow
       # would rebuild once for nothing after every release.
       # Sits between the logins and "Docker meta" on purpose : it consumes the
-      # former because the base lives on Docker Hub, where anonymous requests are
-      # rate limited per IP on shared runner addresses, and the latter consumes
-      # its outputs. A step that can fail stands between a published release and
-      # a pushed image, so it had better not be one that fails for lack of
-      # credentials
+      # former because the base lives on Docker Hub, where requests are rate
+      # limited and anonymous ones are limited per IP on shared runner
+      # addresses, and the latter consumes its outputs
       - name: Resolve the digest of the base image
         id: base
         run: |
           set -euo pipefail
           BASE_IMAGE="$(awk 'toupper($1) == "FROM" { print $2; exit }' Dockerfile)"
           echo "image=$BASE_IMAGE" >> "$GITHUB_OUTPUT"
-          echo "digest=$(docker buildx imagetools inspect "$BASE_IMAGE" --format '{{json .Manifest}}' | jq -r '.digest')" >> "$GITHUB_OUTPUT"
+          # Docker Hub answers 429 once the pull quota for the current window is
+          # spent, and every request this workflow makes there counts against
+          # it : this one, and the two the build below makes to load the base
+          # metadata for amd64 and arm64. Retrying rides out the short spikes,
+          # a quota that is genuinely exhausted outlives the waits and fails
+          # the run, which is the honest outcome
+          for DELAY in 60 300 0; do
+            if DIGEST="$(docker buildx imagetools inspect "$BASE_IMAGE" --format '{{json .Manifest}}' | jq -r '.digest')"; then
+              echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            if [ "$DELAY" -gt 0 ]; then
+              echo "::warning::Could not resolve $BASE_IMAGE, retrying in ${DELAY}s"
+              sleep "$DELAY"
+            fi
+          done
+          echo "::error::Could not resolve the digest of $BASE_IMAGE"
+          exit 1
 
       - name: Docker meta
         id: meta
@@ -147,7 +157,13 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
+      # docker/build-push-action carries no retry of its own, and a 429 kills
+      # the build in its first second, on the metadata of the base image,
+      # before a single layer moves. One more attempt, far enough apart to
+      # outlast a spike
       - name: Build and publish Docker image
+        id: build
+        continue-on-error: true
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -156,3 +172,35 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Wait for the registry before retrying
+        if: steps.build.outcome == 'failure'
+        run: sleep 300
+
+      # Same inputs as the attempt above, deliberately : this is that step
+      # again, not a different build. Should the first attempt have died with
+      # some of its layers already pushed, pushing the same tags a second time
+      # is what a re-fired release does today and the registries take it fine
+      - name: Retry building and publishing Docker image
+        if: steps.build.outcome == 'failure'
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      # Last, where it used to sit right after the checkout : a release note is
+      # the announcement that a version is out, and announcing it before the
+      # image was pushed is what left seventeen versions, v1.50 and most of
+      # v1.52 to v1.69, behind a GitHub release with nothing to pull from
+      # either registry. Published only once the push went through, a release
+      # that fails simply does not exist, and re-firing the workflow from the
+      # Actions tab publishes it for real : re-firing a tag that already has a
+      # release updates that release in place, so recovering them costs nothing
+      - name: Generate release note
+        uses: softprops/action-gh-release@v3
+        with:
+          generate_release_notes: true


### PR DESCRIPTION
Nothing has reached Docker Hub or GHCR since **v1.51**. Both registries stop there, while the releases page shows v1.69.

## What is actually broken

Every release build from v1.52 on died in its first second, on the base image:

```
#3 [linux/arm64 internal] load metadata for docker.io/library/ubuntu:latest
#3 ERROR: unexpected status from HEAD request to
https://registry-1.docker.io/v2/library/ubuntu/manifests/latest: 429 Too Many Requests
```

Docker Hub rate limits pulls per window, and `Docker image CI` spends three requests there on every run: one resolving the base digest, two loading that base metadata for `amd64` and `arm64`. Enough tag builds landing close together and the quota runs out.

What made this invisible is the **order of the steps**. `Generate release note` ran right after the checkout, before anything was built, so the GitHub release was published first and the image second. A build dying afterwards left the version announced with nothing behind it.

Seventeen versions are in that state today — a GitHub release, no image on either registry:

> v1.50, v1.52 → v1.59, v1.62 → v1.69

(v1.60 and v1.61 are a separate, unrelated matter: their `test` job fails, so they were never released at all. See below.)

`latest` is stale too. Because the highest-version check compares against every tag in the repository, each successful build declined to move `latest` once higher tags existed, and the build for the highest tag failed — so `latest` sits on an image from the v1.46 era.

## Changes

- **`Generate release note` moved to the end of the job**, after the push. A release that fails to publish its image now simply does not exist, instead of announcing a version nobody can pull.
- **The base digest resolution retries** up to three times over ~6 minutes.
- **The build and push retries once**, five minutes later, via `continue-on-error` on the first attempt. `docker/build-push-action` has no retry of its own, and a 429 kills the build before a single layer moves.

The retry loop was exercised against a stubbed registry: succeeds on the first attempt, succeeds on the last attempt, and exhausts all three and exits non-zero, with no premature `set -e` abort in any case.

## Recovering the missing images

Not done here — it republishes public images, so it is your call. Each missing version can be re-fired from the Actions tab (`Docker image CI` → `Run workflow` → pick the tag), which the workflow already supports. `softprops/action-gh-release` updates an existing release in place, so re-firing a tag that already has a release is harmless.

Two things worth knowing before doing that in bulk:

1. Firing them all at once is what exhausted the quota in the first place. Spacing them out, or doing only the versions that matter, avoids a repeat.
2. Re-firing **v1.69 last** is what puts `latest` back where it belongs — it is the only tag the highest-version check will let publish `latest`.

Note that re-firing a tag runs the workflow file **as it exists on that tag**, so these fixes only apply to releases tagged after this is merged. The recovery runs use the old copy — which works, it just has no retry.

## Two things found on the way, deliberately left out of this PR

- **v1.60 / v1.61 fail the test suite**, so their `build` job was skipped and they were never released. That is a genuine test failure on those commits, not a publishing problem.
- **The base digest label can lie.** `Resolve the digest of the base image` resolves `ubuntu:latest` and records it as `org.opencontainers.image.base.digest`, then the build separately re-resolves `ubuntu:latest`. If Ubuntu publishes a new `latest` between the two, the image is labelled with a digest it was not built from — and `Base image refresh` compares that label against the live digest, so it would conclude the image is current when it is not. Fixing it means pinning the build to the already-resolved digest (`ARG BASE_IMAGE` in the `Dockerfile`), which touches the image build itself and belongs in its own change.