### PR TITLE
Ask the registry which version is published, not git which tag exists

### DIFF
--- a/.github/workflows/base_image_refresh.yml
+++ b/.github/workflows/base_image_refresh.yml
@@ -38,7 +38,13 @@ jobs:
   check:
     name: Check whether the base image changed
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    # Was 5, which no longer fits what this job does. The retry ladder on the
+    # base image digest sleeps 60s then 300s before its last attempt, so six
+    # minutes of it are spent waiting on purpose ; at 5 the job was killed
+    # mid-sleep and the third attempt could never run. The release walk above it
+    # also costs one registry read per version tag that has never been
+    # published. Fifteen leaves room for both and still bounds a wedged job
+    timeout-minutes: 15
     permissions:
       contents: read
       # Reading the published image back, see the login step below

--- a/.github/workflows/base_image_refresh.yml
+++ b/.github/workflows/base_image_refresh.yml
@@ -51,21 +51,67 @@ jobs:
       release-sha: ${{ steps.release.outputs.sha }}
       image-name: ${{ steps.image-name.outputs.value }}
     steps:
-      # The whole history, tags included : the last release tag is read from it
+      # The whole history, tags included : the version tags are the candidate
+      # list the current release is picked out of
       - name: Checkout
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
-      - name: Find the last release tag
+      # Moved above the release lookup, which now needs both this name and the
+      # credentials below
+      - name: Calculate final Docker image name
+        id: image-name
+        run: |
+          set -euo pipefail
+          IMAGE_NAME="${{ github.repository }}"
+          FINAL_NAME="${IMAGE_NAME/_Docker/}"
+          # docker/metadata-action lowercases it on the publishing side, this
+          # one is read back from a registry so it has to be lowercased here
+          echo "value=${FINAL_NAME,,}" >> "$GITHUB_OUTPUT"
+
+      # The package is public, so the reads below would work unauthenticated.
+      # Logging in anyway : this job fails the run rather than assume anything,
+      # so a read that only works while the package stays public is a daily
+      # failure waiting for the day someone flips its visibility
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Find the last published release
         id: release
         run: |
           set -euo pipefail
-          # Same pattern as the tags "Docker image CI" builds on. Version sort,
-          # so v1.10 comes out above v1.9
-          TAG="$(git tag --list 'v[0-9]*.[0-9]*' --sort=-v:refname | head -n 1)"
+          # Not "the highest v* tag" any more, for the same reason the release
+          # build stopped asking that question. During the 429 storm the highest
+          # tag was v1.69, whose image never reached either registry ; this
+          # workflow would have rebuilt and republished "latest" from it every
+          # night, publishing an image for a version nobody can pull by number.
+          # The tags are walked highest first and the first one that actually
+          # resolves in the registry is the release "latest" belongs to
+          IMAGE="ghcr.io/${{ steps.image-name.outputs.value }}"
+          ERRORS="$RUNNER_TEMP/imagetools-error.txt"
+          TAG=""
+          for CANDIDATE in $(git tag --list 'v[0-9]*.[0-9]*' --sort=-v:refname); do
+            if docker buildx imagetools inspect "$IMAGE:$CANDIDATE" --format '{{json .Manifest}}' >/dev/null 2>"$ERRORS"; then
+              TAG="$CANDIDATE"
+              break
+            fi
+            if grep -qiE 'not found|manifest unknown|name unknown' "$ERRORS"; then
+              continue
+            fi
+            # Same doctrine as the comparison below : credentials, rate limit or
+            # outage are not an answer to "was this version published ?", and
+            # guessing here would republish "latest" from the wrong source
+            echo "::error::Could not read $IMAGE:$CANDIDATE, giving up rather than guessing which version is the current release"
+            cat "$ERRORS"
+            exit 1
+          done
           if [ -z "$TAG" ]; then
-            echo "::error::No v* tag found, nothing has ever been released"
+            echo "::error::No v* tag resolves in $IMAGE, nothing has ever been published"
             exit 1
           fi
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
@@ -85,30 +131,23 @@ jobs:
             echo "::error::No FROM instruction found in the Dockerfile of ${{ steps.release.outputs.tag }}"
             exit 1
           fi
