### PR TITLE
Name the server, not its power supply, when several FRU devices answer

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -1276,17 +1276,26 @@ function get_Dell_server_model() {
     print_configuration_error_and_exit "IDRAC_HOST / IDRAC_USERNAME / IDRAC_PASSWORD" "$IDRAC_HOST" "credentials that can open an IPMI session. ipmitool said: $IPMI_FRU_content"
   fi
 
-  SERVER_MANUFACTURER=$(echo "$IPMI_FRU_content" | grep "Product Manufacturer" | awk -F ': ' '{print $2}')
-  SERVER_MODEL=$(echo "$IPMI_FRU_content" | grep "Product Name" | awk -F ': ' '{print $2}')
+  # Only the FIRST match of each field. "ipmitool fru" describes every FRU device on the bus, and more
+  # than one of them fills these fields : a populated power supply reports its own manufacturer and its
+  # own product name. Keeping every match sets these variables to several newline-separated values, the
+  # server's own and its parts', and the equality test the caller runs against SERVER_MANUFACTURER then
+  # fails on a genuine Dell -- refusing to start with "Your server isn't a Dell product" on hardware
+  # this function had just identified correctly. ipmitool prints the builtin FRU device (ID 0), which
+  # describes the server itself, before it walks the SDR records, so the first match is the right one
+  SERVER_MANUFACTURER=$(echo "$IPMI_FRU_content" | grep "Product Manufacturer" | awk -F ': ' '{print $2; exit}')
+  SERVER_MODEL=$(echo "$IPMI_FRU_content" | grep "Product Name" | awk -F ': ' '{print $2; exit}')
 
-  # Check if SERVER_MANUFACTURER is empty, if yes, assign value based on "Board Mfg"
+  # Check if SERVER_MANUFACTURER is empty, if yes, assign value based on "Board Mfg". First match only,
+  # for the same reason as above, and this is the likelier of the two paths to meet a second match :
+  # Dell power supplies commonly leave the "Product *" fields empty and fill only the board ones
   if [ -z "$SERVER_MANUFACTURER" ]; then
-    SERVER_MANUFACTURER=$(echo "$IPMI_FRU_content" | tr -s ' ' | grep "Board Mfg :" | awk -F ': ' '{print $2}')
+    SERVER_MANUFACTURER=$(echo "$IPMI_FRU_content" | tr -s ' ' | grep "Board Mfg :" | awk -F ': ' '{print $2; exit}')
   fi
 
   # Check if SERVER_MODEL is empty, if yes, assign value based on "Board Product"
   if [ -z "$SERVER_MODEL" ]; then
-    SERVER_MODEL=$(echo "$IPMI_FRU_content" | tr -s ' ' | grep "Board Product :" | awk -F ': ' '{print $2}')
+    SERVER_MODEL=$(echo "$IPMI_FRU_content" | tr -s ' ' | grep "Board Product :" | awk -F ': ' '{print $2; exit}')
   fi
 }
 

--- a/tests/cases/50_server_model_detection.sh
+++ b/tests/cases/50_server_model_detection.sh
@@ -33,6 +33,37 @@ function test_the_server_model_falls_back_on_the_fru_board_fields() {
   assert_equals "PowerEdge R630" "$SERVER_MODEL"
 }
 
