### PR TITLE
Name SC2329 alongside SC2317 on the supervisor's trap handler

### DIFF
--- a/supervisor.sh
+++ b/supervisor.sh
@@ -65,7 +65,10 @@ function apply_Dell_default_fan_control_profile_on_behalf_of_the_monitoring_proc
 # case -- and no further signal it can catch will change that, so it is killed outright. Docker's own
 # grace period is ten seconds by default, so this deadline has to be comfortably inside it or the
 # container is SIGKILLed as a whole before this ever gets to act
-# shellcheck disable=SC2317  # Only invoked indirectly, via the trap below; shellcheck's reachability analysis can't see that
+# shellcheck disable=SC2317,SC2329  # Only invoked indirectly, via the trap below; shellcheck's reachability analysis can't see that.
+# Both codes are needed : shellcheck 0.11.0 split the "defined but only reached through a trap" case out of
+# SC2317, which still covers the commands in the body, into SC2329 on the definition itself. Neither version
+# objects to the code it does not know, so this one line is green on both sides of the runner image's bump
 function stop_the_monitored_process() {
   SIGNAL_WAS_FORWARDED=true
 


### PR DESCRIPTION
Closes #315. One line of `supervisor.sh`, plus the comment explaining why it names two codes. **No production change** — a shellcheck directive is a comment.

## The problem

`stop_the_monitored_process()` is only reached through `trap 'stop_the_monitored_process' …` twenty lines below it. shellcheck cannot see that, so the `# shellcheck disable=SC2317` above it is what keeps the check green — and it is load-bearing, not decoration: delete it and 0.9.0 reports **15** SC2317 findings across the function body.

**shellcheck 0.11.0 split that judgement.** SC2317 still covers the commands in the body; "this function is never invoked" moved to a new code, **SC2329**, anchored on the definition line — which the directive does not name.

```
0.9.0   (ubuntu-latest today)      exit=0
0.11.0  (Ubuntu 26.04 image)       supervisor.sh:69  SC2329  This function is never invoked.   exit=1
```

`shellcheck.yml` runs on `ubuntu-latest`. `actions/runner-images` lists shellcheck `0.9.0-1` for Ubuntu 24.04 and `0.11.0-2` for 26.04, and its own migration note says the `-latest` move is gradual over one to two months with no opt-out short of pinning. So this goes red on a day nobody touched this repository, on whatever pull request is open at the time, and its author will reasonably suspect their own change first.

## The fix

```diff
-# shellcheck disable=SC2317  # Only invoked indirectly, via the trap below; …
+# shellcheck disable=SC2317,SC2329  # Only invoked indirectly, via the trap below; …
```

Neither version objects to the code it does not know — 0.9.0 ignores the unknown `SC2329`, 0.11.0 ignores the now-inapplicable `SC2317` — so one line is green on **both** sides of the bump, with no version pin and no window where either is red. The added comment says why both are there, so a future reader does not "clean up" the one that looks redundant on their machine.

## Verification

Running the workflow's own command, `shellcheck -x` over the five shipped scripts:

| shellcheck | before | after |
|---|---|---|
| 0.9.0 | exit 0 | **exit 0** |
| 0.11.0 | exit 1, `SC2329` | **exit 0** |

The 0.11.0 binary is the official static release, downloaded and run here rather than reasoned about.

**340 test cases pass (1872 assertions)**, unchanged.

## Scope

`supervisor.sh:68` is the only SC2317 directive in the repository — the others are SC2034 (`functions.sh:2`, `constants.sh:2`) and SC2181 (`functions.sh` ×4), neither affected by the split — and `.shellcheckrc` disables only SC2086 and SC2206. Nothing else needs the same treatment.

Rejected: disabling SC2329 in `.shellcheckrc`, which silences it repository-wide instead of at the one justified site; pinning shellcheck in CI, which freezes the analyser and leaves the stale directive in place.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HKfi9Rtqpgh6TvcqQxv3Yk)_