-          DIGEST="$(docker buildx imagetools inspect "$BASE_IMAGE" --format '{{json .Manifest}}' | jq -r '.digest')"
-          echo "image=$BASE_IMAGE" >> "$GITHUB_OUTPUT"
-          echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
-
-      - name: Calculate final Docker image name
-        id: image-name
-        run: |
-          set -euo pipefail
-          IMAGE_NAME="${{ github.repository }}"
-          FINAL_NAME="${IMAGE_NAME/_Docker/}"
-          # docker/metadata-action lowercases it on the publishing side, this
-          # one is read back from a registry so it has to be lowercased here
-          echo "value=${FINAL_NAME,,}" >> "$GITHUB_OUTPUT"
-
-      # The package is public, so the read below would work unauthenticated.
-      # Logging in anyway : the comparison now fails the run rather than assume
-      # the base moved, so a read that only works while the package stays public
-      # is a daily failure waiting for the day someone flips its visibility
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          # Same ladder as "Docker image CI" uses on this exact call : the base
+          # lives on Docker Hub, which answers 429 once the pull quota of the
+          # window is spent. Without it the nightly repair is down precisely
+          # during the rate limit storms it exists to repair
+          for DELAY in 60 300 0; do
+            if DIGEST="$(docker buildx imagetools inspect "$BASE_IMAGE" --format '{{json .Manifest}}' | jq -r '.digest')"; then
+              echo "image=$BASE_IMAGE" >> "$GITHUB_OUTPUT"
+              echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            if [ "$DELAY" -gt 0 ]; then
+              echo "::warning::Could not resolve $BASE_IMAGE, retrying in ${DELAY}s"
+              sleep "$DELAY"
+            fi
+          done
+          echo "::error::Could not resolve the digest of $BASE_IMAGE"
+          exit 1
 
       - name: Compare it with the base of the published image
         id: compare
@@ -116,9 +155,9 @@ jobs:
           set -euo pipefail
           # Read from GHCR rather than Docker Hub : anonymous Docker Hub
           # requests are rate limited per IP, and the runners share theirs.
-          # The publishing step below records the base digest as a label, which
-          # is what makes this comparison possible without keeping state
-          # anywhere else
+          # The publishing steps record both the base digest and the version as
+          # labels, which is what makes these comparisons possible without
+          # keeping state anywhere else
           IMAGE="ghcr.io/${{ steps.image-name.outputs.value }}:latest"
           ERRORS="$RUNNER_TEMP/imagetools-error.txt"
 
