### PR TITLE
Write the image's Docker Hub page from the README

### DIFF
--- a/.github/generate_dockerhub_description.sh
+++ b/.github/generate_dockerhub_description.sh
@@ -1,0 +1,248 @@
+#!/bin/bash
+
+# Renders README.md into the page Docker Hub shows on the image's repository,
+# and prints it on stdout.
+#
+# Why the README is not simply uploaded as it is :
+#
+#   - Docker Hub caps that page at 25,000 characters, and the README passed
+#     that a while ago. The action that uploads it truncates whatever it is
+#     handed, which lands in the middle of the parameters table with nothing on
+#     the page to say a word about it. Here the cut is made on a section
+#     boundary and every section left out is named at the bottom, with a link.
+#   - The README navigates itself through anchors : a table of contents, and a
+#     "back to top" link under each section. Docker Hub renders the page
+#     without the ids they point at, so all of them go nowhere.
+#   - A relative link resolves against Docker Hub there, so "./.env.example"
+#     is a 404. They are rewritten into their absolute GitHub form.
+#
+# Usage : .github/generate_dockerhub_description.sh [README path]
+
+set -euo pipefail
+
+# Docker Hub's own limit on a repository description. Counted in bytes below,
+# which is the same number for the ASCII the README is almost entirely made of
+# and an over-estimate for the handful of characters that are not : erring on
+# the short side is what keeps the upload from being rejected
+readonly DESCRIPTION_SIZE_LIMIT=25000
+
+README_FILE="${1:-}"
+if [ -z "$README_FILE" ]; then
+  REPOSITORY_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+  README_FILE="$REPOSITORY_ROOT/README.md"
+fi
+readonly README_FILE
+
+if [ ! -f "$README_FILE" ]; then
+  printf 'No README to render at %s\n' "$README_FILE" >&2
+  exit 1
+fi
+
+# The links this writes have to be absolute, so the repository they point at has
+# to be known. GITHUB_REPOSITORY is set on every runner ; the git remote covers
+# a run from a working copy, and having neither is not something to guess at :
+# a wrong owner here is a page full of links to somebody else's repository
+REPOSITORY="${GITHUB_REPOSITORY:-}"
+if [ -z "$REPOSITORY" ]; then
+  REMOTE_URL="$(git -C "$(dirname "$README_FILE")" remote get-url origin 2> /dev/null || true)"
+  REPOSITORY="$(printf '%s' "$REMOTE_URL" | sed -E 's#^.*github\.com[:/]##; s#\.git$##')"
+fi
+if [ -z "$REPOSITORY" ]; then
+  printf 'Set GITHUB_REPOSITORY to "owner/name" : the absolute links cannot be built without it\n' >&2
+  exit 1
+fi
+readonly REPOSITORY
+
+readonly REPOSITORY_URL="https://github.com/$REPOSITORY"
+# "HEAD" rather than a branch name : GitHub resolves it to the repository's
+# default branch, so these links keep working whatever branch this runs from,
+# and survive the default branch being renamed
+readonly BLOB_URL="$REPOSITORY_URL/blob/HEAD"
+
+# "Container console log example" -> "container-console-log-example", the anchor
+# GitHub gives that heading. Lowercase, spaces to hyphens, and everything that
+# is neither a letter, a digit, a hyphen nor an underscore dropped. The classes
+# are spelled out in ASCII on purpose : tr works on bytes, so a UTF-8 character
+# must not be handed to it as something to case-fold
+function anchor_of_heading() {
+  local SLUG
+  SLUG="$(printf '%s' "$1" | tr 'ABCDEFGHIJKLMNOPQRSTUVWXYZ' 'abcdefghijklmnopqrstuvwxyz')"
+  SLUG="${SLUG// /-}"
+  SLUG="$(printf '%s' "$SLUG" | sed 's/[^a-z0-9_-]//g')"
+  printf '%s' "$SLUG"
+}
+
+CLEANED_FILE="$(mktemp)"
+readonly CLEANED_FILE
+trap 'rm -f "$CLEANED_FILE"' EXIT
+
+# First pass : everything that is about the README being read on GitHub rather
+# than about the image
+awk -v blob_url="$BLOB_URL" '
+  # Rewrites the target of every markdown link on the line into an absolute one.
+  # Written as a scan rather than a gsub because the replacement depends on the
+  # target : an anchor becomes a link into the README, a path becomes a link
+  # into the repository, and anything already absolute is left alone
+  function absolutise(line,   out, opening, closing, target) {
+    out = ""
+    while ((opening = index(line, "](")) > 0) {
+      out = out substr(line, 1, opening + 1)
+      line = substr(line, opening + 2)
+      closing = index(line, ")")
+      # An unbalanced "](" is left exactly as it was rather than guessed at
+      if (closing == 0) break
+      target = substr(line, 1, closing - 1)
+      out = out absolutise_target(target)
+      line = substr(line, closing)
+    }
+    return out line
+  }
+
+  function absolutise_target(target) {
+    # "#usage" : a section of the README, which only exists on GitHub
+    if (target ~ /^#/) return blob_url "/README.md" target
+    # "https:", "mailto:", "//host/..." : already absolute
+    if (target ~ /^[a-zA-Z][a-zA-Z0-9+.-]*:/) return target
+    if (target ~ /^\/\//) return target
+    sub(/^\.\//, "", target)
+    return blob_url "/" target
+  }
+
+  # Removing lines leaves the gaps they used to fill. Blank lines are held back
+  # rather than printed as they come, so a run of them collapses to one and the
+  # ones a removal left at the top of the file are dropped altogether : markdown
+  # reads both the same way, and every byte saved here is a byte of
+  # documentation that fits on the page. Every rule that prints flushes what is
+  # held first, or it would swallow a separation that was meant to be there
+  function flush_pending_blank_line() {
+    if (blank_lines > 0 && printed_any) print ""
+    blank_lines = 0
+    printed_any = 1
+  }
+
+  # A fenced block is copied out untouched : "./Dell_iDRAC_fan_controller.sh" in
+  # a shell example is a path on the reader"s machine, not a link to rewrite.
+  # Its own blank lines are content, and reach the rule below while in_code
+  # holds, which prints them as they are
+  /^[ \t]*```/ { in_code = !in_code; flush_pending_blank_line(); print; next }
+  in_code { print; next }
+
+  # The table of contents, down to the heading that follows it : every one of
+  # its entries is an anchor, and none of them resolves on Docker Hub
+  /^## / && in_table_of_contents { in_table_of_contents = 0 }
+  /^##[ \t]+[Tt]able of contents[ \t]*$/ { in_table_of_contents = 1; next }
+  in_table_of_contents { next }
+
+  # The div the "back to top" links target, and the links themselves
+  /^<div id="top">/ { next }
+  /^<p align="right">.*back to top/ { next }
+
+  # The comments that announce each section, "<!-- USAGE -->". Invisible in both
+  # renderings, so nothing on the page changes ; what this avoids is the one
+  # belonging to the first dropped section being left behind by the cut below,
+  # hanging under the last section that was kept
+  /^[ \t]*<!--.*-->[ \t]*$/ { next }
+
+  # A reference-style definition, "[label]: ./LICENSE". The inline form is
+  # handled by absolutise() above, this one is a line of its own
+  /^\[[^]]+\]:[ \t]*[^ \t]/ {
+    label = $0
+    sub(/:[ \t]*.*$/, ":", label)
+    target = $0
+    sub(/^\[[^]]+\]:[ \t]*/, "", target)
+    title = ""
+    if (match(target, /[ \t]+["(].*$/)) {
+      title = substr(target, RSTART)
+      target = substr(target, 1, RSTART - 1)
+    }
+    flush_pending_blank_line()
+    print label " " absolutise_target(target) title
+    next
+  }
+
+  /^[ \t]*$/ { blank_lines++; next }
+
+  {
+    flush_pending_blank_line()
+    print absolutise($0)
+  }
+' "$README_FILE" > "$CLEANED_FILE"
+
+# Second pass : where the sections start, so the cut below lands between two of
+# them instead of inside one. Fence-aware, so a "## " written inside a code
+# block is not mistaken for a heading
+declare -a SECTION_START_LINES=()
+declare -a SECTION_TITLES=()
+while IFS=$'\t' read -r LINE_NUMBER TITLE; do
+  SECTION_START_LINES+=("$LINE_NUMBER")
+  SECTION_TITLES+=("$TITLE")
+done < <(awk '
+  /^[ \t]*```/ { in_code = !in_code; next }
+  in_code { next }
+  /^## / { printf "%d\t%s\n", FNR, substr($0, 4) }
+' "$CLEANED_FILE")
+
+readonly SECTION_COUNT="${#SECTION_START_LINES[@]}"
+
+# The footer is what tells the reader this page is an extract and where the rest
+# is. Its own size counts against the limit, so it is rebuilt for each candidate
+# rather than measured once
+# Usage : footer_for "Troubleshooting" "Contributing"
+function footer_for() {
+  printf -- '---\n\n'
+  if [ "$#" -gt 0 ]; then
+    printf 'Docker Hub allows %s characters on this page, which the full documentation no longer fits in. These sections are on GitHub :\n\n' \
+      "$DESCRIPTION_SIZE_LIMIT"
+
+    local DROPPED_TITLE
+    for DROPPED_TITLE in "$@"; do
+      printf -- '- [%s](%s/README.md#%s)\n' "$DROPPED_TITLE" "$BLOB_URL" "$(anchor_of_heading "$DROPPED_TITLE")"
+    done
+    printf '\n'
+  fi
+  printf 'Issues, discussions and the full documentation : %s\n' "$REPOSITORY_URL"
+}
+
+# Usage : byte_size "$TEXT"
+function byte_size() {
+  local SIZE
+  SIZE="$(printf '%s' "$1" | wc -c)"
+  printf '%s' "${SIZE// /}"
+}
+
+# Keep as many whole sections as fit, dropping them from the end : the reader
+# who lands here wants to know what the image is, what it needs and how to run
+# it, in that order, and that is the order the README already puts them in.
+# Written as a search rather than a fixed list of sections to leave out so that
+# the page follows the README on its own : a section that grows pushes the last
+# one off, a section that shrinks brings it back
+KEPT_SECTIONS="$SECTION_COUNT"
+while [ "$KEPT_SECTIONS" -ge 0 ]; do
+  if [ "$KEPT_SECTIONS" -eq "$SECTION_COUNT" ]; then
+    BODY="$(cat "$CLEANED_FILE")"
+  else
+    LAST_KEPT_LINE=$(( ${SECTION_START_LINES[$KEPT_SECTIONS]} - 1 ))
+    BODY="$(head -n "$LAST_KEPT_LINE" "$CLEANED_FILE")"
+  fi
+
+  DROPPED_TITLES=("${SECTION_TITLES[@]:$KEPT_SECTIONS}")
+  CANDIDATE="$BODY"$'\n\n'"$(footer_for "${DROPPED_TITLES[@]}")"
+
+  if [ "$(byte_size "$CANDIDATE")" -le "$DESCRIPTION_SIZE_LIMIT" ]; then
+    printf '%s\n' "$CANDIDATE"
+    exit 0
+  fi
+
+  KEPT_SECTIONS=$(( KEPT_SECTIONS - 1 ))
+done
+
+# Not reachable while the text above the first section is a title and a table of
+# contents. Should that ever stop being true, a page cut mid-sentence still
+# beats no page at all, and the warning says which one this is
+printf '::warning::%s does not fit in %s characters before its first section, cutting inside it\n' \
+  "$README_FILE" "$DESCRIPTION_SIZE_LIMIT" >&2
+
+FOOTER="$(footer_for "${SECTION_TITLES[@]}")"
+BUDGET=$(( DESCRIPTION_SIZE_LIMIT - $(byte_size "$FOOTER") - 2 ))
+head -c "$BUDGET" "$CLEANED_FILE" | head -n -1
+printf '\n%s\n' "$FOOTER"

--- a/.github/workflows/dockerhub_description.yml
+++ b/.github/workflows/dockerhub_description.yml
@@ -1,0 +1,87 @@
+name: Docker Hub description
+
+# Docker Hub keeps an image's page on its own side, and nothing in this
+# repository ever wrote it : half a million pulls in, the page read "No overview
+# available" and its one-line summary held the GitHub URL and nothing else. The
+# registry that most users reach the image through was the only place the
+# documentation did not exist.
+#
+# This renders README.md into that page every time the README moves, so the two
+# can no longer drift apart.
+#
+# Separate from "Docker image CI" on purpose : the page describes the repository
+# and not a version, and README changes land on master between releases, where
+# a workflow that fires on a version tag - and ignores README.md when it does -
+# never runs. GitHub Container Registry needs none of this : it reads the README
+# off the repository the image is linked to, through the
+# org.opencontainers.image.source label docker/metadata-action already writes.
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - README.md
+      # The renderer and this file : a change to either can change the page
+      # without the README having moved at all
+      - .github/generate_dockerhub_description.sh
+      - .github/workflows/dockerhub_description.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Two pushes in quick succession would otherwise race to write the same page,
+# and which one wins is decided by whichever request Docker Hub happens to serve
+# last. Only the newest README is worth uploading, so the older run is dropped
+concurrency:
+  group: dockerhub-description
+  cancel-in-progress: true
+
+jobs:
+  describe:
+    name: Update the image's page on Docker Hub
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      # Same derivation as the two publishing workflows, lowercased : this one
+      # names the repository to a Docker Hub API call rather than to
+      # docker/metadata-action, and Docker Hub has no repository whose name
+      # carries a capital letter
+      - name: Calculate final Docker image name
+        id: docker_image_name
+        run: |
+          set -euo pipefail
+          IMAGE_NAME="${{ github.repository }}"
+          FINAL_NAME="${IMAGE_NAME/_Docker/}"
+          echo "value=${FINAL_NAME,,}" >> "$GITHUB_OUTPUT"
+
+      - name: Render README.md into the description
+        run: |
+          set -euo pipefail
+          .github/generate_dockerhub_description.sh > "$RUNNER_TEMP/dockerhub_description.md"
+          echo "Rendered $(wc -c < "$RUNNER_TEMP/dockerhub_description.md") characters" >> "$GITHUB_STEP_SUMMARY"
+
+      # /!\ DOCKERHUB_TOKEN has to be a personal access token with the
+      # "Read, Write, Delete" scope. The narrower "Read & Write" one is enough to
+      # push an image, which is all the other workflows ask of it, but not to
+      # write the repository's description : this step answers a 401 if the token
+      # only carries that
+      - name: Publish it on Docker Hub
+        uses: peter-evans/dockerhub-description@v5
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: ${{ steps.docker_image_name.outputs.value }}
+          readme-filepath: ${{ runner.temp }}/dockerhub_description.md
+          # The line under the image's name on Docker Hub, capped at 100
+          # characters. Taken from the repository's own description so that the
+          # two are written once, on GitHub
+          short-description: ${{ github.event.repository.description }}
+          # Deliberately left off : the renderer above already rewrote every
+          # relative link, and it does so outside fenced code blocks only, where
+          # this action's own completion would rewrite the paths inside the
+          # docker run examples too
+          enable-url-completion: false

--- a/tests/README.md
+++ b/tests/README.md
@@ -22,6 +22,7 @@ It exits `0` when every test case passed, `1` otherwise.
 | --- | --- |
 | `cases/10_shell_scripts.sh` | Syntax of every script, files shipped in the Docker image, drift between the code and what documents it, healthcheck |
 | `cases/12_github_workflows.sh` | The two publishing workflows no pull request ever runs : the release build and the base image refresh |
+| `cases/13_dockerhub_description.sh` | The page Docker Hub shows on the image's repository, rendered from `README.md` by a workflow no pull request fires either |
 | `cases/15_test_runner.sh` | The runner itself : the ways it used to stay green while nothing had been verified |
 | `cases/17_reports.sh` | The JUnit XML and Markdown reports, whose consumer is a parser rather than a reader |
 | `cases/20_fan_speed_conversions.sh` | `FAN_SPEED` given as a percentage or as a hexadecimal byte |

--- a/tests/cases/10_shell_scripts.sh
+++ b/tests/cases/10_shell_scripts.sh
@@ -8,6 +8,7 @@ function test_every_shell_script_has_a_valid_syntax() {
   local SCRIPT
   for SCRIPT in \
     "$REPO_ROOT"/*.sh \
+    "$REPO_ROOT"/.github/*.sh \
     "$TESTS_DIRECTORY"/*.sh \
     "$TESTS_DIRECTORY"/lib/*.sh \
     "$TESTS_DIRECTORY"/cases/*.sh \

--- a/tests/cases/13_dockerhub_description.sh
+++ b/tests/cases/13_dockerhub_description.sh
@@ -1,0 +1,179 @@
+#!/bin/bash
+
+# Docker Hub is where most users meet this image, and the page it shows them is
+# not stored here : it is uploaded by the "Docker Hub description" workflow,
+# which renders README.md through .github/generate_dockerhub_description.sh.
+# Like the two publishing workflows, that one never runs on a pull request, and
+# what it produces is read by nobody in this repository. These are the checks
+# that read it anyway.
+
+# The owner and name a real run gets from GITHUB_REPOSITORY. Anything would do,
+# it is pinned here so that the links the renderer builds can be asserted on
+# without the assertions depending on which fork the suite runs from
+readonly DOCKERHUB_DESCRIPTION_REPOSITORY="owner/repository"
+readonly DOCKERHUB_DESCRIPTION_REPOSITORY_URL="https://github.com/$DOCKERHUB_DESCRIPTION_REPOSITORY"
+
+# Docker Hub's own limit, stated again rather than read from the renderer : the
+# point of a test is to hold the contract from outside. A renderer that raises
+# its own constant should fail here, not agree with itself
+readonly DOCKERHUB_DESCRIPTION_SIZE_LIMIT=25000
+
+readonly DOCKERHUB_DESCRIPTION_GENERATOR=".github/generate_dockerhub_description.sh"
+readonly DOCKERHUB_DESCRIPTION_WORKFLOW=".github/workflows/dockerhub_description.yml"
+
+# The suite also runs inside the built image, which carries the scripts but
+# neither the .github directory nor the README they are rendered from
+# Usage : if ! dockerhub_description_can_be_rendered; then skip_test "..."; return 0; fi
+function dockerhub_description_can_be_rendered() {
+  [ -x "$REPO_ROOT/$DOCKERHUB_DESCRIPTION_GENERATOR" ] && [ -f "$REPO_ROOT/README.md" ]
+}
+
+# Usage : DESCRIPTION="$(rendered_dockerhub_description)"
+function rendered_dockerhub_description() {
+  GITHUB_REPOSITORY="$DOCKERHUB_DESCRIPTION_REPOSITORY" \
+    "$REPO_ROOT/$DOCKERHUB_DESCRIPTION_GENERATOR" "$REPO_ROOT/README.md"
+}
+
+function test_the_dockerhub_description_fits_the_page_docker_hub_allows() {
+  # This is the whole reason the README is not simply uploaded as it is : Docker
+  # Hub does not refuse an oversized description, the action uploading it
+  # truncates it, and a page cut in the middle of the parameters table looks
+  # exactly like a page that documents that much and no more
+  if ! dockerhub_description_can_be_rendered; then
+    skip_test "no .github and README next to the scripts"
+    return 0
+  fi
+
+  local DESCRIPTION
+  DESCRIPTION="$(rendered_dockerhub_description)"
+
+  local SIZE
+  SIZE="$(printf '%s' "$DESCRIPTION" | wc -c)"
+  # BSD wc pads its output, GNU wc does not
+  SIZE="${SIZE//[[:space:]]/}"
+
+  if [ "$SIZE" -le "$DOCKERHUB_DESCRIPTION_SIZE_LIMIT" ]; then
+    pass
+  else
+    fail "the rendered page is $SIZE characters long, Docker Hub keeps the first $DOCKERHUB_DESCRIPTION_SIZE_LIMIT and drops the rest"
+  fi
+}
+
+function test_the_dockerhub_description_carries_no_link_docker_hub_cannot_resolve() {
+  # A relative link resolves against Docker Hub's own domain there, and the
+  # anchors the README navigates itself with point at ids that page does not
+  # have. Both render as a working link and answer a 404
+  if ! dockerhub_description_can_be_rendered; then
+    skip_test "no .github and README next to the scripts"
+    return 0
+  fi
+
+  local DESCRIPTION
+  DESCRIPTION="$(rendered_dockerhub_description)"
+
+  local RELATIVE_LINKS
+  RELATIVE_LINKS="$(printf '%s\n' "$DESCRIPTION" |
+    grep -noE '\]\([^)]*\)' |
+    grep -vE '\((https?://|mailto:)' || true)"
+  assert_empty "$RELATIVE_LINKS" \
+    "every link on the Docker Hub page has to be absolute, it is not served from GitHub"
+
+  local SELF_ANCHORS
+  SELF_ANCHORS="$(printf '%s\n' "$DESCRIPTION" | grep -nE 'href="#|back to top' || true)"
+  assert_empty "$SELF_ANCHORS" \
+    "the anchors the README navigates itself with go nowhere on the Docker Hub page"
+}
+
+function test_no_readme_section_disappears_from_the_dockerhub_description() {
+  # The renderer drops whole sections from the end until what is left fits, so
+  # which ones it drops changes as the README grows. What must not change is
+  # that a dropped section is still named on the page, with a link to it :
+  # otherwise a section quietly stops existing for every reader who arrives
+  # through Docker Hub, and nothing anywhere says so
+  if ! dockerhub_description_can_be_rendered; then
+    skip_test "no .github and README next to the scripts"
+    return 0
+  fi
+
+  local DESCRIPTION
+  DESCRIPTION="$(rendered_dockerhub_description)"
+
+  local SECTION_TITLE
+  while IFS= read -r SECTION_TITLE; do
+    [ -n "$SECTION_TITLE" ] || continue
+    # The table of contents is a list of anchors and nothing else, it is
+    # dropped rather than linked to
+    [ "$SECTION_TITLE" != "Table of contents" ] || continue
+
+    if printf '%s\n' "$DESCRIPTION" | grep -qxF "## $SECTION_TITLE"; then
+      pass
+    elif printf '%s\n' "$DESCRIPTION" | grep -qF "[$SECTION_TITLE]($DOCKERHUB_DESCRIPTION_REPOSITORY_URL"; then
+      pass
+    else
+      fail "the README has a \"$SECTION_TITLE\" section, the Docker Hub page neither carries it nor links to it"
+    fi
+  done < <(grep -E '^## ' "$REPO_ROOT/README.md" | sed 's/^## //')
+}
+
+function test_the_dockerhub_description_keeps_what_the_reader_came_for() {
+  # Whatever the cut leaves out, someone landing on the image's page is there to
+  # find out what it needs and how to start it. These are the sections that
+  # answer that, and the page is worth publishing only while it still holds them
+  if ! dockerhub_description_can_be_rendered; then
+    skip_test "no .github and README next to the scripts"
+    return 0
+  fi
+
+  local DESCRIPTION
+  DESCRIPTION="$(rendered_dockerhub_description)"
+
+  local SECTION
+  for SECTION in "Requirements" "Supported architectures" "Usage" "Parameters"; do
+    assert_contains "$DESCRIPTION" "## $SECTION" \
+      "the Docker Hub page has to keep its \"$SECTION\" section"
+  done
+
+  assert_contains "$DESCRIPTION" "docker run" \
+    "the Docker Hub page has to show how the image is started"
+  assert_contains "$DESCRIPTION" "$DOCKERHUB_DESCRIPTION_REPOSITORY_URL" \
+    "the Docker Hub page has to link back to the repository it is rendered from"
+}
+
+function test_the_dockerhub_description_workflow_renders_the_page_it_publishes() {
+  # The renderer and the workflow only meet at a path written in both. Renaming
+  # one of them is caught here rather than by a red run of the one workflow no
+  # pull request fires
+  if [ ! -f "$REPO_ROOT/$DOCKERHUB_DESCRIPTION_WORKFLOW" ]; then
+    skip_test "no .github/workflows next to the scripts"
+    return 0
+  fi
+
+  local -r WORKFLOW_CONTENT="$(cat "$REPO_ROOT/$DOCKERHUB_DESCRIPTION_WORKFLOW")"
+
+  assert_contains "$WORKFLOW_CONTENT" "$DOCKERHUB_DESCRIPTION_GENERATOR" \
+    "the workflow has to render the page through $DOCKERHUB_DESCRIPTION_GENERATOR"
+
+  if [ -f "$REPO_ROOT/$DOCKERHUB_DESCRIPTION_GENERATOR" ]; then
+    pass
+  else
+    fail "$DOCKERHUB_DESCRIPTION_WORKFLOW runs $DOCKERHUB_DESCRIPTION_GENERATOR, which does not exist"
+    return 1
+  fi
+
+  # The workflow runs it as a command rather than through bash, so the bit is
+  # what makes the difference between a rendered page and "Permission denied"
+  if [ -x "$REPO_ROOT/$DOCKERHUB_DESCRIPTION_GENERATOR" ]; then
+    pass
+  else
+    fail "$DOCKERHUB_DESCRIPTION_GENERATOR is run as a command by the workflow, it has to be executable"
+  fi
+
+  # A README change that never reaches the page is the drift this whole
+  # workflow exists to remove. Read line by line off the file rather than
+  # matched on the content read above : bash anchors a regex on the whole
+  # string, so "^" there would only ever mean the first line of the workflow
+  local README_TRIGGER
+  README_TRIGGER="$(grep -E '^[[:space:]]+- README\.md$' "$REPO_ROOT/$DOCKERHUB_DESCRIPTION_WORKFLOW" || true)"
+  assert_not_empty "$README_TRIGGER" \
+    "the workflow has to list README.md among the paths it runs on"
+}


### PR DESCRIPTION
## What this is about

Docker Hub keeps an image's page on its own side, and nothing in this repository ever wrote it. Half a million pulls in, the overview reads **"No overview available"** and the one-line summary holds the GitHub URL and nothing else — the registry most users reach this image through is the only place its documentation does not exist.

This adds a `Docker Hub description` workflow that renders `README.md` into that page on every push to `master` that touches it.

## Why a workflow of its own

The page describes the repository and not a version, and README changes land on `master` between releases — where `Docker image CI` (which fires on a version tag, and `paths-ignore`s `README.md` when it does) never runs.

GHCR needs none of this: it reads the README off the repository the image is linked to, through the `org.opencontainers.image.source` label `docker/metadata-action` already writes.

## Why the README is not uploaded as it is

| | |
| --- | --- |
| Docker Hub caps the page at **25,000 characters**, which the README (32.3 kB) passed a while ago | The upload action truncates whatever it is handed, so the page would end in the middle of the parameters table with nothing on it to say so |
| The README navigates itself through anchors — a table of contents, a "back to top" link under each section | Docker Hub renders the page without the ids they point at, so every one of them goes nowhere |
| A relative link resolves against Docker Hub's own domain there | `./.env.example` is a 404 |

`.github/generate_dockerhub_description.sh` stands between the two. It drops the anchors, rewrites every relative link into its absolute GitHub form — outside fenced code blocks, where a path is a path on the reader's machine and not a link — and keeps as many **whole sections** as fit, naming the ones it left out with a link to each.

Which sections those are is searched rather than listed, so the page follows the README on its own: a section that grows pushes the last one off, a section that shrinks brings it back. Today that leaves 20.5 kB ending after `Stopping the container`, with `Troubleshooting`, `Contributing` and `License` linked at the bottom.

## Tests

`tests/cases/13_dockerhub_description.sh` reads the page this produces, which nothing else in this repository does:

- it fits the limit Docker Hub allows
- it carries no link Docker Hub cannot resolve (relative paths, self-anchors)
- **no README section disappears from it without being named** — the invariant that matters as the README grows
- it keeps what someone landing there came to find out (`Requirements`, `Supported architectures`, `Usage`, `Parameters`, a `docker run`, a link home)
- the workflow and the renderer still meet at the same path, and that path is still executable

`10_shell_scripts.sh` now syntax-checks `.github/*.sh` alongside the shipped scripts. Full suite: **340 test cases, 1871 assertions, green**. Both new files are `shellcheck -x` clean.

## ⚠️ One thing to check before merging

`DOCKERHUB_TOKEN` has to carry the **"Read, Write, Delete"** scope. The narrower "Read & Write" is enough to push an image, which is all the other workflows ask of it, but not to write a repository's description — the publishing step answers a `401` if the token only carries that. The workflow can be re-fired from the Actions tab once the token is right.

## What CI still cannot do on Docker Hub

For the record, the rest of that page is not automatable: the **repository logo** is reserved for verified publishers, the **linked source repository** belongs to the retired automated-builds feature, and **categories** are a one-off setting that does not drift — worth setting once by hand in the UI.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9kPzaDb2cZaodEJbVTAZJ)_