### PR TITLE
Ask create-github-app-token for the client ID it now wants

### DIFF
--- a/.github/workflows/auto_update_pull_request_branches.yml
+++ b/.github/workflows/auto_update_pull_request_branches.yml
@@ -31,29 +31,37 @@ name: Auto-update pull request branches
 # runs it creates are held in an approval-required state : the pull request
 # shows an "Approve workflows to run" banner that somebody with write access has
 # to click before the required checks even start. No repository setting turns
-# that off, and
-# swapping one click per pull request for another is not worth a workflow, so
-# the update has to come from an identity GitHub already trusts.
+# that off, and swapping one click per pull request for another is not worth a
+# workflow, so the update has to come from an identity GitHub already trusts.
 #
 # Two identities qualify, and both are wired up. Whichever is used needs the
 # same three repository permissions : "Contents : read and write", "Pull
 # requests : read and write" and "Workflows : read and write".
 #
-# That third one is the one easily forgotten, and leaving it out is a trap :
-# rebasing replays the branch's commits, and a branch that adds or edits
+# That third one is the one easily forgotten : an update that would write
 # anything under .github/workflows is refused without it, with "refusing to
 # allow [...] to create or update workflow [...] without workflow scope
-# (updatePullRequestBranch)". This repository merges such pull requests
-# regularly, so a credential missing it would work until precisely the pull
-# request that needed it most.
+# (updatePullRequestBranch)". Granting it on an App that is already installed is
+# not enough on its own, either - an installation keeps the permissions it was
+# created with, so one added afterwards has to be accepted again on the
+# installation page before it takes effect.
+#
+# That same message is also what a fork's pull request produces, for an
+# unrelated reason : the credential has no permissions at all on the fork, so it
+# has no "workflows" permission there either. Read it as "cannot write workflow
+# files where it is being asked to" rather than as a verdict on this
+# repository's own configuration. Which of the two it is can be told apart by
+# where the update was headed : the warning below names the pull request, and
+# whether that one comes from a fork is the answer.
 #
 # A GitHub App is what this repository uses, and what GitHub itself points to
 # for this case. Nothing about it has to be renewed by hand, because the private
 # key does not expire ; the installation token minted from it does, after an
 # hour, which is why the key rather than a token is what is stored. The key goes
-# into the PULL_REQUESTS_UPDATE_APP_PRIVATE_KEY secret and the App's identifier
-# into the PULL_REQUESTS_UPDATE_APP_ID variable, and the first step below mints
-# a fresh token from them at the start of every run.
+# into the PULL_REQUESTS_UPDATE_APP_PRIVATE_KEY secret and the App's client
+# identifier into the PULL_REQUESTS_UPDATE_APP_CLIENT_ID variable, and the first
+# step below mints a fresh token from them at the start of every run. That is
+# the client ID shown on the App's settings page, not the App ID next to it.
 #
 # A fine-grained personal access token in the PULL_REQUESTS_UPDATE_TOKEN secret
 # works too, and is quicker to set up : its resource owner has to be this
@@ -93,10 +101,10 @@ jobs:
       # migration, and it needs no change to this file
       - name: Mint an installation token, if a GitHub App is configured
         id: app-token
-        if: vars.PULL_REQUESTS_UPDATE_APP_ID != ''
+        if: vars.PULL_REQUESTS_UPDATE_APP_CLIENT_ID != ''
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.PULL_REQUESTS_UPDATE_APP_ID }}
+          client-id: ${{ vars.PULL_REQUESTS_UPDATE_APP_CLIENT_ID }}
           private-key: ${{ secrets.PULL_REQUESTS_UPDATE_APP_PRIVATE_KEY }}
 
       - name: Rebase every conflict-free pull request that is behind master
@@ -105,7 +113,7 @@ jobs:
           # otherwise. Whichever it is, it needs the three permissions the
           # header describes
           GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.PULL_REQUESTS_UPDATE_TOKEN }}
