### PR TITLE
Build from the base digest that gets recorded, not from latest twice

### DIFF
--- a/.github/workflows/base_image_refresh.yml
+++ b/.github/workflows/base_image_refresh.yml
@@ -53,6 +53,7 @@ jobs:
       changed: ${{ steps.compare.outputs.changed }}
       base-image: ${{ steps.base.outputs.image }}
       base-digest: ${{ steps.base.outputs.digest }}
+      base-pinned: ${{ steps.base.outputs.pinned }}
       release-tag: ${{ steps.release.outputs.tag }}
       release-sha: ${{ steps.release.outputs.sha }}
       image-name: ${{ steps.image-name.outputs.value }}
@@ -131,20 +132,55 @@ jobs:
           # being refreshed is built from that tag, so its base is the one that
           # matters. A base already pinned by digest simply never moves, and
           # this workflow then never has anything to do
-          BASE_IMAGE="$(git show "${{ steps.release.outputs.tag }}:Dockerfile" \
-            | awk 'toupper($1) == "FROM" { print $2; exit }')"
+          # Two Dockerfile shapes have to parse here, and both are live : the
+          # tags released from now on name their base on an ARG above the FROM
+          # line, every tag released before that ARG existed names it on the
+          # FROM line itself. This job reads whichever the last published
+          # release happens to carry
+          BASE_IMAGE="$(git show "${{ steps.release.outputs.tag }}:Dockerfile" | awk '
+            toupper($1) == "ARG" {
+              eq = index($2, "=")
+              if (eq > 1) default_of[substr($2, 1, eq - 1)] = substr($2, eq + 1)
+            }
+            toupper($1) == "FROM" {
+              ref = $2
+              if (ref ~ /^\$\{?[A-Za-z_][A-Za-z0-9_]*\}?$/) {
+                name = ref
+                gsub(/^\$\{?|\}$/, "", name)
+                ref = default_of[name]
+              }
+              print ref
+              exit
+            }')"
           if [ -z "$BASE_IMAGE" ]; then
-            echo "::error::No FROM instruction found in the Dockerfile of ${{ steps.release.outputs.tag }}"
+            echo "::error::Could not work out the base image from the Dockerfile of ${{ steps.release.outputs.tag }}"
             exit 1
           fi
           # Same ladder as "Docker image CI" uses on this exact call : the base
           # lives on Docker Hub, which answers 429 once the pull quota of the
           # window is spent. Without it the nightly repair is down precisely
           # during the rate limit storms it exists to repair
+          # Drop an existing digest, then drop a tag, then pin to the digest just
+          # resolved. A colon only introduces a tag when it sits in the last path
+          # segment : in "registry:5000/image" it is a host and a port
+          pin_to_digest() {
+            local REF="${BASE_IMAGE%%@*}" REPO
+            case "${REF##*/}" in
+              *:*) REPO="${REF%:*}" ;;
+              *)   REPO="$REF" ;;
+            esac
+            printf '%s@%s\n' "$REPO" "$1"
+          }
+
           for DELAY in 60 300 0; do
             if DIGEST="$(docker buildx imagetools inspect "$BASE_IMAGE" --format '{{json .Manifest}}' | jq -r '.digest')"; then
               echo "image=$BASE_IMAGE" >> "$GITHUB_OUTPUT"
               echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
+              # Both builds below are given this, so the base the suite runs on,
+              # the base that gets pushed and the digest recorded as a label are
+              # the same one - the whole point of a run that exists because the
+              # base moved
+              echo "pinned=$(pin_to_digest "$DIGEST")" >> "$GITHUB_OUTPUT"
               exit 0
             fi
             if [ "$DELAY" -gt 0 ]; then
@@ -292,6 +328,11 @@ jobs:
           # Resolve the base from the registry rather than reuse whatever the
           # runner already had : that resolution is the whole point of the run
           pull: true
+          # The exact digest the check job compared against, not "latest"
+          # re-resolved here. A release tag predating this ARG ignores it and
+          # resolves its own FROM line, exactly as this job did before
+          build-args: |
+            BASE_IMAGE=${{ needs.check.outputs.base-pinned }}
           tags: dell_idrac_fan_controller:test
 
       - name: Run the test suite inside the image
