### PR TITLE
Write FAN_SPEED's range and unit where its readers are (#328)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@
 IDRAC_HOST=<iDRAC IP address, or "local">
 IDRAC_USERNAME=<iDRAC username>
 IDRAC_PASSWORD=<iDRAC password>
-FAN_SPEED=<decimal or hexadecimal fan speed>
+FAN_SPEED=<fan speed in %, from 0 to 100, or hexadecimal from 0x00 to 0x64>
 CPU_TEMPERATURE_THRESHOLD=<decimal temperature threshold in °C, from 20 to 125, or auto>
 CPU_TEMPERATURE_SOURCE=<auto, ipmi or lm-sensors>
 CHECK_INTERVAL=<seconds between each check>

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ docker run -d \
   --name Dell_iDRAC_fan_controller \
   --restart=unless-stopped \
   -e IDRAC_HOST=local \
-  -e FAN_SPEED=<decimal or hexadecimal fan speed> \
+  -e FAN_SPEED=<fan speed in %, from 0 to 100, or hexadecimal from 0x00 to 0x64> \
   -e CPU_TEMPERATURE_THRESHOLD=<decimal temperature threshold in °C, from 20 to 125, or auto> \
   -e CPU_TEMPERATURE_SOURCE=<auto, ipmi or lm-sensors> \
   -e CHECK_INTERVAL=<seconds between each check> \
@@ -103,7 +103,7 @@ docker run -d \
   -e IDRAC_HOST=<iDRAC IP address> \
   -e IDRAC_USERNAME=<iDRAC username> \
   -e IDRAC_PASSWORD=<iDRAC password> \
-  -e FAN_SPEED=<decimal or hexadecimal fan speed> \
+  -e FAN_SPEED=<fan speed in %, from 0 to 100, or hexadecimal from 0x00 to 0x64> \
   -e CPU_TEMPERATURE_THRESHOLD=<decimal temperature threshold in °C, from 20 to 125, or auto> \
   -e CPU_TEMPERATURE_SOURCE=<auto, ipmi or lm-sensors> \
   -e CHECK_INTERVAL=<seconds between each check> \
@@ -129,7 +129,7 @@ services:
     restart: unless-stopped
     environment:
       - IDRAC_HOST=local
-      - FAN_SPEED=<decimal or hexadecimal fan speed>
+      - FAN_SPEED=<fan speed in %, from 0 to 100, or hexadecimal from 0x00 to 0x64>
       - CPU_TEMPERATURE_THRESHOLD=<decimal temperature threshold in °C, from 20 to 125, or auto>
       - CPU_TEMPERATURE_SOURCE=<auto, ipmi or lm-sensors>
       - CHECK_INTERVAL=<seconds between each check>
@@ -156,7 +156,7 @@ services:
       - IDRAC_HOST=<iDRAC IP address>
       - IDRAC_USERNAME=<iDRAC username>
       - IDRAC_PASSWORD=<iDRAC password>
-      - FAN_SPEED=<decimal or hexadecimal fan speed>
+      - FAN_SPEED=<fan speed in %, from 0 to 100, or hexadecimal from 0x00 to 0x64>
       - CPU_TEMPERATURE_THRESHOLD=<decimal temperature threshold in °C, from 20 to 125, or auto>
       - CPU_TEMPERATURE_SOURCE=<auto, ipmi or lm-sensors>
       - CHECK_INTERVAL=<seconds between each check>