-          UPDATING_AS: ${{ vars.PULL_REQUESTS_UPDATE_APP_ID != '' && 'the GitHub App' || 'the personal access token' }}
+          UPDATING_AS: ${{ vars.PULL_REQUESTS_UPDATE_APP_CLIENT_ID != '' && 'the GitHub App' || 'the personal access token' }}
           REPOSITORY: ${{ github.repository }}
           # Whether a pull request whose rebase conflicts is updated with a
           # merge commit rather than left behind
@@ -162,7 +170,7 @@ jobs:
           }
 
           if [ -z "$GH_TOKEN" ]; then
-            echo "::error::No credential is configured, so nothing can be updated. Set either the PULL_REQUESTS_UPDATE_TOKEN secret or the PULL_REQUESTS_UPDATE_APP_ID variable together with the PULL_REQUESTS_UPDATE_APP_PRIVATE_KEY secret. The comment at the top of this workflow says what each one needs and why the default token is not enough."
+            echo "::error::No credential is configured, so nothing can be updated. Set either the PULL_REQUESTS_UPDATE_TOKEN secret or the PULL_REQUESTS_UPDATE_APP_CLIENT_ID variable together with the PULL_REQUESTS_UPDATE_APP_PRIVATE_KEY secret. The comment at the top of this workflow says what each one needs and why the default token is not enough."
             exit 1
           fi
 


### PR DESCRIPTION
Every run of "Auto-update pull request branches" logs:

```
Input 'app-id' has been deprecated with message: Use 'client-id' instead.
```

The action still honours `app-id`, but the two inputs take **different values**: `client-id` wants the App's *Client ID*, not the *App ID* next to it on the settings page. So the repository variable is renamed alongside the input rather than left holding a value its name no longer describes.

| | before | after |
|---|---|---|
| action input | `app-id` | `client-id` |
| variable | `PULL_REQUESTS_UPDATE_APP_ID` | `PULL_REQUESTS_UPDATE_APP_CLIENT_ID` |
| value it holds | App ID | **Client ID** |

The secret `PULL_REQUESTS_UPDATE_APP_PRIVATE_KEY` is unchanged.

## ⚠️ Set the variable before merging

`PULL_REQUESTS_UPDATE_APP_CLIENT_ID` has to exist **before** this merges. The minting step is conditioned on it, so with only the old variable set the step is skipped, the credential falls back to a personal access token that does not exist on this repository, and the run stops on "No credential is configured".

That failure is loud rather than silent, but it is still a run that does nothing. Adding the new variable first makes the transition seamless; the old one can be deleted afterwards.

Settings → Secrets and variables → Actions → **Variables** → New repository variable, with the Client ID from the App's settings page.

## Comment corrections

Two, both about accuracy rather than behaviour.

The header claimed that a **rebase** is what a missing `Workflows` permission refuses. The first two runs of the workflow show otherwise: pull request #313, which modifies two workflow files, rebased fine, while what was refused was the **merge fall-back onto a fork**.

That matters because the message names a permission in both cases and only one of them is about this repository's own configuration:

- the credential genuinely lacks `Workflows` here — worth fixing, and note that granting it on an already-installed App is not enough, since an installation keeps the permissions it was created with until the new ones are accepted on the installation page;
- or the update was headed for a **fork**, where the credential has no permissions at all and therefore no `workflows` permission either — expected, permanent, and already documented as out of reach.

Both readings are now given, along with how to tell them apart: the warning names the pull request, and whether that one comes from a fork is the answer.

The paragraph explaining why the default `GITHUB_TOKEN` is not used had also kept a stray line break from an earlier edit.

## Testing

The YAML parses and the step script passes `bash -n`. The change to executable lines is exactly four — the `if` condition, the action input, the `UPDATING_AS` expression and the error message — all of them the same rename; everything else in the diff is comments.

This cannot be verified further before merging: the workflow only runs from master, and the new variable is what proves it. The first run afterwards will log `Updating as the GitHub App` if the variable was read, and the deprecation warning should be gone.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WQ4zfMTXXv6WN95iBEFXoA)_