@@ -127,10 +166,18 @@ jobs:
               | jq -r 'if has("config") then [.] else [.[]] end
                        | map(.config.Labels["org.opencontainers.image.base.digest"] // empty)
                        | first // ""')"
+            # The same read, one label over : which VERSION "latest" is on. Both
+            # publishers stamp it, the release build explicitly since this rule
+            # depends on it
+            PUBLISHED_VERSION="$(printf '%s' "$CONFIG" \
+              | jq -r 'if has("config") then [.] else [.[]] end
+                       | map(.config.Labels["org.opencontainers.image.version"] // empty)
+                       | first // ""')"
           elif grep -qiE 'not found|manifest unknown|name unknown' "$ERRORS"; then
             # Nothing published under that tag yet, so there is nothing to
             # compare against and everything to build
             PUBLISHED=""
+            PUBLISHED_VERSION=""
           else
             # Credentials, rate limit, registry outage : none of these are an
             # answer to "did the base move ?". Failing here is deliberate.
@@ -143,10 +190,37 @@ jobs:
           fi
 
           CURRENT="${{ steps.base.outputs.digest }}"
-          if [ "$PUBLISHED" = "$CURRENT" ]; then
+          RELEASE="${{ steps.release.outputs.tag }}"
+
+          # "latest" sitting ahead of the highest release that resolves in the
+          # registry means a version tag was deleted from under us, or something
+          # was published by hand. Rebuilding from older source would move
+          # "latest" backwards, which is the one thing neither workflow may ever
+          # do, so this stops instead of guessing
+          if [ -n "$PUBLISHED_VERSION" ] && [ "$PUBLISHED_VERSION" != "$RELEASE" ] \
+             && [ "$(printf '%s\n%s\n' "$PUBLISHED_VERSION" "$RELEASE" | sort -V | tail -n 1)" = "$PUBLISHED_VERSION" ]; then
+            echo "::error::latest is on $PUBLISHED_VERSION, ahead of the highest published release $RELEASE. Refusing to rebuild it from older source"
+            exit 1
+          fi
+
+          if [ "$PUBLISHED" = "$CURRENT" ] && [ "$PUBLISHED_VERSION" = "$RELEASE" ]; then
             CHANGED=false
           else
             CHANGED=true
+            if [ "$PUBLISHED_VERSION" != "$RELEASE" ]; then
+              # This is the second half of the "latest" rule and the only thing
+              # that repairs it without a human. The release build decides
+              # whether it may claim "latest" from what is published when it
+              # starts building, so several releases building at once can all
+              # decide yes and the last one to finish pushing wins, whatever its
+              # version. Nothing ends up on a version that failed to build, but
+              # "latest" can end a burst one or two releases short. This is where
+              # that is put right, at most a day later, whether the base moved or
+              # not.
+              # Expected once more, harmlessly, the first time this runs against
+              # a "latest" published before the label was stamped explicitly
+              echo "::warning::latest is on ${PUBLISHED_VERSION:-an unrecorded version}, the highest published release is $RELEASE. Republishing it"
+            fi
             if [ -z "$PUBLISHED" ]; then
               # Expected exactly once, the first time this runs against an image
               # published before the label existed. Twice in a row means the

--- a/.github/workflows/build_and_publish_docker_image.yml
+++ b/.github/workflows/build_and_publish_docker_image.yml
@@ -50,8 +50,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
-          # Whether this tag gets "latest" is decided by comparing it against every
-          # other tag, which the default single-commit fetch does not bring along
+          # The tags are the list of versions that could outrank this one, which
+          # the "latest" check below walks. The default single-commit fetch does
+          # not bring them along
           fetch-depth: 0
 
       - name: Calculate final Docker image name
@@ -60,22 +61,6 @@ jobs:
           IMAGE_NAME="${{ github.repository }}"
           FINAL_NAME="${IMAGE_NAME/_Docker/}"
           echo "value=$FINAL_NAME" >> $GITHUB_OUTPUT
-
-      # Builds can run concurrently and old tags can be rebuilt on demand, so the
-      # order in which images reach the registry says nothing about their version.
-      # Only the highest version tag may claim "latest"
-      - name: Check whether this tag is the highest version
-        id: highest_version
-        run: |
-          # sort -V, not sort : lexicographically "v1.9" sorts above "v1.19"
-          HIGHEST_TAG="$(git tag --list 'v[0-9]*.[0-9]*' | sort -V | tail -1)"
-          if [ "$HIGHEST_TAG" = "$GITHUB_REF_NAME" ]; then
-            echo "$GITHUB_REF_NAME is the highest version tag, it will be published as 'latest'"
-            echo "value=true" >> $GITHUB_OUTPUT
-          else
-            echo "$GITHUB_REF_NAME is behind $HIGHEST_TAG, 'latest' will be left untouched"
-            echo "value=false" >> $GITHUB_OUTPUT
-          fi
 
       - name: Login to Docker Hub
         uses: docker/login-action@v4
@@ -123,6 +108,121 @@ jobs:
           echo "::error::Could not resolve the digest of $BASE_IMAGE"
           exit 1
 
+      # Whether this tag may claim "latest" used to be decided by comparing it
+      # against the highest tag that EXISTS in git. A tag existing means someone
+      # typed "git tag" ; it says nothing about an image having come out of it.
+      # Thirty tags, v1.40 to v1.69, were pushed within twenty-five minutes ; the
+      # builds of v1.52 to v1.69 all died on a 429 from Docker Hub while loading
+      # the metadata of the base image ; v1.47 to v1.51 built and pushed
+      # perfectly and every one of them declined "latest", because v1.69 existed
+      # above them. "latest" sat on the v1.46 image for two days with five newer
+      # versions published and none of them structurally able to rescue it, and
+      # only came back when v1.69 was re-fired days later.
+      #
+      # So the question asked here is the one that matters to whoever pulls
+      # "latest" : is a higher version actually PUBLISHED ? A tag whose build
+      # pushed nothing leaves no trace in a registry and can no longer hold
+      # "latest" hostage. And because the answer is re-derived from the registry
+      # by every later release, a wrong answer repairs itself instead of being
+      # reproduced forever, the way a comparison against git necessarily was -
+      # git never changes its mind, which is why all five good builds gave the
+      # same wrong answer.
+      #
+      # Sits here rather than up by the checkout because it needs the two logins
+      # above, and above "Docker meta" because that step consumes its output
+      - name: Check whether a higher version is already published
+        id: highest_version
+        run: |
+          set -euo pipefail
+
+          # Read from GHCR and not from Docker Hub, for the same reason the base
+          # image refresh workflow reads it there. Docker Hub answers 429 once
+          # the pull quota of the window is spent - the very failure that
+          # stranded "latest" - and every request made there competes with the
+          # base image metadata that this build and every concurrent one need.
+          # GHCR reads are authenticated with GITHUB_TOKEN, carry no pull quota,
+          # and the job is already logged in.
+          # The price, stated plainly : a version that reached Docker Hub but
+          # not GHCR is invisible here. Only a half-failed push can produce one,
+          # its own run is red, and the next release settles it
+          IMAGE="ghcr.io/${{ steps.docker_image_name.outputs.value }}"
+          # Registry APIs reject the repository's own capitalisation.
+          # metadata-action lowercases on the publishing side ; this step talks
+          # to a registry by hand, so it does it itself
+          IMAGE="${IMAGE,,}"
+          ERRORS="$RUNNER_TEMP/imagetools-error.txt"
+
+          # Three answers and not two, deliberately : "the registry did not
+          # answer" is not "there is nothing there". 0 published, 1 nothing under
+          # that tag, 2 no usable answer.
+          # Every path returns explicitly, because the caller invokes this on the
+          # left of a "||", which switches errexit off inside the body
+          version_is_published() {
+            if docker buildx imagetools inspect "$IMAGE:$1" --format '{{json .Manifest}}' >/dev/null 2>"$ERRORS"; then
+              return 0
+            fi
+            # The wordings a registry uses for a tag that was never pushed, the
+            # same set the base image refresh workflow already keys on. Note what
+            # is deliberately NOT in that list : "denied" and "unauthorized". A
+            # token that cannot read the package must never look like an empty
+            # registry, that is exactly how "latest" would walk backwards on a
+            # permissions mistake
+            if grep -qiE 'not found|manifest unknown|name unknown' "$ERRORS"; then
+              return 1
+            fi
+            cat "$ERRORS"
+            return 2
+          }
+
+          # "$1 is a strictly higher version than $2". sort -V, not sort :
+          # lexicographically "v1.9" sorts above "v1.19"
+          higher_than() {
+            if [ "$1" = "$2" ]; then
+              return 1
+            fi
+            [ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | tail -n 1)" = "$1" ]
+          }
+
+          # Highest first, so the first published candidate found is the highest
+          # published one and the walk stops there. A release that is the newest
+          # tag - every normal release, and the very first one ever - has no
+          # candidate above it and reads nothing at all : the registry is only
+          # ever consulted in the situation the old check got wrong.
+          # "if ... then break" and not "[ ... ] && break" : this loop is the
+          # whole decision, and it is not the place to lean on how errexit treats
+          # an and-list
+          BLOCKER=""
+          UNREADABLE=""
+          for CANDIDATE in $(git tag --list 'v[0-9]*.[0-9]*' --sort=-v:refname); do
+            if ! higher_than "$CANDIDATE" "$GITHUB_REF_NAME"; then
+              break
+            fi
+            STATUS=0
+            version_is_published "$CANDIDATE" || STATUS=$?
+            case "$STATUS" in
+              0) BLOCKER="$CANDIDATE"; break ;;
+              1) ;;  # tagged in git, never pushed : it outranks nothing
+              *) UNREADABLE="$CANDIDATE"; break ;;
+            esac
+          done
+
+          if [ -n "$UNREADABLE" ]; then
+            # Declining is what this workflow already did whenever it was unsure,
+            # so an unreadable registry costs nothing that was not already being
+            # lost - and never the release itself, the version tag and the
+            # release note still go out. Unlike before, the decision is not
+            # final : the next release asks the registry again, and re-firing
+            # this tag from the Actions tab retries it immediately
+            echo "::warning::Could not tell whether $UNREADABLE is published, 'latest' will be left untouched"
+            echo "value=false" >> "$GITHUB_OUTPUT"
+          elif [ -n "$BLOCKER" ]; then
+            echo "$BLOCKER is already published and outranks $GITHUB_REF_NAME, 'latest' will be left untouched"
+            echo "value=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "No published version outranks $GITHUB_REF_NAME, it will be published as 'latest'"
+            echo "value=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v6
@@ -141,15 +241,25 @@ jobs:
             type=raw,value=${{ github.ref_name }},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
             type=raw,value=latest,enable=${{ steps.highest_version.outputs.value == 'true' }}
           # The explicit "latest" entry above is the only thing that may publish it,
