### PR TITLE
Identify the server from its own FRU device, not from the first that answers

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -1272,27 +1272,39 @@ function get_Dell_server_model() {
   IPMI_FRU_content=$(ipmitool -I $IDRAC_LOGIN_STRING fru 2>&1)
   local -r ipmitool_exit_code=$?
 
-  # Only the FIRST match of each field. "ipmitool fru" describes every FRU device on the bus, and more
-  # than one of them fills these fields : a populated power supply reports its own manufacturer and its
-  # own product name. Keeping every match sets these variables to several newline-separated values, the
-  # server's own and its parts', and the equality test the caller runs against SERVER_MANUFACTURER then
-  # fails on a genuine Dell -- refusing to start with "Your server isn't a Dell product" on hardware
-  # this function had just identified correctly (issue #319). ipmitool prints the builtin FRU device
-  # (ID 0), which describes the server itself, before it walks the SDR records, so the first match is
-  # the right one
-  SERVER_MANUFACTURER=$(echo "$IPMI_FRU_content" | grep "Product Manufacturer" | awk -F ': ' '{print $2; exit}')
-  SERVER_MODEL=$(echo "$IPMI_FRU_content" | grep "Product Name" | awk -F ': ' '{print $2; exit}')
+  # The server is the builtin FRU device (ID 0). "ipmitool fru" describes every FRU device on the bus,
+  # and all the others are parts rather than the server : a populated power supply fills these very same
+  # fields with its own manufacturer and its own product name.
+  #
+  # Reading the whole inventory and taking the first match (issue #319) is right only as long as the
+  # builtin device fills the field itself. When it does not, the first match silently comes from
+  # whichever device is listed next, so a server declaring no manufacturer of its own gets identified by
+  # its power supply's brand -- and a non-Dell server carrying a Dell branded power supply then passes
+  # the caller's "is this a Dell?" test, which exists to keep Dell's raw commands away from hardware
+  # that is not Dell. Narrowing the search to the builtin device's own section closes that.
+  #
+  # An inventory that labels no builtin device is read whole, exactly as before, rather than not at all
+  local FRU_SERVER_SECTION
+  FRU_SERVER_SECTION=$(echo "$IPMI_FRU_content" | awk '
+    /^FRU Device Description/ { inside = ($0 ~ /Builtin FRU Device/); next }
+    inside')
+  if [ -z "$FRU_SERVER_SECTION" ]; then
+    FRU_SERVER_SECTION="$IPMI_FRU_content"
+  fi
 
-  # Check if SERVER_MANUFACTURER is empty, if yes, assign value based on "Board Mfg". First match only,
-  # for the same reason as above, and this is the likelier of the two paths to meet a second match :
-  # Dell power supplies commonly leave the "Product *" fields empty and fill only the board ones
+  # First match only within that section too : one device cannot sensibly report the field twice, but a
+  # whole-inventory fallback above would otherwise bring the parts back in
+  SERVER_MANUFACTURER=$(echo "$FRU_SERVER_SECTION" | grep "Product Manufacturer" | awk -F ': ' '{print $2; exit}')
+  SERVER_MODEL=$(echo "$FRU_SERVER_SECTION" | grep "Product Name" | awk -F ': ' '{print $2; exit}')
+
+  # Check if SERVER_MANUFACTURER is empty, if yes, assign value based on "Board Mfg"
   if [ -z "$SERVER_MANUFACTURER" ]; then
-    SERVER_MANUFACTURER=$(echo "$IPMI_FRU_content" | tr -s ' ' | grep "Board Mfg :" | awk -F ': ' '{print $2; exit}')
+    SERVER_MANUFACTURER=$(echo "$FRU_SERVER_SECTION" | tr -s ' ' | grep "Board Mfg :" | awk -F ': ' '{print $2; exit}')
   fi
 
   # Check if SERVER_MODEL is empty, if yes, assign value based on "Board Product"
   if [ -z "$SERVER_MODEL" ]; then
-    SERVER_MODEL=$(echo "$IPMI_FRU_content" | tr -s ' ' | grep "Board Product :" | awk -F ': ' '{print $2; exit}')
+    SERVER_MODEL=$(echo "$FRU_SERVER_SECTION" | tr -s ' ' | grep "Board Product :" | awk -F ': ' '{print $2; exit}')
   fi
 
   # Whether the server could be identified is the reliable signal here, not ipmitool's

--- a/tests/cases/50_server_model_detection.sh
+++ b/tests/cases/50_server_model_detection.sh
@@ -107,6 +107,54 @@ function test_the_board_field_fallback_reads_the_server_and_not_the_first_device
   assert_not_contains "$SERVER_MODEL" "PWR SPLY" "the power supply's board product must not answer for the server"
 }
 
+function test_an_inventory_naming_no_builtin_device_is_still_read_whole() {
+  # The identification is narrowed to the builtin FRU device's own section, which assumes the inventory
+  # labels it. Nothing guarantees every ipmitool build and every BMC does, and a server that used to be
+  # identified must not stop being just because its output is shaped differently -- so an inventory
+  # naming no builtin device falls back to being read whole, exactly as before that narrowing.
+  # This holds that fallback, which is otherwise invisible : it only ever runs on outputs no other case
+  # produces, and a narrowing that silently identified nothing would still leave the suite green
+  export MOCK_IPMITOOL_FRU_OUTPUT
+  MOCK_IPMITOOL_FRU_OUTPUT=' Product Manufacturer  : DELL
+ Product Name          : PowerEdge R730xd'
+
+  local EXIT_CODE=0
+  capture_output get_Dell_server_model || EXIT_CODE=$?
+
+  assert_equals 0 "$EXIT_CODE" "an unlabelled inventory must not stop a server it can still identify"
+  assert_equals "DELL" "$SERVER_MANUFACTURER"
+  assert_equals "PowerEdge R730xd" "$SERVER_MODEL"
+}
+
+function test_the_board_fields_are_read_whole_too_when_no_builtin_device_is_named() {
+  # The same fallback on the other path : both pairs are narrowed, so both need it
+  export MOCK_IPMITOOL_FRU_OUTPUT
+  MOCK_IPMITOOL_FRU_OUTPUT=' Board Mfg             : DELL
+ Board Product         : PowerEdge R630'
+
+  local EXIT_CODE=0
+  capture_output get_Dell_server_model || EXIT_CODE=$?
+
+  assert_equals 0 "$EXIT_CODE" "the board fallback must survive an unlabelled inventory as well"
+  assert_equals "DELL" "$SERVER_MANUFACTURER"
+  assert_equals "PowerEdge R630" "$SERVER_MODEL"
+}
+
+function test_a_server_with_empty_bays_and_populated_power_supplies_is_read_correctly() {
+  # The three hazards on one machine, which is what ordinary hardware looks like : empty drive bays
+  # making the walk exit non-zero (#193), a populated power supply filling the same fields as the
+  # server (#319), and the server's own fields being the ones that must answer (#323)
+  simulate_partially_readable_fru_inventory --manufacturer "DELL" --model "PowerEdge R740xd" --with-readable-psu
+
+  local EXIT_CODE=0
+  capture_output get_Dell_server_model || EXIT_CODE=$?
+
+  assert_equals 0 "$EXIT_CODE" "none of the three hazards should stop a server that identified itself"
+  assert_equals "DELL" "$SERVER_MANUFACTURER"
+  assert_equals "PowerEdge R740xd" "$SERVER_MODEL"
+  assert_not_contains "$SERVER_MODEL" "PWR SPLY" "the power supply must not answer for the server"
+}
+
 function test_a_failing_ipmi_connection_stops_the_controller_with_an_actionable_error() {
   export MOCK_IPMITOOL_FRU_EXIT_CODE=1
   export MOCK_IPMITOOL_FRU_OUTPUT="Error: Unable to establish IPMI v2 / RMCP+ session"

--- a/tests/cases/50_server_model_detection.sh
+++ b/tests/cases/50_server_model_detection.sh
@@ -64,6 +64,49 @@ function test_a_populated_power_supply_does_not_poison_the_board_field_fallback_
   assert_equals "PowerEdge R630" "$SERVER_MODEL" "the board fallback must not append the power supply's board product"
 }
 
+function test_a_server_declaring_no_manufacturer_is_read_for_its_model_alone() {
+  # Some servers name themselves but fill no manufacturer field, in either the board or the product
+  # pair. The model still identifies them, so this must not be fatal here : it is the caller that
+  # decides what to do with a server it cannot confirm is a Dell
+  export MOCK_IPMITOOL_FRU_OUTPUT
+  MOCK_IPMITOOL_FRU_OUTPUT=$(make_fru_output --model "PowerEdge R730xd" --no-manufacturer)
+
+  local EXIT_CODE=0
+  capture_output get_Dell_server_model || EXIT_CODE=$?
+
+  assert_equals 0 "$EXIT_CODE" "a server that named itself was identified, whatever its manufacturer field says"
+  assert_empty "$SERVER_MANUFACTURER" "no manufacturer was declared, so none must be invented"
+  assert_equals "PowerEdge R730xd" "$SERVER_MODEL"
+}
+
+function test_a_server_declaring_no_manufacturer_is_not_given_its_power_supplys_brand() {
+  # The identification must read the SERVER, not merely the first FRU device that happened to fill the
+  # field. A server declaring no manufacturer of its own, with a Dell branded power supply on the bus,
+  # must not come back as "DELL" : Dell_iDRAC_fan_controller.sh tests SERVER_MANUFACTURER to keep Dell's
+  # raw commands away from hardware that is not Dell, and borrowing a power supply's brand defeats it
+  export MOCK_IPMITOOL_FRU_OUTPUT
+  MOCK_IPMITOOL_FRU_OUTPUT=$(make_fru_output --model "Super Server X11DPi-N" --no-manufacturer --with-readable-psu)
+
+  get_Dell_server_model
+
+  assert_empty "$SERVER_MANUFACTURER" "the power supply's manufacturer is not the server's"
+  assert_not_equals "DELL" "$SERVER_MANUFACTURER" "a Dell power supply must never make a server pass for a Dell"
+  assert_equals "Super Server X11DPi-N" "$SERVER_MODEL" "the model is still the server's own"
+}
+
+function test_the_board_field_fallback_reads_the_server_and_not_the_first_device_that_answers() {
+  # Same hazard on the fallback path, which is where it actually bites : Dell power supplies commonly
+  # fill only their board fields, and the fallback only runs on a server that filled no product field
+  export MOCK_IPMITOOL_FRU_OUTPUT
+  MOCK_IPMITOOL_FRU_OUTPUT=$(make_fru_output --model "Super Server X11DPi-N" --no-manufacturer --board-fields-only --with-readable-psu)
+
+  get_Dell_server_model
+
+  assert_empty "$SERVER_MANUFACTURER" "the board fallback must stay inside the builtin FRU device"
+  assert_equals "Super Server X11DPi-N" "$SERVER_MODEL" "the model must be the server's, not the power supply's"
+  assert_not_contains "$SERVER_MODEL" "PWR SPLY" "the power supply's board product must not answer for the server"
+}
+
 function test_a_failing_ipmi_connection_stops_the_controller_with_an_actionable_error() {
   export MOCK_IPMITOOL_FRU_EXIT_CODE=1
   export MOCK_IPMITOOL_FRU_OUTPUT="Error: Unable to establish IPMI v2 / RMCP+ session"

--- a/tests/cases/90_integration.sh
+++ b/tests/cases/90_integration.sh
@@ -356,6 +356,25 @@ function test_the_controller_starts_on_a_server_whose_power_supplies_are_populat
   assert_contains "$OUTPUT" "User static fan control profile (5%)" "the controller should reach its monitoring loop"
 }
 
+function test_the_controller_refuses_a_server_whose_only_dell_marking_is_its_power_supply() {
+  # The safety guarantee of the case below, on the shape that used to slip past it. A non-Dell server
+  # declaring no manufacturer of its own, with a Dell branded power supply on the FRU bus, was read as
+  # "DELL" and started -- so Dell's proprietary raw commands reached hardware that was never Dell.
+  # Whatever such a server does with 0x30 0x30 is undefined, which is exactly what the check exists to
+  # avoid, so the refusal matters more than the identification
+  export MOCK_IPMITOOL_FRU_OUTPUT
+  MOCK_IPMITOOL_FRU_OUTPUT=$(make_fru_output --model "Super Server X11DPi-N" --no-manufacturer --with-readable-psu)
+
+  local OUTPUT
+  OUTPUT=$(run_controller)
+  local -r EXIT_CODE=$?
+
+  assert_equals 1 "$EXIT_CODE"
+  assert_contains "$OUTPUT" "Your server isn't a Dell product"
+  assert_equals "0" "$(count_ipmitool_calls_matching "raw 0x30")" \
+    "no fan control command must ever reach a server whose only Dell marking is a spare part"
+}
+
 function test_the_controller_refuses_to_run_on_a_server_that_is_not_a_dell() {
   export MOCK_IPMITOOL_FRU_OUTPUT
   MOCK_IPMITOOL_FRU_OUTPUT=$(make_fru_output --manufacturer "Supermicro" --model "Super Server X11DPi-N")

--- a/tests/lib/fixtures.sh
+++ b/tests/lib/fixtures.sh
@@ -18,6 +18,11 @@
 # fields at all and only expose "Board Mfg" / "Board Product", which
 # get_Dell_server_model() falls back on
 #
+# --no-manufacturer reproduces the servers that name themselves but declare no
+# manufacturer at all, in either the board or the product fields. Combined with
+# --with-readable-psu it is what tells whether the identification is really reading
+# the server, or merely the first FRU device that happened to fill the field
+#
 # --with-unreadable-devices appends the empty drive backplane, PERC and PSU bays that
 # a partially populated server reports as unreadable. They are what makes the real
 # "ipmitool fru" exit non-zero on hardware that is nonetheless perfectly healthy, and


### PR DESCRIPTION
Closes #323.

#320 made the four FRU parses take the first match across the whole inventory, so that a populated power supply was no longer collected alongside the server. That is right **only as long as the builtin FRU device (ID 0) fills the field itself**.

When it does not, the first match silently comes from whichever device is listed next. A server declaring no manufacturer of its own, with a Dell branded power supply on the bus, therefore came back as `SERVER_MANUFACTURER="DELL"`:

```
MANUFACTURER = [DELL]                      ← the power supply's
MODEL        = [Super Server X11DPi-N]     ← the server's
```

`Dell_iDRAC_fan_controller.sh` tests exactly that value to keep Dell's proprietary raw commands away from hardware that is not Dell. A Supermicro passed that check and started, on the strength of a spare part's brand.

## What this changes

Narrow all four parses to the builtin FRU device's own section, which is what describes the server.

An inventory labelling no builtin device is read whole, exactly as before, so nothing that used to be identified stops being. That fallback is deliberate: it keeps this from being a behaviour change for any output shape that does not name the device, only a narrowing for the ones that do.

## Scope

Distinct from #319, though it lives in the same lines. #319 was *two* devices filling one field and the parse keeping both; this is *zero* devices filling it on the server and *one* filling it elsewhere, the parse then reaching outside the server. #320's fix is what makes the second case silent rather than visibly wrong.

Unrelated to #193: the inventory here is entirely readable and `ipmitool fru` exits `0`.

## How many devices actually fill these fields

Measured on a real PowerEdge T630:

```
# ipmitool fru | grep -c "Board Mfg"
8
# ipmitool fru | grep -c "Product Manufacturer"
1
```

Eight FRU devices fill `Board Mfg` on one ordinary server. That is the premise of both #319 and this PR, and it is not a marginal shape.

That particular machine was never broken: its builtin device fills the `Product *` fields, so the board fallback never runs on it and the eight candidates are never consulted. But the fallback is precisely what runs on a server filling only its board fields — a shape this repository supports and tests (`make_fru_output --board-fields-only`) — and on such a machine the pre-#320 parse would have collected all eight into `SERVER_MANUFACTURER`, and the post-#320 parse would take whichever device happens to be listed first.

## Tests

Seven cases, in three groups.

**The defect itself.** `make_fru_output --no-manufacturer` already existed and was documented, but no case used it — that dormant fixture is exactly what describes this shape, and the gap that let this through. It is now exercised by:

- the product fields
- the board fallback, where it actually bites: Dell power supplies commonly fill only their board fields, and the fallback only runs on a server that filled no product field
- an end-to-end run where the controller refuses such a server and sends it **no raw command at all**, which is the guarantee that matters
- the plain shape the fixture describes: a server naming itself but declaring no manufacturer is still identified by its model, and that is not fatal in `get_Dell_server_model()` — the caller decides

**The fallback this narrowing introduces.** It only ever runs on outputs no other case produces, so a narrowing that silently identified nothing on those would still have left the suite green. It is the branch most able to regress unnoticed, being the one that exists to prevent a regression. Two cases hold it, one per pair of fields.

**The three hazards on one machine**, which is what ordinary hardware looks like: empty drive bays making the walk exit non-zero (#193), a populated power supply filling the same fields as the server (#319), and the server's own fields being the ones that answer (#323). Each is covered alone elsewhere; this holds that they compose.

## Verification

Suite green at 357 cases / 1928 assertions. `shellcheck -x` over the five shipped scripts exits 0.

Reverting `functions.sh` to master's fails the three cases covering the defect. Removing only the fallback fails exactly the two covering it. No case in this PR passes vacuously.

The power supply fixture's exact strings are reconstructed from the Dell FRU field layout rather than captured from a machine; the counts above attest the mechanism itself.