@@ -369,8 +410,12 @@ jobs:
           push: true
           # Deliberately no "pull" here, unlike the test build above : the base
           # was resolved there, and re-resolving it would miss the builder cache
-          # and rebuild amd64 into something the suite never ran on. Should the
-          # base move between the two, the label records the digest the check
-          # job saw, one behind, and the next run picks the difference up
+          # and rebuild amd64 into something the suite never ran on
+          # The same pinned digest the test build was given. The base moving
+          # between the two builds used to leave the label one behind the bytes ;
+          # pinned, both builds are on the digest the check job saw and the label
+          # records, and a base that moves mid-run is simply picked up tomorrow
+          build-args: |
+            BASE_IMAGE=${{ needs.check.outputs.base-pinned }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build_and_publish_docker_image.yml
+++ b/.github/workflows/build_and_publish_docker_image.yml
@@ -87,7 +87,30 @@ jobs:
         id: base
         run: |
           set -euo pipefail
-          BASE_IMAGE="$(awk 'toupper($1) == "FROM" { print $2; exit }' Dockerfile)"
+          # The FROM line is "FROM ${BASE_IMAGE}" and the reference lives on the
+          # ARG above it, so the name has to be followed there. A Dockerfile that
+          # still names its base directly on the FROM line - every tag released
+          # before that ARG existed, which is what "Base image refresh" reads -
+          # is parsed exactly as before
+          BASE_IMAGE="$(awk '
+            toupper($1) == "ARG" {
+              eq = index($2, "=")
+              if (eq > 1) default_of[substr($2, 1, eq - 1)] = substr($2, eq + 1)
+            }
+            toupper($1) == "FROM" {
+              ref = $2
+              if (ref ~ /^\$\{?[A-Za-z_][A-Za-z0-9_]*\}?$/) {
+                name = ref
+                gsub(/^\$\{?|\}$/, "", name)
+                ref = default_of[name]
+              }
+              print ref
+              exit
+            }' Dockerfile)"
+          if [ -z "$BASE_IMAGE" ]; then
+            echo "::error::Could not work out the base image from the Dockerfile"
+            exit 1
+          fi
           echo "image=$BASE_IMAGE" >> "$GITHUB_OUTPUT"
           # Docker Hub answers 429 once the pull quota for the current window is
           # spent, and every request this workflow makes there counts against
@@ -95,9 +118,24 @@ jobs:
           # metadata for amd64 and arm64. Retrying rides out the short spikes,
           # a quota that is genuinely exhausted outlives the waits and fails
           # the run, which is the honest outcome
+          # Drop an existing digest, then drop a tag, then pin to the digest just
+          # resolved. A colon only introduces a tag when it sits in the last path
+          # segment : in "registry:5000/image" it is a host and a port
+          pin_to_digest() {
+            local REF="${BASE_IMAGE%%@*}" REPO
+            case "${REF##*/}" in
+              *:*) REPO="${REF%:*}" ;;
+              *)   REPO="$REF" ;;
+            esac
+            printf '%s@%s\n' "$REPO" "$1"
+          }
+
           for DELAY in 60 300 0; do
             if DIGEST="$(docker buildx imagetools inspect "$BASE_IMAGE" --format '{{json .Manifest}}' | jq -r '.digest')"; then
               echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
+              # What the build below is actually given, so the label above and
+              # the bytes underneath the image describe the same base
+              echo "pinned=$(pin_to_digest "$DIGEST")" >> "$GITHUB_OUTPUT"
               exit 0
             fi
             if [ "$DELAY" -gt 0 ]; then
@@ -280,6 +318,11 @@ jobs:
           platforms: linux/amd64,linux/arm64
           file: ./Dockerfile
           push: true