@@ -205,7 +205,15 @@ All parameters are optional as they have default values (including default iDRAC
 - `IDRAC_HOST` parameter can be set to "local" or to your distant iDRAC's IP address. **Default** value is "local".
 - `IDRAC_USERNAME` parameter is only necessary if you're adressing a distant iDRAC. **Default** value is "root".
 - `IDRAC_PASSWORD` parameter is only necessary if you're adressing a distant iDRAC. **Default** value is "calvin".
-- `FAN_SPEED` parameter can be set as a decimal (from 0 to 100%) or hexadecimaladecimal value (from 0x00 to 0x64) you want to set the fans to. **Default** value is 5(%).
+- `FAN_SPEED` parameter is the duty cycle the fans are held at while your fan control profile is applied. It can be set as a decimal percentage (from 0 to 100%) or as the same value in hexadecimal (from 0x00 to 0x64). **Default** value is 5(%).
+  - Anything outside that range stops the container at startup rather than being clamped or passed through to the fans, `200` having once reached `ipmitool` as `0xc8`.
+  - :warning: **The `0x` prefix is the only thing that tells the two notations apart**, and both are accepted, so a value that lost its prefix is not refused — it just applies a different duty cycle than the one you meant. `0x64` is 100% while `64` is 64%; `0x30` is 48% while `30` is 30%. The startup log always states the one that was resolved:
+
+    ```
+    Fan speed objective: 64%
+    ```
+
+    That is the line to check first if the fans do not behave the way you expected.
 - `CPU_TEMPERATURE_THRESHOLD` parameter is the T°junction (junction temperature) threshold beyond which the Dell fan mode defined in your BIOS will become active again (to protect the server hardware against overheat). It can be set to a decimal number of degrees Celsius, from 20 to 125, or to "auto" to let the container read the threshold from the CPUs themselves. **Default** value is "auto".
   - An explicit value has to be **between 20°C and 125°C**, and the container refuses to start on anything outside that window rather than run with it. No CPU throttles below the lower bound and none tolerates more than the upper one, so a value outside it is a typo (`500` for `50`) or a Fahrenheit reading rather than a setting — and left in place it would be silent, every comparison against it reading as "not overheating" while the whole chassis stayed at `FAN_SPEED`.
   - A value **above** the maximum is not a stricter setting but the absence of one, which is why it is refused rather than clamped. No PowerEdge CPU reaches 125°C — the server's own thermal protection powers the machine off first — so such a threshold could never be crossed, the overheat fallback it governs could never fire, and the container would print `CPU temperature threshold: 160°C` at startup while supervising nothing. **That fallback cannot be switched off, by design**, and no value of this parameter is meant to do it. `MONITORING_ONLY_MODE` is not that switch either: it never applies **any** profile, yours included.
@@ -402,7 +410,7 @@ or
 export IDRAC_HOST=<iDRAC IP address>
 export IDRAC_USERNAME=<iDRAC username>
 export IDRAC_PASSWORD=<iDRAC password>
-export FAN_SPEED=<decimal or hexadecimal fan speed>
+export FAN_SPEED=<fan speed in %, from 0 to 100, or hexadecimal from 0x00 to 0x64>
 export CPU_TEMPERATURE_THRESHOLD=<decimal temperature threshold in °C, from 20 to 125, or auto>
 export CHECK_INTERVAL=<seconds between each check>
 export MAXIMUM_IPMI_UNREACHABLE_DURATION=<how long the iDRAC may stay unreachable before exiting, or empty>

--- a/constants.sh
+++ b/constants.sh
@@ -21,6 +21,17 @@ readonly FALLBACK_CPU_TEMPERATURE_THRESHOLD=50
 readonly MINIMUM_PLAUSIBLE_CPU_TEMPERATURE_THRESHOLD=20
 readonly MAXIMUM_PLAUSIBLE_CPU_TEMPERATURE_THRESHOLD=125
 
+# Bounds of the fan speed, as a percentage of the fans' duty cycle. Dell's raw command takes a byte,
+# so the same setting is also accepted in hexadecimal, and the maximum is 0x64 in that notation --
+# derived from this number rather than written beside it, two spellings of one bound being one more
+# thing that can drift apart.
+#
+# Kept here rather than written into validate_fan_speed_parameter() for the same reason the check
+# interval's bounds are : the documentation states them too, and nothing could compare the two while
+# they lived only in the validator. test_the_readme_documents_the_fan_speed_range() now does (#328)
+readonly MINIMUM_FAN_SPEED_PERCENTAGE=0
+readonly MAXIMUM_FAN_SPEED_PERCENTAGE=100
+
 # Bounds the check interval is measured against, in seconds. The interval is the controller's reaction
 # time : between two checks the fans stay pinned at FAN_SPEED with Dell's own dynamic fan control
 # disabled, so it is also the longest the server can heat up before anything raises them again.

--- a/functions.sh
+++ b/functions.sh
@@ -118,16 +118,22 @@ function validate_fan_speed_parameter() {
   local -r VALUE="$2"
   local DECIMAL_VALUE
 
+  # One command substitution per statement, which is why these are hoisted rather than expanded inside
+  # the messages below (see test_no_statement_expands_two_command_substitutions)
+  local -r MINIMUM_HEXADECIMAL_FAN_SPEED=$(convert_decimal_value_to_hexadecimal "$MINIMUM_FAN_SPEED_PERCENTAGE")
+  local -r MAXIMUM_HEXADECIMAL_FAN_SPEED=$(convert_decimal_value_to_hexadecimal "$MAXIMUM_FAN_SPEED_PERCENTAGE")
+  local -r ACCEPTED_RANGE="a percentage from ${MINIMUM_FAN_SPEED_PERCENTAGE} to ${MAXIMUM_FAN_SPEED_PERCENTAGE}, or the same value in hexadecimal from ${MINIMUM_HEXADECIMAL_FAN_SPEED} to ${MAXIMUM_HEXADECIMAL_FAN_SPEED}"
+
   if [[ "$VALUE" =~ ^0[xX][0-9A-Fa-f]{1,2}$ ]]; then
     DECIMAL_VALUE=$(convert_hexadecimal_value_to_decimal "$VALUE")
   elif [[ "$VALUE" =~ ^[0-9]+$ ]]; then
     DECIMAL_VALUE=$(normalize_decimal_value "$VALUE")
   else
-    print_configuration_error_and_exit "$PARAMETER_NAME" "$VALUE" "a percentage from 0 to 100, or the same value in hexadecimal from 0x00 to 0x64"
+    print_configuration_error_and_exit "$PARAMETER_NAME" "$VALUE" "$ACCEPTED_RANGE. The \"0x\" prefix is what tells the two notations apart"
   fi
 
-  if [ "$DECIMAL_VALUE" -gt 100 ]; then
-    print_configuration_error_and_exit "$PARAMETER_NAME" "$VALUE" "a percentage from 0 to 100, or the same value in hexadecimal from 0x00 to 0x64 (this is ${DECIMAL_VALUE}%)"
+  if [ "$DECIMAL_VALUE" -gt "$MAXIMUM_FAN_SPEED_PERCENTAGE" ]; then
+    print_configuration_error_and_exit "$PARAMETER_NAME" "$VALUE" "$ACCEPTED_RANGE (this is ${DECIMAL_VALUE}%)"
   fi
 }
 

--- a/tests/cases/10_shell_scripts.sh
+++ b/tests/cases/10_shell_scripts.sh
@@ -377,6 +377,49 @@ function test_the_readme_documents_the_plausible_temperature_threshold_window() 
     ".env.example should carry the same unit and range, being the other file users copy from"
 }
 
