### PR TITLE
Give the hardware questions somewhere for the answers to arrive

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+# Keeping blank issues enabled on purpose : most reports here are one-off
+# questions about a log line, and a form is the wrong shape for those. The
+# templates beside this file exist for the reports whose value depends entirely
+# on which commands were run, where a free-form issue tends to arrive missing
+# the one output that would have settled it.
+blank_issues_enabled: true
+
+contact_links:
+  - name: Question about a parameter, a log line or a troubleshooting step
+    url: https://github.com/tigerblue77/Dell_iDRAC_fan_controller_Docker#readme
+    about: The README documents every parameter, what the startup log states and the known troubleshooting paths. Most questions are answered there.

--- a/.github/ISSUE_TEMPLATE/hardware_report.yml
+++ b/.github/ISSUE_TEMPLATE/hardware_report.yml
@@ -1,0 +1,144 @@
+name: Hardware report
+description: Answer one of the open questions that can only be settled on real hardware
+title: "Hardware report: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Three open questions in this repository cannot be answered without output from a
+        server nobody here owns. If you have one of these machines, a single paste settles
+        a question that has been open for months — and the container gets better on
+        hardware its author cannot test.
+
+        | Issue | Needs | What it decides |
+        |---|---|---|
+        | [#263](https://github.com/tigerblue77/Dell_iDRAC_fan_controller_Docker/issues/263) | a **14th generation PowerEdge or newer** (R640, R740, R650, R750, R660, R760, the MX and XR lines, or anything on iDRAC 9/10) | whether the iDRAC really *refuses* the third-party PCIe cooling command, or accepts it silently and makes the container report a setting it never applied |
+        | [#257](https://github.com/tigerblue77/Dell_iDRAC_fan_controller_Docker/issues/257) | an **AMD PowerEdge** (R6415, R7415, R6515, R7515, R6525, R7525, R6615, R7615…) | whether AMD servers can use the two `lm-sensors` features they are currently excluded from |
+        | [#256](https://github.com/tigerblue77/Dell_iDRAC_fan_controller_Docker/issues/256) | a server whose **iDRAC controls the fans but reports no CPU temperature at all** | whether the `lm-sensors` fallback addresses the failure those servers actually have |
+
+        Fill in only the sections that apply to your machine. A partial report is far
+        better than none: **paste the output verbatim, including any error.** An error
+        message is data here, not a reason to hold the report back.
+
+        > [!NOTE]
+        > These commands only *read* from your BMC. None of them changes a fan speed or
+        > any other setting.
+
+  - type: checkboxes
+    id: questions
+    attributes:
+      label: Which question are you answering?
+      description: Tick every one that applies. Tick none if you are simply reporting what your server does.
+      options:
+        - label: "#263 — my server is 14th generation or newer"
+        - label: "#257 — my server is an AMD PowerEdge"
+        - label: "#256 — my iDRAC controls the fans but reports no CPU temperature"
+
+  - type: input
+    id: model
+    attributes:
+      label: Server model
+      description: Exactly as Dell names it, or as the container prints it at startup.
+      placeholder: PowerEdge R740xd
+    validations:
+      required: true
+
+  - type: input
+    id: idrac
+    attributes:
+      label: iDRAC generation and firmware version
+      description: Readable in the iDRAC web console under "iDRAC Settings". Say "unknown" rather than guessing.
+      placeholder: iDRAC 9, firmware 3.30.30.30
+    validations:
+      required: true
+
+  - type: dropdown
+    id: cpu_vendor
+    attributes:
+      label: CPU manufacturer
+      options:
+        - Intel
+        - AMD
+        - Not sure
+    validations:
+      required: true
+
+  - type: dropdown
+    id: mode
+    attributes:
+      label: How does the container reach the BMC?
+      description: '"local" means IDRAC_HOST=local with the IPMI device passed through; "network" means an iDRAC address over the LAN.'
+      options:
+        - local
+        - network
+        - both, and they behave differently
+    validations:
+      required: true
+
+  - type: textarea
+    id: sdr
+    attributes:
+      label: "Sensor inventory — `ipmitool -I open sdr elist all`"
+      description: |
+        Wanted by **#256** and **#257**. From the Docker host, or inside the container.
+        In network mode, replace `-I open` with `-I lanplus -H <address> -U <user> -P <password>`
+        — and remove the password from what you paste.
+      render: shell
+      placeholder: |
+        $ ipmitool -I open sdr elist all
+        Inlet Temp       | 04h | ok  |  7.1 | 21 degrees C
+        Temp             | 01h | ok  |  3.1 | 42 degrees C
+        ...
+
+  - type: textarea
+    id: sensors
+    attributes:
+      label: "CPU temperatures the host itself reports — `sensors -u`"
+      description: |
+        Wanted by **#256** and **#257**, and only meaningful in `local` mode — it reads the
+        host's own CPUs, not the iDRAC. Ideally captured at the same moment as the inventory
+        above, so the two scales can be compared. On AMD this is the `k10temp` section
+        (`Tctl` / `Tdie`) that #257 turns on.
+      render: shell
+      placeholder: |
+        $ sensors -u
+        coretemp-isa-0000
+        Package id 0:
+          temp1_input: 42.000
+          temp1_max: 80.000
+          temp1_crit: 90.000
+
+  - type: textarea
+    id: pcie
+    attributes:
+      label: "Third-party PCIe cooling response — the `raw 0x30 0xce` probe"
+      description: |
+        Wanted by **#263**, and the whole question for 14th generation and newer servers.
+        Run it and paste the output *and* the exit code — an `Invalid command` rejection is
+        the answer just as much as a success is.
+      render: shell
+      placeholder: |
+        $ ipmitool -I open raw 0x30 0xce 0x00 0x16 0x05 0x00 0x00 0x00 0x05 0x00 0x00 0x00 0x00; echo "exit: $?"
+        Unable to send RAW command (channel=0x0 netfn=0x30 lun=0x0 cmd=0xce rsp=0xc1): Invalid command
+        exit: 1
+
+  - type: textarea
+    id: startup_log
+    attributes:
+      label: Container startup log
+      description: |
+        `docker logs <container>` from the first line onwards. Useful on its own: recent
+        versions name the server, the temperature source in use, the threshold retained and
+        where it came from — so this alone often contains the answer.
+      render: shell
+
+  - type: textarea
+    id: anything_else
+    attributes:
+      label: Anything else worth knowing
+      description: Container version, how the server is loaded when you captured this, or anything that looked wrong.
+
+  - type: markdown
+    attributes:
+      value: |
+        Thank you — this is the only way these three questions get closed.


### PR DESCRIPTION
Closes #321.

#256, #257 and #263 are each blocked on output from a server nobody here owns. Each states exactly which commands would settle it. None of them was reachable by somebody who *has* the hardware but has not read the issue — there was no `ISSUE_TEMPLATE` directory at all, so every report started from an empty box, and the README's troubleshooting section asks for `sensors -u` with nowhere to send it.

## Files

| File | What |
|---|---|
| `.github/ISSUE_TEMPLATE/hardware_report.yml` | One issue form serving all three questions |
| `.github/ISSUE_TEMPLATE/config.yml` | Keeps blank issues enabled, points questions at the README |

## What the form does that a README paragraph cannot

It opens with a table mapping each of the three issues to the machine that can answer it and to what the answer decides, so a reader works out in one glance whether they are the person being asked. Eligibility is stated next to the field rather than buried — `#263` needs a 14th generation PowerEdge or newer, and the form says which model names those are.

The part worth the effort: **it tells the reporter that a rejection is a result.** #263's whole structure is three outcomes, all informative — `rsp=0xc1`, some *other* `rsp=` code, or a clean exit 0 — and the middle and last rows are the two that would need code. A user who runs the probe, sees `Unable to send RAW command … Invalid command`, and concludes their attempt failed is exactly how that issue stays open forever. The field asks for the output *and* the exit code, and says the error is the data.

`sensors -u` is marked as meaningful only in `local` mode, since it reads the host's CPUs rather than the iDRAC, and #257's AMD question is named on it (`k10temp`, `Tctl`/`Tdie`) so an EPYC owner recognises their own machine.

A note states that every command only reads from the BMC and changes no fan speed — the reasonable hesitation before pasting IPMI commands into a terminal on a production server.

## Deliberately narrow

**One** form. No bug report form, no feature request form. This tracker's free-form issues are not the problem, and funnelling every existing kind of report through a template nobody asked for would be a regression rather than a fix. `config.yml` sets `blank_issues_enabled: true` for the same reason, and adds a single contact link sending "how does this parameter work" to the README instead of into the tracker.

No `labels:` on the form: the repository has `bug`, `enhancement`, `documentation` and `good first issue`, and none of them describes a hardware report. Worth creating a `hardware report` label and adding it to the form afterwards — left out here rather than shipping a form that references a label that does not exist.

## Verification

- Both files parse as YAML, and were checked against GitHub's issue-form schema: required top-level keys (`name`, `description`, `body`) present, every non-`markdown` element carries an `id` and a `label`, and every `dropdown`/`checkboxes` element carries `options`.
- **Test suite green: 350 cases, 1906 assertions**, unchanged — `tests/cases/12_github_workflows.sh` globs `.github/workflows/*.yml` only, so the new directory is outside what it validates, and no shell file was touched.
- No change to any shipped script, the `Dockerfile`, or any workflow. Nothing in the built image moves.

## What this does not do

It does not answer the three questions — nobody in this repository can. It removes the part that *was* in the repository's control: a willing owner of an R760 currently has no path shorter than reading a 2 000-word issue to find out that one command and its exit code are all that is wanted.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DhruzPPRcWf5sp8VsPSve3

---
_Generated by [Claude Code](https://claude.ai/code/session_01DhruzPPRcWf5sp8VsPSve3)_