-          # gated on the highest version check. latest=auto is already inert for
+          # gated on the check above. latest=auto is already inert for
           # type=raw entries - procRaw() hardcodes latest=false under auto - so this
           # pins that behaviour rather than changing it, and keeps it pinned should a
           # type=semver or type=ref entry ever be added here
           flavor: |
             latest=false
+          # base.digest is what "Base image refresh" compares against to tell
+          # whether the base moved. image.version is stamped explicitly rather
+          # than left to whatever metadata-action derives when two type=raw
+          # entries are present : it is what that same workflow reads back off
+          # "latest" to tell which version "latest" is currently on, and a
+          # "latest" it cannot place would make it rebuild every night for
+          # nothing. It is deliberately not consulted by the check above, which
+          # asks whether the VERSION TAG resolves - so a mislabelled "latest"
+          # can cost one redundant nightly rebuild and can never freeze a release
           labels: |
             org.opencontainers.image.base.name=${{ steps.base.outputs.image }}
             org.opencontainers.image.base.digest=${{ steps.base.outputs.digest }}
+            org.opencontainers.image.version=${{ github.ref_name }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4


### PR DESCRIPTION
Closes #308.

`latest` pointed at the **v1.46** image for two days while v1.47 → v1.51 were published successfully and none of them was allowed to move it. #303 fixed why the builds failed; this fixes why five green builds could not repair the damage.

## The defect

```bash
HIGHEST_TAG="$(git tag --list 'v[0-9]*.[0-9]*' | sort -V | tail -1)"
[ "$HIGHEST_TAG" = "$GITHUB_REF_NAME" ]
```

A tag existing means somebody typed `git tag`. It says nothing about an image having come out of it. Thirty tags went up in twenty-five minutes, v1.52 → v1.69 all died on a Docker Hub 429, and each of the five that built correctly declined `latest` because v1.69 existed above them.

The wrong answer was **silent** (all five runs green), **permanent** (git never changes its mind), and **reproduced identically by every later success**. That is a different class of defect from a build that fails loudly and retries — and retries do nothing for it.

## The change

Ask the question that matters to whoever pulls `latest`: *is a higher version actually published?* Walk the version tags above this one, newest first, and ask GHCR whether each resolves.

- A tag whose build pushed nothing leaves no trace in a registry and can no longer hold `latest` hostage.
- A genuinely higher **published** version still blocks a re-fired old tag from dragging `latest` backwards — strictly better than the old test, because it blocks on what users can actually pull.
- The answer is re-derived from the registry by every later release, so a wrong answer repairs itself instead of being reproduced forever.

Three answers, not two: *published*, *absent*, *no usable answer*. `denied` and `unauthorized` are deliberately **not** read as absent — that is exactly how a permissions mistake would walk `latest` backwards. An unreadable registry declines, which is what the step already did whenever unsure, except it is no longer final.

GHCR and not Docker Hub, because Docker Hub is the registry that answers 429, and every read there competes with the base-image metadata the concurrent builds need. The cost is stated in the workflow comment: a version that reached Docker Hub but not GHCR is invisible to this check. Only a half-failed push can create one, and its own run is red.

`latest` stays a `type=raw` entry inside the existing single `build-push-action` call — same call, same two registries, same manifest, pushed atomically with the version tag. **No re-tag, no promote job, no marker ref, no concurrency group, no new action.**

### Every file this touches

Two workflow files, no `Dockerfile` and no script change.

**`build_and_publish_docker_image.yml`**
- `Check whether this tag is the highest version` is **replaced** by `Check whether a higher version is already published`, and **moves** — it used to sit right after the checkout, it now sits after the two `docker/login-action` steps and the base-digest resolution, because it needs credentials, and immediately above `Docker meta`, which consumes its output. Same step `id`, same `value=true|false` output, so the `type=raw,value=latest,enable=…` gate is untouched.
- **A new label is stamped on every published image**: `org.opencontainers.image.version=${{ github.ref_name }}`. It is what the nightly workflow reads back off `latest` to tell which version `latest` is on. Stamped explicitly rather than left to whatever `metadata-action` derives when two `type=raw` entries are present. It is deliberately **not** consulted by the check above, which asks whether the *version tag* resolves — so a mislabelled `latest` can cost one redundant nightly rebuild and can never freeze a release.
- One comment reworded on `fetch-depth: 0` (the tags are still needed, for a different reason).

**`base_image_refresh.yml`**
- `Find the last release tag` becomes `Find the last published release`: it walks the version tags highest-first and takes the first that resolves in the registry, instead of `head -n 1` over git.
- `Calculate final Docker image name` and `Login to GitHub Container Registry` **move up**, above that lookup, which now needs both the name and the credentials.
- `Resolve the digest the base image currently points to` gains the same retry ladder #303 gave the release build.
- `Compare it with the base of the published image` also reads `latest`'s version label, republishes when it is behind the highest published release, and refuses (exit 1) when it is *ahead* of it.
- `timeout-minutes` on the `check` job goes **5 → 15**. This is not cosmetic: the retry ladder sleeps 60 s then 300 s before its last attempt, so six minutes of the job are spent waiting on purpose. At 5 the job would have been killed mid-sleep and the third rung could never have run — a retry ladder silently losing its last attempt, in the workflow that exists to keep working during a rate-limit storm. Caught while auditing this description against the diff, fixed in `22ddf08`.

### The nightly workflow had the same defect, live and unattended

It picked the release to rebuild `latest` from with `head -n 1` over git tags. During the storm the highest tag was v1.69, whose image never existed — it would have republished `latest` nightly from that source, an image for a version nobody can pull by number.

It also becomes the reconciler: when `latest` carries an older version than the highest published release, it republishes. That repairs automatically the one case the release side cannot decide alone — several releases building at once all correctly find nothing higher published, and the last to finish pushing wins.

## Verification

Three step scripts were extracted from the YAML and exercised against a stubbed registry and git: the release decision, the nightly release lookup, and the nightly comparison.

**The release decision** — 8 scenarios:

| Scenario | Result | Registry reads |
|---|---|---|
| The incident: v1.51 builds, v1.52→v1.69 tagged but never published | **claims `latest`** (old rule declined) | 18 |
| Normal release: newest tag, nothing above it | claims | **0** |
| Re-fired old tag v1.45, v1.69 published | declines | 1 |
| Registry answers `denied` | **declines** + warning, exit 0 | 1 |
| Unreadable below an already-published blocker | declines on the blocker | 1 |
| Unreadable above the highest published | declines | 10 |
| First release ever, empty registry | claims | 0 |
| `sort -V`: v1.19 built, v1.9 published | claims | 0 |

A normal release reads the registry **zero times**: it enters the loop, finds the first candidate is not higher than itself, and breaks before any registry call. The registry is consulted only in the situation the old check got wrong.

**The nightly release lookup** — picks `v1.51` in the incident state (the old rule picked v1.69), `v1.69` in the healthy state, and fails rather than guessing when nothing is published or the registry is unreadable.

**The nightly comparison** — 7 scenarios, including the two that worried me about adding an `exit 1` to an unattended workflow:

| Scenario | Result |
|---|---|
| base same, version same | nothing to do |
| base moved, version same | normal refresh |
| `latest` behind the highest published release | republishes + warning (the self-repair) |
| `latest` **ahead** of it (a registry tag was deleted) | refuses, exit 1 |
| version label absent — the first night after this lands | one harmless republication, **no error** |
| version label is the literal `latest` | one harmless republication, **no error** |
| nothing published yet | builds everything |

The last two are the risk worth checking before merging: `sort -V` ranks `v1.69` above both `latest` and the empty string, so the first-night case falls through to the documented one-off republication rather than tripping the refusal.

All eleven inline step scripts across both workflows pass `bash -n`, and both files parse as YAML. Job permissions were checked against the new reads: the nightly `check` job already had `packages: read`, and the release `build` job inherits `packages: write`.

## Designs that were rejected

Three approaches were drafted independently and each was attacked by an adversarial reviewer. All three moved the `latest` write out of the build push — into `imagetools create`, a `refs/tags/latest-published` marker with compare-and-swap, or a serialised promote job — and all three were rated **fatal** for the same underlying reason: a separate write has to be serialised, and registries offer no compare-and-swap to serialise it with.

Two findings worth recording:

- A shared `concurrency:` group is **not** a mutex here. GitHub keeps exactly one *pending* run per group and cancels the older ones, so on a 30-tag burst it would cull ~28 writers and hand the invariant to a single job that must talk to the registry that was 429-ing. It would also silently cancel the nightly base refresh whenever a release lands near midnight.
- Listing registry tags via `/v2/.../tags/list` silently truncates at one page unless the `Link` header is followed, which would freeze `latest` with a green job once the repository passes one page.

## Residuals, stated plainly

**Concurrent claimants are ordered by push completion, not by version.** If v1.47 → v1.51 build simultaneously and all correctly find nothing higher published, all five push `latest` and the last to finish wins — so `latest` can end a burst on v1.47 while v1.51 is published. It never lands on a version that failed to publish and never on a re-fired old tag; the error is bounded to *"a few releases short"*, not *"stranded behind five versions for two days"*, and the nightly reconciler repairs it within a day. Closing it at the point of decision requires the post-push writer that produced every fatal finding above.

**`latest` never moves below the version it already holds — while that version's tag still resolves.** The guarantee comes from the held version being published and therefore blocking anything lower. Delete its tag from the registry by hand and a lower release could claim `latest`; git tags are append-only, registry tags are not. The nightly `exit 1` above is what catches that state rather than papering over it. Note it is not a regression in kind — deleting the git tag defeats the current guard just as well.

**Worst case is one registry read per version tag above this one that was never published.** It short-circuits on the first published candidate, so a normal release costs zero reads and a re-fired old tag costs one. A repository that accumulated hundreds of tagged-but-never-published versions would make every release slow, and would deserve to be noticed.

## Not in scope

- **#309** — v1.60 and v1.61 fail a test about the suite's own README, so they were never released. Two live instances of this issue's trigger shape, but nothing to fix in code.
- **#310** — the recorded `base.digest` label can describe a base the image was not built from. Touches the `Dockerfile` and both publishing workflows; belongs in its own change.