+          # Built from the digest resolved above rather than from "latest" a
+          # second time, so org.opencontainers.image.base.digest describes the
+          # base these bytes were actually built on
+          build-args: |
+            BASE_IMAGE=${{ steps.base.outputs.pinned }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
@@ -299,6 +342,11 @@ jobs:
           platforms: linux/amd64,linux/arm64
           file: ./Dockerfile
           push: true
+          # The same digest the first attempt was given, deliberately : a retry
+          # that re-resolved "latest" could build on a different base from the
+          # one the label records, which is the defect this pinning removes
+          build-args: |
+            BASE_IMAGE=${{ steps.base.outputs.pinned }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,17 @@
 # Named so the publishing workflows can build from the exact base digest they
 # resolved and recorded as org.opencontainers.image.base.digest, instead of
 # letting this line resolve "latest" a second time. Those two resolutions are
-# minutes apart, and when Canonical published in between, the image carried a
-# label naming a base it was not built from - which the nightly base image
-# refresh then compares against the live digest and concludes "unchanged" on an
-# image that is not. The default keeps a plain "docker build ." working, which
-# is how the test suite builds it
+# minutes apart, so when Canonical published in between, the image went out
+# built on the newer base and labelled with the older one.
+# The label lags, it never leads : the resolution always precedes the build. So
+# the cost is a nightly base image refresh that rebuilds an image already
+# sitting on the current base, not one that skips an image that is not - a
+# wasted rebuild rather than a missed security fix.
+# Pinning also keeps that workflow's test build and its publishing build on one
+# digest, which is what makes "the suite ran on the bytes that get pushed" true
+# rather than merely likely.
+# The default keeps a plain "docker build ." working, which is how the test
+# suite builds it
 ARG BASE_IMAGE=ubuntu:latest
 FROM ${BASE_IMAGE}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,13 @@
-FROM ubuntu:latest
+# Named so the publishing workflows can build from the exact base digest they
+# resolved and recorded as org.opencontainers.image.base.digest, instead of
+# letting this line resolve "latest" a second time. Those two resolutions are
+# minutes apart, and when Canonical published in between, the image carried a
+# label naming a base it was not built from - which the nightly base image
+# refresh then compares against the live digest and concludes "unchanged" on an
+# image that is not. The default keeps a plain "docker build ." working, which
+# is how the test suite builds it
+ARG BASE_IMAGE=ubuntu:latest
+FROM ${BASE_IMAGE}
 
 LABEL org.opencontainers.image.authors="tigerblue77"
 


### PR DESCRIPTION
Closes #310.

> [!NOTE]
> The original version of this description, and of #310, claimed this defect could make the nightly refresh **skip** a rebuild that was due. That is the wrong direction and the step order rules it out. Corrected below and in `4f1898b`; the real cost is a wasted rebuild, not a missed security fix. The change is still worth making, for the reasons under *Why this is still worth doing*.

## The defect

The image is built on Ubuntu, and `ubuntu:latest` is a moving pointer. The release workflow asks *"which Ubuntu is that right now?"* **twice, minutes apart**:

| Step | What it does |
|---|---|
| **5.** `Resolve the digest of the base image` | asks, and writes the answer onto the image as `org.opencontainers.image.base.digest` |
| **10.** `Build and publish Docker image` | builds, and resolves `ubuntu:latest` **again**, once per platform |

If Canonical publishes between the two, the image is built on the **newer** base and labelled with the **older** one. The label is a false statement about the image.

## What that actually costs

The resolution at step 5 always precedes the build at step 10, so **the label can only lag reality, never lead it**. That direction matters, because it decides which way the nightly job errs.

`base_image_refresh.yml` compares the published label against the live digest to decide whether to rebuild. With a lagging label it sees `old != current` and **rebuilds an image that is already sitting on the current base** — a redundant rebuild and a redundant republication of `latest`.

The opposite failure, concluding "unchanged" about an image built on an older base and skipping a refresh that was due, would need the label to be *newer* than the build. That cannot happen with the resolution ordered first.

So: **wasted CI time and a republished image, not a missed security fix.** The earlier framing overstated it.

## Why this is still worth doing

1. **The nightly test build and publishing build land on one digest.** This is the substantive win and it is independent of the label question. Today the refresh job builds the image the suite runs on, then builds the image it pushes. Both resolve `ubuntu:latest` on their own, so a base moving between them means the suite validated one image and a different one got pushed. That file argues at length for those two being identical; pinning is what makes it true rather than likely.
2. **The label becomes true by construction.** `org.opencontainers.image.base.digest` is a factual claim about the image, consumed by tooling and by the nightly comparison. Making it accurate by design beats making it accurate by luck.
3. **Fewer redundant nightly rebuilds**, which is the cost described above.

## The change

**`Dockerfile`** takes its base as an ARG:

```dockerfile
ARG BASE_IMAGE=ubuntu:latest
FROM ${BASE_IMAGE}
```

A global `ARG` is the only instruction Docker allows before `FROM`, and the default keeps a plain `docker build .` working — which is exactly what `tests.yml` does, so the suite stays a check on the published runtime.

**Both publishing workflows** pass the digest they resolved, as `BASE_IMAGE=ubuntu@sha256:…`.

### Two Dockerfile shapes have to parse, and both are live

This is the part worth reviewing closely. The release build reads the working tree, which has the ARG. The nightly refresh reads the Dockerfile of **the last published release** — and for every tag up to v1.69 that file names its base on the `FROM` line directly.

The parser follows a `${VAR}` reference to its `ARG` default, and reads a literal `FROM` exactly as before:

| Dockerfile shape | Parsed base |
|---|---|
| `ARG BASE_IMAGE=ubuntu:latest` + `FROM ${BASE_IMAGE}` | `ubuntu:latest` |
| `FROM ubuntu:latest` (every tag ≤ v1.69) | `ubuntu:latest` |
| `FROM $BASE_IMAGE` (unbraced) | resolved from the ARG |
| `ARG BASE_IMAGE=ubuntu@sha256:…` | passed through unchanged |
| lowercase `from`, extra spacing | resolved |
| `FROM ${BASE_IMAGE} AS build` | resolved |
| `FROM ${NOPE}`, never declared | **empty → the step errors** rather than resolving to nothing |

Checked against the real files: `git show v1.51:Dockerfile` and `git show v1.69:Dockerfile` both still parse to `ubuntu:latest`, and the real `base` step extracted from each workflow was run against both and against the new shape — same three outputs every time.

Old release tags also **ignore the build arg they are handed**, since their Dockerfile declares no such ARG. That costs a BuildKit warning and leaves them with exactly the behaviour they have today.

### Pinning is not a naive string append

`registry:5000/image` is a host and a port, not a tag. The helper drops an existing digest, then drops a tag only when the colon sits in the last path segment:

| Input | Pinned |
|---|---|
| `ubuntu:latest` | `ubuntu@sha256:…` |
| `ubuntu` | `ubuntu@sha256:…` |
| `ubuntu:24.04@sha256:old` | `ubuntu@sha256:…` |
| `docker.io/library/ubuntu:22` | `docker.io/library/ubuntu@sha256:…` |
| `registry:5000/img` | `registry:5000/img@sha256:…` |
| `registry:5000/img:tag` | `registry:5000/img@sha256:…` |

## Verification

- Both workflow files parse as YAML; all inline step scripts pass `bash -n`.
- All **four** `build-push-action` steps across the two workflows carry the build arg — the release build, its retry, the nightly test build and the nightly publishing build. Checked programmatically rather than by eye, because a retry that re-resolved `latest` would reintroduce the defect.
- The `base` step of each workflow was extracted from the YAML and executed against a stubbed registry: the release one against the new `Dockerfile`, the nightly one against `v1.51`, `v1.69` and the new shape.
- The parser was exercised against the seven Dockerfile shapes above, and the pinning helper against the seven references.

**What I could not verify here:** there is no Docker daemon in this environment, so I could not build the image locally. Two things rest on documented Docker behaviour rather than on a run I watched:

1. a global `ARG` before `FROM`, consumed by that `FROM` — **now proven by this PR's own CI**: the `Run the test suite inside the Docker image` job runs `docker build --tag dell_idrac_fan_controller:test .` with no build args, and it is green;
2. an unused `--build-arg` producing a warning rather than an error, which is what release tags ≤ v1.69 will hit in the nightly job. That path only runs at nightly-refresh time and is not reachable from a PR. Triggering `Base image refresh` by hand after merge is what would exercise it.

## Not in scope

The `Dockerfile` keeps `ubuntu:latest` as its default rather than being pinned to a digest in-tree. Pinning it there would stop the nightly refresh from ever having anything to do, which is a different decision.