+function test_a_populated_power_supply_is_not_mistaken_for_the_server_itself() {
+  # "ipmitool fru" describes every FRU device on the bus, and a populated power supply
+  # fills the same "Product Manufacturer" / "Product Name" fields as the server. Keeping
+  # every match makes the manufacturer "DELL\nDELL", which the caller's
+  # [[ ! $SERVER_MANUFACTURER == "DELL" ]] fails, refusing to start with "Your server
+  # isn't a Dell product" on a server that was just identified correctly
+  export MOCK_IPMITOOL_FRU_OUTPUT
+  MOCK_IPMITOOL_FRU_OUTPUT=$(make_fru_output --manufacturer "DELL" --model "PowerEdge R740xd" --with-readable-psu)
+
+  get_Dell_server_model
+
+  assert_equals "DELL" "$SERVER_MANUFACTURER" "the manufacturer is the server's own, once, not one per FRU device"
+  assert_equals "PowerEdge R740xd" "$SERVER_MODEL" "the model is the server's, not its power supply's"
+  assert_not_contains "$SERVER_MODEL" "PWR SPLY" "the power supply's product name must not leak into the model"
+}
+
+function test_a_populated_power_supply_does_not_poison_the_board_field_fallback_either() {
+  # The same hazard on the fallback path, and the likelier one on real hardware : Dell
+  # power supplies commonly leave the "Product *" fields empty and fill only the board
+  # ones, and the fallback is exactly what runs on a server that filled no product field
+  # either. Nothing about a failing connection is involved -- this inventory is entirely
+  # readable, so "ipmitool fru" exits 0 and no connection check stands in the way
+  export MOCK_IPMITOOL_FRU_OUTPUT
+  MOCK_IPMITOOL_FRU_OUTPUT=$(make_fru_output --manufacturer "DELL" --model "PowerEdge R630" --board-fields-only --with-readable-psu)
+
+  get_Dell_server_model
+
+  assert_equals "DELL" "$SERVER_MANUFACTURER" "the board fallback must take the first match only"
+  assert_equals "PowerEdge R630" "$SERVER_MODEL" "the board fallback must not append the power supply's board product"
+}
+
 function test_a_failing_ipmi_connection_stops_the_controller_with_an_actionable_error() {
   export MOCK_IPMITOOL_FRU_EXIT_CODE=1
   export MOCK_IPMITOOL_FRU_OUTPUT="Error: Unable to establish IPMI v2 / RMCP+ session"

--- a/tests/cases/90_integration.sh
+++ b/tests/cases/90_integration.sh
@@ -339,6 +339,23 @@ function test_the_controller_survives_a_recent_server_that_rejects_the_fan_contr
   assert_contains "$OUTPUT" "45°C" "the temperatures must still be monitored and logged"
 }
 
+function test_the_controller_starts_on_a_server_whose_power_supplies_are_populated() {
+  # What the user sees when a second FRU device fills the same fields as the server : the
+  # container refuses to start, claiming the server is not a Dell. The counterpart of
+  # test_the_controller_refuses_to_run_on_a_server_that_is_not_a_dell() below -- that
+  # refusal must keep firing on a real non-Dell, and must never fire on a Dell whose
+  # power supply happens to be readable
+  export MOCK_IPMITOOL_FRU_OUTPUT
+  MOCK_IPMITOOL_FRU_OUTPUT=$(make_fru_output --manufacturer "DELL" --model "PowerEdge R740xd" --with-readable-psu)
+
+  local -r OUTPUT=$(run_controller)
+
+  assert_contains "$OUTPUT" "Server model: DELL PowerEdge R740xd" "the server is named once, without its power supply"
+  assert_not_contains "$OUTPUT" "isn't a Dell product" "a Dell with populated power supplies is still a Dell"
+  assert_not_contains "$OUTPUT" "PWR SPLY" "the power supply must never appear as the server model"
+  assert_contains "$OUTPUT" "User static fan control profile (5%)" "the controller should reach its monitoring loop"
+}
+
 function test_the_controller_refuses_to_run_on_a_server_that_is_not_a_dell() {
   export MOCK_IPMITOOL_FRU_OUTPUT
   MOCK_IPMITOOL_FRU_OUTPUT=$(make_fru_output --manufacturer "Supermicro" --model "Super Server X11DPi-N")

--- a/tests/lib/fixtures.sh
+++ b/tests/lib/fixtures.sh
@@ -12,15 +12,21 @@
 
 # Build an "ipmitool fru" output
 # Usage : make_fru_output [--manufacturer NAME] [--model NAME] [--board-fields-only] [--no-manufacturer]
+#                         [--with-readable-psu]
 #
 # --board-fields-only reproduces the servers that don't fill the "Product *"
 # fields at all and only expose "Board Mfg" / "Board Product", which
 # get_Dell_server_model() falls back on
+#
+# --with-readable-psu appends a POPULATED power supply. It is a FRU device of its
+# own, and it fills the very same manufacturer and product fields as the server, so
+# it is what makes a parse keeping every match collect two values instead of one
 function make_fru_output() {
   local MANUFACTURER="DELL"
   local MODEL="PowerEdge R730xd"
   local BOARD_FIELDS_ONLY=false
   local WITH_MANUFACTURER=true
+  local WITH_READABLE_PSU=false
 
   while [ $# -gt 0 ]; do
     case "$1" in
@@ -28,6 +34,7 @@ function make_fru_output() {
       --model) MODEL="$2"; shift 2 ;;
       --board-fields-only) BOARD_FIELDS_ONLY=true; shift ;;
       --no-manufacturer) WITH_MANUFACTURER=false; shift ;;
+      --with-readable-psu) WITH_READABLE_PSU=true; shift ;;
       *) printf 'make_fru_output: unknown option "%s"\n' "$1" >&2; return 1 ;;
     esac
   done