+function test_the_readme_documents_the_fan_speed_range() {
+  # The range validate_fan_speed_parameter() enforces was stated in exactly one
+  # sentence of the README -- which spelled it "hexadecimaladecimal" -- and in
+  # none of the six placeholders a user copies into a "docker run", a compose file
+  # or a .env. A bound met for the first time as a container refusing to start is
+  # the defect #326 was about; this is the same one, one parameter over (#328)
+  if [ ! -f "$REPO_ROOT/README.md" ] || [ ! -f "$REPO_ROOT/.env.example" ]; then
+    # The suite is running inside the built image, which carries neither the
+    # README (excluded by .dockerignore) nor the example file shipped beside it
+    skip_test "no README and .env.example next to the scripts"
+    return 0
+  fi
+
+  assert_not_empty "$MINIMUM_FAN_SPEED_PERCENTAGE" \
+    "constants.sh should define the bottom of the fan speed range" || return 1
+  assert_not_empty "$MAXIMUM_FAN_SPEED_PERCENTAGE" \
+    "constants.sh should define the top of the fan speed range" || return 1
+
+  # Derived rather than written out, so that the documentation is held to the same
+  # bound in both notations. One substitution per statement, as everywhere else
+  local -r MINIMUM_HEXADECIMAL_FAN_SPEED=$(convert_decimal_value_to_hexadecimal "$MINIMUM_FAN_SPEED_PERCENTAGE")
+  local -r MAXIMUM_HEXADECIMAL_FAN_SPEED=$(convert_decimal_value_to_hexadecimal "$MAXIMUM_FAN_SPEED_PERCENTAGE")
+
+  local -r README_CONTENT=$(cat "$REPO_ROOT/README.md")
+
+  # The parameter's own bullet, matched with its parentheses so that the assertion
+  # cannot be satisfied by the placeholders further up the file
+  assert_contains "$README_CONTENT" \
+    "(from $MINIMUM_FAN_SPEED_PERCENTAGE to $MAXIMUM_FAN_SPEED_PERCENTAGE%)" \
+    "the README's FAN_SPEED bullet should state the percentage range the validator enforces"
+  assert_contains "$README_CONTENT" \
+    "(from $MINIMUM_HEXADECIMAL_FAN_SPEED to $MAXIMUM_HEXADECIMAL_FAN_SPEED)" \
+    "and the same bound in the hexadecimal notation it also accepts"
+
+  # The placeholders, which is where a user meets the parameter first : they carry
+  # the unit as well, "%" being what says 5 is a duty cycle rather than a speed
+  local -r PLACEHOLDER="in %, from $MINIMUM_FAN_SPEED_PERCENTAGE to $MAXIMUM_FAN_SPEED_PERCENTAGE, or hexadecimal from $MINIMUM_HEXADECIMAL_FAN_SPEED to $MAXIMUM_HEXADECIMAL_FAN_SPEED"
+  assert_contains "$README_CONTENT" "$PLACEHOLDER" \
+    "the README's FAN_SPEED placeholders should carry the unit and both ranges"
+  assert_contains "$(cat "$REPO_ROOT/.env.example")" "$PLACEHOLDER" \
+    ".env.example should carry the same, being the other file users copy from"
+}
+
 function test_the_suites_own_readme_lists_every_case_file() {
   # The three guards above watch the documentation the users read. This one
   # watches the documentation the contributors read : tests/README.md holds a

--- a/tests/cases/20_fan_speed_conversions.sh
+++ b/tests/cases/20_fan_speed_conversions.sh
@@ -36,6 +36,26 @@ function test_a_hexadecimal_fan_speed_is_always_a_lowercase_two_digit_byte() {
   assert_equals "0xab" "$(convert_decimal_value_to_hexadecimal 171)"
 }
 
+function test_the_prefix_is_what_tells_the_two_notations_apart() {
+  # Both spellings are accepted and neither is refused, so the prefix is the whole
+  # difference between them : a value that lost its "0x" applies another duty cycle
+  # rather than reporting anything. The README states this pair, and this is what
+  # holds the statement to the dispatcher that produces it (#328)
+  convert_fan_speed_parameter "0x64"
+  assert_equals "100" "$DECIMAL_SPEED" "0x64 is 100%"
+  assert_equals "0x64" "$HEXADECIMAL_SPEED" "and reaches ipmitool as the byte it already was"
+
+  convert_fan_speed_parameter "64"
+  assert_equals "64" "$DECIMAL_SPEED" "64 without the prefix is 64%, not 100%"
+  assert_equals "0x40" "$HEXADECIMAL_SPEED" "and reaches ipmitool as 0x40"
+
+  convert_fan_speed_parameter "0x30"
+  assert_equals "48" "$DECIMAL_SPEED" "0x30 is 48%"
+
+  convert_fan_speed_parameter "30"
+  assert_equals "30" "$DECIMAL_SPEED" "30 without the prefix is 30%, not 48%"
+}
+
 function test_every_valid_fan_speed_percentage_survives_a_round_trip() {
   local PERCENTAGE
   for ((PERCENTAGE = 0; PERCENTAGE <= 100; PERCENTAGE++)); do


### PR DESCRIPTION
Closes #328.

The same defect #327 fixed for `CPU_TEMPERATURE_THRESHOLD`, one parameter over, plus one that belongs to `FAN_SPEED` alone. **No change to what is accepted** — the bounds, both notations and every refusal behave exactly as before.

## 1. The range and the unit, in the files users copy

All six placeholders read `<decimal or hexadecimal fan speed>` — naming neither bound, nor the `%` that makes `5` a duty cycle rather than a speed:

```
FAN_SPEED=<decimal or hexadecimal fan speed>
```
now:
```
FAN_SPEED=<fan speed in %, from 0 to 100, or hexadecimal from 0x00 to 0x64>
```

in `.env.example`, the four `Usage` examples and the manual-run `export` block. `.env.example` is the route the README itself recommends for credentials, so a bound stated only in a bullet three sections down is one the copying user never meets — the argument accepted in #326.

## 2. The typo, in the one sentence that did state it

> …a decimal (from 0 to 100%) or **hexadecimaladecimal** value (from 0x00 to 0x64)…

Long-standing, and sitting exactly where a reader goes to resolve the placeholder. The bullet is rewritten around it.

## 3. The `0x` prefix, which is this parameter's own trap

Both notations are accepted for the same setting and the prefix is the whole difference between them. A value that lost it is **not** refused — both readings are inside 0–100 — so the fans run at a duty cycle nobody chose:

| Value set | Duty cycle applied | Byte sent |
| --- | --- | --- |
| `0x64` | 100% | `0x64` |
| `64` | **64%** | `0x40` |
| `0x30` | 48% | `0x30` |
| `30` | **30%** | `0x1e` |

The README now states this pair and points at the startup line that resolves it (`Fan speed objective: 64%`), and the refusal for a malformed value says what the prefix is for:

```
  Parameter : FAN_SPEED
  Value     : "0x64%"
  Expected  : a percentage from 0 to 100, or the same value in hexadecimal from 0x00 to 0x64. The
"0x" prefix is what tells the two notations apart
```

## 4. The bound becomes comparable

`MINIMUM_FAN_SPEED_PERCENTAGE` / `MAXIMUM_FAN_SPEED_PERCENTAGE` move to `constants.sh`, following what `MAXIMUM_CHECK_INTERVAL_IN_SECONDS` already does — used by the comparison *and* quoted back in the refusal, so the message cannot disagree with the check. The hexadecimal form is derived from the decimal one rather than written beside it, two spellings of one bound being one more thing that can drift; the two conversions are hoisted into separate statements to keep the one-command-substitution-per-statement invariant that `test_no_statement_expands_two_command_substitutions` enforces.

Without this the documentation guard would only be a third place repeating `100`.

## Tests

`21_fan_speed_validation.sh` already covers the bounds (`0`, `100`, `101`, `0x64`, `0x65`, `0xff`), both notations, padded values, non-numeric refusals and the error block, so **no behavioural case was added** — there was nothing uncovered. The two added are the ones nothing held:

- `test_the_readme_documents_the_fan_speed_range()` — `README.md` and `.env.example` against the constants, in both notations, including the unit.
- `test_the_prefix_is_what_tells_the_two_notations_apart()` — the README's claim about `0x` against `convert_fan_speed_parameter()`, which had no direct test at all.

## Verification

- `./tests/run_tests.sh` — **363 passed** (1965 assertions), up from 361/1953.
- `shellcheck -x` on the five shipped scripts — clean.
- Both guards mutation-tested: reverting the `.env.example` placeholder, moving the constant to 90 while the README says 100, and breaking the prefix dispatch each turn the corresponding case red.

## Out of scope, noted in the issue

`CHECK_INTERVAL=<seconds between each check>` names its unit but not its bounds, though the container warns above 60 seconds and refuses above 15 minutes (#314). Same shape, same fix, left out of this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y4jdnzs3FoBoGdBmwThR7y)_