@@ -42,6 +49,9 @@ function make_fru_output() {
   printf ' Board Part Number     : 0599V5A05\n'
 
   if $BOARD_FIELDS_ONLY; then
+    if $WITH_READABLE_PSU; then
+      make_readable_psu_fru_device --board-fields-only
+    fi
     return 0
   fi
 
@@ -53,6 +63,35 @@ function make_fru_output() {
   printf ' Product Version       : A05\n'
   printf ' Product Serial        : 5N7XXX2\n'
   printf ' Product Asset Tag     :\n'
+
+  if $WITH_READABLE_PSU; then
+    make_readable_psu_fru_device
+  fi
+}
+
+# A populated power supply, as "ipmitool fru" lists it after the builtin FRU device
+# (ID 0) that describes the server. Its manufacturer is the same string the server
+# reports, and its product name is the PSU's own, so a parse taking every match hands
+# the caller "DELL\nDELL" and a two-line model.
+#
+# --board-fields-only reproduces the Dell power supplies that leave the "Product *"
+# fields empty : that shape is what reaches get_Dell_server_model()'s board fallback,
+# which only runs when the server itself filled no product field either
+# Usage : make_readable_psu_fru_device [--board-fields-only]
+function make_readable_psu_fru_device() {
+  printf '\n'
+  printf 'FRU Device Description : PSU1 (ID 1)\n'
+  printf ' Board Mfg             : DELL\n'
+  printf ' Board Product         : PWR SPLY,750W,RDNT,LTON\n'
+  printf ' Board Serial          : CN7792165F0J3B\n'
+
+  if [ "${1:-}" == "--board-fields-only" ]; then
+    return 0
+  fi
+
+  printf ' Product Manufacturer  : DELL\n'
+  printf ' Product Name          : PWR SPLY,750W,RDNT,LTON\n'
+  printf ' Product Part Number   : 0PJMDNA01\n'
 }
 
 # Build a single "ipmitool sdr type temperature" line


### PR DESCRIPTION
Closes #319.

`ipmitool fru` describes every FRU device on the bus, and a populated power supply is one of them. It fills the same fields as the server: `Board Mfg : DELL`, `Board Product : PWR SPLY,750W,RDNT,LTON`, and on some models the `Product *` pair too.

All four parses grepped the whole inventory and kept every match, so a server with a readable power supply came out as:

```
SERVER_MANUFACTURER = "DELL\nDELL"
SERVER_MODEL        = "PowerEdge R630\nPWR SPLY,495W,RDNT,DELTA"
```

`Dell_iDRAC_fan_controller.sh` then tests `[[ ! $SERVER_MANUFACTURER == "DELL" ]]`, which a two-line value fails, and the container stops with **"Your server isn't a Dell product"** — on hardware `get_Dell_server_model()` had just identified correctly.

## What this changes

Take the first match only, in all four parses. `ipmitool` prints the builtin FRU device (ID 0), which describes the server itself, before it walks the SDR records, so the first match is the server's own.

The board fallback is the likelier of the two paths to meet a second match, Dell power supplies commonly leaving the `Product *` fields empty. That path also needs the server itself to have filled no product field — a shape this repository already supports and tests.

## Scope

Independent of #193 and of its fix in #192. Nothing about a failing connection is involved here: the inventory is entirely readable, `ipmitool fru` exits `0`, and no connection check stands in the way. This is reachable on `master` today.

The two do meet on real hardware. A server with empty drive bays **and** populated power supplies hits #193 first; once #192 lands, it walks into this one. Kept separate so #192 stays scoped to what it was reviewed for.

## Tests

`make_fru_output --with-readable-psu` appends a populated power supply, in both its board-fields-only and full forms. Three cases hold the rule:

- the product fields path
- the board field fallback
- an end-to-end run whose container reaches its monitoring loop instead of refusing to start

Reverting the four parses to keeping every match fails exactly those three, and nothing else.

Suite green at 343 cases / 1881 assertions. `shellcheck -x` over the five shipped scripts exits 0.

## Not verified on hardware

The power supply fixture is reconstructed from the Dell FRU field layout, not captured from a machine. The mechanism — several FRU devices filling one field, the parse keeping both — is measured and certain; the exact strings are plausible rather than attested. On a PowerEdge T630, `ipmitool fru | grep -c "Product Manufacturer"` returns `1`, so that machine is not exposed through the product path. The same count run against `Board Mfg` is the quick check for the fallback path, which is the one this is mostly about.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nwph3LB7GB3dKFnWs5GWBV)_