### PR TITLE
Settle "latest" after the push instead of guessing before it

### DIFF
--- a/.github/reconcile_latest_tag.sh
+++ b/.github/reconcile_latest_tag.sh
@@ -1,0 +1,188 @@
+#!/bin/bash
+
+# Points "latest" at the highest version actually published, in each registry it
+# is given, and leaves alone the ones where it already does.
+#
+# Why this exists next to the check that already gates "latest" at build time,
+# rather than replacing it :
+#
+# That check asks the registry "is a higher version already published ?", and it
+# asks about ninety seconds before the push. Releases tagged inside that window
+# - v1.73, v1.74 and v1.75 went out twenty-eight seconds apart - all get "no"
+# for an answer, because none of them has finished publishing when the others
+# ask. Each then pushes "latest", and which push lands last is settled per
+# registry inside a single buildx export : that is how "latest" came to be v1.75
+# on Docker Hub and v1.74 on GHCR at the same moment (issue #325).
+#
+# The point of running after the push is not that the window is narrower here.
+# It is that once the builds HAVE published, the question stops depending on
+# when it is asked : two concurrent releases reaching this script compute the
+# same answer and write the same thing. The race stops mattering rather than
+# being avoided more carefully.
+#
+# It reads before it writes and writes nothing when the two already agree, so
+# the ordinary release - published on its own, "latest" already correct - costs
+# two reads per registry and no write at all.
+#
+# Usage : .github/reconcile_latest_tag.sh <namespace/image> <registry> [registry ...]
+
+set -euo pipefail
+
+readonly LATEST_TAG="latest"
+# Stamped on every image by both publishing workflows, and already what "Base
+# image refresh" reads back to tell which version "latest" is on
+readonly VERSION_LABEL="org.opencontainers.image.version"
+
+if [ "$#" -lt 2 ]; then
+  printf 'Usage : %s <namespace/image> <registry> [registry ...]\n' "${0##*/}" >&2
+  exit 2
+fi
+
+IMAGE="$1"
+shift
+# Registry APIs reject the repository's own capitalisation, and the caller is
+# likely to be holding it the way GitHub spells it
+readonly IMAGE="${IMAGE,,}"
+declare -ra REGISTRIES=("$@")
+
+ERRORS_FILE="$(mktemp)"
+readonly ERRORS_FILE
+trap 'rm -f "$ERRORS_FILE"' EXIT
+
+# Three answers and not two, for the reason the build-time check gives : "the
+# registry did not answer" is not "there is nothing there". 0 published, 1
+# nothing under that tag, 2 no usable answer.
+# Note what is deliberately absent from the wordings below : "denied" and
+# "unauthorized". A token that cannot read the package must never look like an
+# empty registry, that is exactly how "latest" would walk backwards on a
+# permissions mistake.
+# Usage : tag_is_published "ghcr.io/owner/image:v1.75"
+function tag_is_published() {
+  if docker buildx imagetools inspect "$1" --format '{{json .Manifest}}' > /dev/null 2>"$ERRORS_FILE"; then
+    return 0
+  fi
+  if grep -qiE 'not found|manifest unknown|name unknown' "$ERRORS_FILE"; then
+    return 1
+  fi
+  cat "$ERRORS_FILE" >&2
+  return 2
+}
+
+# Which version a tag is on, read off the label rather than compared on digests.
+# An index re-created under a second name can be re-marshalled into different
+# bytes for the same content, so a digest comparison would find a difference
+# that is not one, rewrite "latest" over it, and do so again on every release
+# forever. The label moves with the image and answers the question that is
+# actually being asked.
+# Same three answers as above.
+# Usage : VERSION="$(version_of_tag "ghcr.io/owner/image:latest")"
+function version_of_tag() {
+  local CONFIG
+  if CONFIG="$(docker buildx imagetools inspect "$1" --format '{{json .Image}}' 2>"$ERRORS_FILE")"; then
+    # A multi-platform image answers with one config per platform, a
+    # single-platform one with the config itself. Both publishers stamp the
+    # same version on every platform, so the first one found is the answer
+    printf '%s' "$CONFIG" |
+      jq -r 'if has("config") then [.] else [.[]] end
+             | map(.config.Labels["'"$VERSION_LABEL"'"] // empty)
+             | first // ""'
+    return 0
+  fi
+  if grep -qiE 'not found|manifest unknown|name unknown' "$ERRORS_FILE"; then
+    return 1
+  fi
+  cat "$ERRORS_FILE" >&2
+  return 2
+}
+
+# Highest first, so the first tag found published in a registry is the highest
+# published one there and the walk stops. A tag existing in git says someone
+# typed "git tag" and nothing about an image having come out of it, which is
+# why each candidate is asked of the registry rather than trusted
+declare -a VERSION_TAGS=()
+while IFS= read -r VERSION_TAG; do
+  [ -n "$VERSION_TAG" ] || continue
+  VERSION_TAGS+=("$VERSION_TAG")
+done < <(git tag --list 'v[0-9]*.[0-9]*' --sort=-v:refname)
+
+if [ "${#VERSION_TAGS[@]}" -eq 0 ]; then
+  printf '::warning::No version tag exists, there is nothing to point "%s" at\n' "$LATEST_TAG"
+  exit 0
+fi
+
+EXIT_CODE=0
+
+for REGISTRY in "${REGISTRIES[@]}"; do
+  REFERENCE="$REGISTRY/$IMAGE"
+
+  HIGHEST_PUBLISHED=""
+  UNREADABLE=""
+  for VERSION_TAG in "${VERSION_TAGS[@]}"; do
+    STATUS=0
+    tag_is_published "$REFERENCE:$VERSION_TAG" || STATUS=$?
+    case "$STATUS" in
+      0) HIGHEST_PUBLISHED="$VERSION_TAG"; break ;;
+      1) ;; # tagged in git, never pushed here : it is not a candidate
+      *) UNREADABLE="$VERSION_TAG"; break ;;
+    esac
+  done
+
+  # An unreadable registry is not an answer, and this script is the last thing
+  # standing between a published release and the run's summary : it warns and
+  # moves on rather than redden a release that did go out. The next release
+  # asks again, and re-firing this tag retries it immediately
+  if [ -n "$UNREADABLE" ]; then
+    printf '::warning::Could not tell whether %s is published on %s, leaving its "%s" alone\n' \
+      "$UNREADABLE" "$REGISTRY" "$LATEST_TAG"
+    continue
+  fi
+
+  if [ -z "$HIGHEST_PUBLISHED" ]; then
+    printf '::warning::No version is published on %s, there is nothing to point "%s" at\n' \
+      "$REGISTRY" "$LATEST_TAG"
+    continue
+  fi
+
+  STATUS=0
+  CURRENT_VERSION="$(version_of_tag "$REFERENCE:$LATEST_TAG")" || STATUS=$?
+  if [ "$STATUS" -eq 2 ]; then
+    printf '::warning::Could not read "%s" on %s, leaving it alone\n' "$LATEST_TAG" "$REGISTRY"
+    continue
+  fi
+
+  if [ "$STATUS" -eq 0 ] && [ "$CURRENT_VERSION" = "$HIGHEST_PUBLISHED" ]; then
+    printf '%s : "%s" is already %s\n' "$REGISTRY" "$LATEST_TAG" "$HIGHEST_PUBLISHED"
+    continue
+  fi
+
+  # An image published before the version label existed reads as empty here, and
+  # is repointed once rather than left unexplained
+  printf '%s : "%s" is on %s, pointing it at %s\n' \
+    "$REGISTRY" "$LATEST_TAG" "${CURRENT_VERSION:-an image carrying no version}" "$HIGHEST_PUBLISHED"
+
+  # A manifest copy and not a rebuild : the bytes of the highest published
+  # version are what "latest" has to serve, and rebuilding them would produce a
+  # different image than the one that version tag resolves to
+  if ! docker buildx imagetools create --tag "$REFERENCE:$LATEST_TAG" "$REFERENCE:$HIGHEST_PUBLISHED"; then
+    # Knowing what to do and failing to do it is a real failure, unlike a
+    # registry that could not be read : this one goes red
+    printf '::error::Could not point "%s" at %s on %s\n' "$LATEST_TAG" "$HIGHEST_PUBLISHED" "$REGISTRY" >&2
+    EXIT_CODE=1
+    continue
+  fi
+
+  # Read back rather than trust the write. "latest" resolving to the wrong
+  # version is silent by nature - every pull succeeds, they just get the wrong
+  # image - so the one moment it can be caught cheaply is here
+  STATUS=0
+  CURRENT_VERSION="$(version_of_tag "$REFERENCE:$LATEST_TAG")" || STATUS=$?
+  if [ "$STATUS" -ne 0 ] || [ "$CURRENT_VERSION" != "$HIGHEST_PUBLISHED" ]; then
+    printf '::error::"%s" on %s did not settle on %s\n' "$LATEST_TAG" "$REGISTRY" "$HIGHEST_PUBLISHED" >&2
+    EXIT_CODE=1
+    continue
+  fi
+
+  printf '%s : "%s" is now %s\n' "$REGISTRY" "$LATEST_TAG" "$HIGHEST_PUBLISHED"
+done
+
+exit "$EXIT_CODE"

--- a/.github/reconcile_latest_tag.sh
+++ b/.github/reconcile_latest_tag.sh
@@ -145,13 +145,34 @@ for REGISTRY in "${REGISTRIES[@]}"; do
 
   STATUS=0
   CURRENT_VERSION="$(version_of_tag "$REFERENCE:$LATEST_TAG")" || STATUS=$?
-  if [ "$STATUS" -eq 2 ]; then
+  # Anything that is not "read it" or "it is not there" is the unreadable case :
+  # a read that failed in a way this script has no name for is the last thing
+  # that should be allowed to decide where "latest" points
+  if [ "$STATUS" -ge 2 ]; then
     printf '::warning::Could not read "%s" on %s, leaving it alone\n' "$LATEST_TAG" "$REGISTRY"
     continue
   fi
 
   if [ "$STATUS" -eq 0 ] && [ "$CURRENT_VERSION" = "$HIGHEST_PUBLISHED" ]; then
     printf '%s : "%s" is already %s\n' "$REGISTRY" "$LATEST_TAG" "$HIGHEST_PUBLISHED"
+    continue
+  fi
+
+  # "latest" already ahead of every version that resolves means a version tag
+  # was deleted from under us, or something was published by hand. Pointing it
+  # at the highest version still published would move "latest" BACKWARDS, and
+  # handing users an older image than the one they already have is the one thing
+  # no workflow here may ever do. "Base image refresh" refuses the same
+  # situation for the same reason.
+  #
+  # It warns where that workflow errors, and the difference is deliberate : that
+  # one is a maintenance run with nothing to withhold, this one stands behind a
+  # release whose image did go out. Someone still has to look - a state nothing
+  # here produced does not repair itself - but not at the cost of a red release
+  if [ -n "$CURRENT_VERSION" ] && [ "$CURRENT_VERSION" != "$HIGHEST_PUBLISHED" ] &&
+    [ "$(printf '%s\n%s\n' "$CURRENT_VERSION" "$HIGHEST_PUBLISHED" | sort -V | tail -n 1)" = "$CURRENT_VERSION" ]; then
+    printf '::warning::"%s" on %s is on %s, ahead of the highest version published there (%s). Refusing to move it backwards\n' \
+      "$LATEST_TAG" "$REGISTRY" "$CURRENT_VERSION" "$HIGHEST_PUBLISHED"
     continue
   fi
 

--- a/.github/workflows/build_and_publish_docker_image.yml
+++ b/.github/workflows/build_and_publish_docker_image.yml
@@ -362,3 +362,24 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true
+
+      # After the release note, so that a registry hiccup here cannot withhold
+      # the announcement of a version whose image did go out.
+      #
+      # "Is a higher version already published ?" is decided above, before a
+      # single layer moves, and two releases tagged less than a build apart both
+      # get "no" : neither has published when the other asks, so both claim
+      # "latest" and the last push wins, separately on each registry. That is
+      # how "latest" was v1.75 on Docker Hub and v1.74 on GHCR at the same
+      # moment. Asked again here, once the pushes are done, the question has an
+      # answer that no longer depends on when it is asked : concurrent releases
+      # reaching this step agree, and whichever writes last writes the same
+      # thing. See .github/reconcile_latest_tag.sh
+      - name: Point "latest" at the highest published version
+        run: |
+          set -euo pipefail
+          IMAGE="${{ steps.docker_image_name.outputs.value }}"
+          # Both registries, and in this order : Docker Hub is where the pull
+          # count is, so it is the one worth settling first if the run is about
+          # to be cut short
+          .github/reconcile_latest_tag.sh "${IMAGE,,}" docker.io ghcr.io

--- a/tests/README.md
+++ b/tests/README.md
@@ -23,6 +23,7 @@ It exits `0` when every test case passed, `1` otherwise.
 | `cases/10_shell_scripts.sh` | Syntax of every script, files shipped in the Docker image, drift between the code and what documents it, healthcheck |
 | `cases/12_github_workflows.sh` | The two publishing workflows no pull request ever runs : the release build and the base image refresh |
 | `cases/13_dockerhub_description.sh` | The page Docker Hub shows on the image's repository, rendered from `README.md` by a workflow no pull request fires either |
+| `cases/14_latest_tag_reconciliation.sh` | Which version `latest` ends up on after a release, against a stubbed registry. Skipped where `jq` is missing, the one thing the script needs that the suite does not |
 | `cases/15_test_runner.sh` | The runner itself : the ways it used to stay green while nothing had been verified |
 | `cases/17_reports.sh` | The JUnit XML and Markdown reports, whose consumer is a parser rather than a reader |
 | `cases/20_fan_speed_conversions.sh` | `FAN_SPEED` given as a percentage or as a hexadecimal byte |

--- a/tests/cases/14_latest_tag_reconciliation.sh
+++ b/tests/cases/14_latest_tag_reconciliation.sh
@@ -273,6 +273,37 @@ function test_an_unreadable_registry_is_left_alone_rather_than_treated_as_empty(
   teardown_reconciliation_sandbox
 }
 
+function test_a_latest_ahead_of_every_published_version_is_not_dragged_backwards() {
+  if ! latest_tag_reconciliation_can_run; then
+    skip_test "no .github next to the scripts, or no jq"
+    return 0
+  fi
+
+  # A version tag deleted from under us, or something pushed by hand : "latest"
+  # is on v1.76 and no v1.76 resolves any more. Pointing it at the highest
+  # version that still does would hand every user of "latest" an OLDER image
+  # than the one they already have, which is the single thing this script must
+  # never do. "Base image refresh" refuses the same situation
+  setup_reconciliation_sandbox "v1.74 v1.75" \
+    "docker.io/owner/image:v1.74	v1.74" \
+    "docker.io/owner/image:v1.75	v1.75" \
+    "docker.io/owner/image:latest	v1.76"
+
+  local OUTPUT EXIT_CODE=0
+  OUTPUT="$(run_reconciliation docker.io)" || EXIT_CODE=$?
+
+  assert_equals "v1.76" "$(published_version "docker.io/owner/image:latest")" \
+    "latest must not be moved back onto an older version than the one it serves"
+  assert_empty "$(cat "$REGISTRY_CREATE_LOG")" \
+    "nothing should be written when the only available move is backwards"
+  assert_contains "$OUTPUT" "::warning::" \
+    "a state nothing here produced has to be reported for someone to look at"
+  assert_equals "0" "$EXIT_CODE" \
+    "it must not redden a release whose image did go out"
+
+  teardown_reconciliation_sandbox
+}
+
 function test_a_write_that_did_not_take_is_reported_rather_than_assumed() {
   if ! latest_tag_reconciliation_can_run; then
     skip_test "no .github next to the scripts, or no jq"

--- a/tests/cases/14_latest_tag_reconciliation.sh
+++ b/tests/cases/14_latest_tag_reconciliation.sh
@@ -1,0 +1,329 @@
+#!/bin/bash
+
+# "latest" is the tag almost every user actually pulls, and the only one whose
+# value is a decision rather than a name. That decision is taken twice : once
+# before the build, by the check that gates it, and once after the push, by
+# .github/reconcile_latest_tag.sh. Neither runs on a pull request, and both are
+# read by nobody until "latest" is already wrong on somebody's server.
+#
+# The registry is stubbed here, so these exercise the decision and not Docker :
+# a fake "docker" first in the PATH answers for a registry whose contents the
+# test states, and records what was written back to it.
+
+readonly RECONCILIATION_SCRIPT=".github/reconcile_latest_tag.sh"
+readonly RECONCILIATION_WORKFLOW=".github/workflows/build_and_publish_docker_image.yml"
+readonly RECONCILIATION_IMAGE="owner/image"
+
+# The suite also runs inside the built image, which carries the shipped scripts
+# but not the .github directory. jq is what the script reads a label with : the
+# suite's own dependencies stop at bash, coreutils, grep and awk, so a machine
+# without it skips these rather than turning the promise in tests/README.md into
+# a lie. Every runner and the devcontainer have it
+# Usage : if ! latest_tag_reconciliation_can_run; then skip_test "..."; return 0; fi
+function latest_tag_reconciliation_can_run() {
+  [ -x "$REPO_ROOT/$RECONCILIATION_SCRIPT" ] && command -v jq > /dev/null 2>&1
+}
+
+# Builds the world the script runs in : a git repository holding the version
+# tags it walks, and a registry it can only see through a stubbed docker.
+#
+# The registry is a file of "reference<tab>version" lines. A reference absent
+# from it does not exist, and the version "!UNREADABLE" is a registry that
+# answers something that is neither, which the script must never read as empty.
+# Usage : setup_reconciliation_sandbox "v1.74 v1.75" \
+#           "docker.io/owner/image:v1.75	v1.75" "docker.io/owner/image:latest	v1.74"
+function setup_reconciliation_sandbox() {
+  local -r GIT_TAGS="$1"
+  shift
+
+  SANDBOX="$(mktemp -d)"
+  REGISTRY_STATE_FILE="$SANDBOX/registry"
+  REGISTRY_CREATE_LOG="$SANDBOX/created"
+  export MOCK_REGISTRY_STATE_FILE="$REGISTRY_STATE_FILE"
+  export MOCK_REGISTRY_CREATE_LOG="$REGISTRY_CREATE_LOG"
+
+  : > "$REGISTRY_STATE_FILE"
+  : > "$REGISTRY_CREATE_LOG"
+  local ENTRY
+  for ENTRY in "$@"; do
+    printf '%s\n' "$ENTRY" >> "$REGISTRY_STATE_FILE"
+  done
+
+  mkdir -p "$SANDBOX/bin"
+  cat > "$SANDBOX/bin/docker" << 'STUB'
+#!/bin/bash
+# Answers the two imagetools calls the script makes, off the state file, and
+# records the writes. Positional rather than parsed : the script calls this with
+# a fixed shape, and a stub that accepted more shapes than the real command
+# would hide a call that docker itself would refuse
+#   docker buildx imagetools inspect <reference> --format <template>
+#   docker buildx imagetools create --tag <target> <source>
+set -uo pipefail
+
+function version_of() {
+  awk -F'\t' -v reference="$1" '$1 == reference { print $2; found = 1; exit }
+                                END { if (!found) exit 1 }' "$MOCK_REGISTRY_STATE_FILE"
+}
+
+case "${3:-}" in
+  inspect)
+    REFERENCE="${4:-}"
+    if ! VERSION="$(version_of "$REFERENCE")"; then
+      printf '%s: not found\n' "$REFERENCE" >&2
+      exit 1
+    fi
+    if [ "$VERSION" = "!UNREADABLE" ]; then
+      printf 'unexpected status from HEAD request to %s: 429 Too Many Requests\n' "$REFERENCE" >&2
+      exit 1
+    fi
+    case "${6:-}" in
+      *.Manifest*) printf '{"digest":"sha256:%s"}\n' "${REFERENCE//[^a-z0-9]/}" ;;
+      *.Image*)
+        if [ "$VERSION" = "!UNLABELLED" ]; then
+          printf '{"config":{"Labels":{}}}\n'
+        else
+          printf '{"config":{"Labels":{"org.opencontainers.image.version":"%s"}}}\n' "$VERSION"
+        fi
+        ;;
+      *) printf 'unexpected format %s\n' "${6:-}" >&2; exit 64 ;;
+    esac
+    ;;
+  create)
+    TARGET="${5:-}"
+    SOURCE="${6:-}"
+    printf '%s <- %s\n' "$TARGET" "$SOURCE" >> "$MOCK_REGISTRY_CREATE_LOG"
+    # A manifest copy leaves the target carrying the source's labels, which is
+    # what the script reads back to confirm the write landed
+    if [ "${MOCK_REGISTRY_CREATE_IS_A_NOOP:-false}" = true ]; then
+      # A registry that takes the write, answers 200 and serves the old image
+      # anyway. Nothing in the exit code says so
+      exit 0
+    fi
+    VERSION="$(version_of "$SOURCE")" || VERSION=""
+    awk -F'\t' -v reference="$TARGET" '$1 != reference' "$MOCK_REGISTRY_STATE_FILE" > "$MOCK_REGISTRY_STATE_FILE.new"
+    mv "$MOCK_REGISTRY_STATE_FILE.new" "$MOCK_REGISTRY_STATE_FILE"
+    printf '%s\t%s\n' "$TARGET" "$VERSION" >> "$MOCK_REGISTRY_STATE_FILE"
+    ;;
+  *)
+    printf 'the stub was called in a shape the script is not supposed to use : %s\n' "$*" >&2
+    exit 64
+    ;;
+esac
+STUB
+  chmod 0755 "$SANDBOX/bin/docker"
+  export PATH="$SANDBOX/bin:$PATH"
+
+  mkdir -p "$SANDBOX/repository"
+  git -C "$SANDBOX/repository" init -q
+  git -C "$SANDBOX/repository" -c user.name=t -c user.email=t@t \
+    commit -q --allow-empty -m "tagged"
+  local TAG
+  for TAG in $GIT_TAGS; do
+    git -C "$SANDBOX/repository" tag "$TAG"
+  done
+}
+
+function teardown_reconciliation_sandbox() {
+  [ -n "${SANDBOX:-}" ] && rm -rf "$SANDBOX"
+}
+
+# Usage : OUTPUT="$(run_reconciliation docker.io ghcr.io)"
+function run_reconciliation() {
+  # From inside the repository, because the version tags the script walks are
+  # the ones git answers with where it runs
+  (cd "$SANDBOX/repository" && "$REPO_ROOT/$RECONCILIATION_SCRIPT" "$RECONCILIATION_IMAGE" "$@") 2>&1
+}
+
+# Usage : VERSION="$(published_version "docker.io/owner/image:latest")"
+function published_version() {
+  awk -F'\t' -v reference="$1" '$1 == reference { print $2; exit }' "$REGISTRY_STATE_FILE"
+}
+
+function test_latest_is_repointed_at_the_highest_published_version() {
+  if ! latest_tag_reconciliation_can_run; then
+    skip_test "no .github next to the scripts, or no jq"
+    return 0
+  fi
+
+  # The state issue #325 left behind : the same two version tags published
+  # everywhere, and a "latest" that disagrees from one registry to the other
+  setup_reconciliation_sandbox "v1.74 v1.75" \
+    "docker.io/owner/image:v1.74	v1.74" \
+    "docker.io/owner/image:v1.75	v1.75" \
+    "docker.io/owner/image:latest	v1.75" \
+    "ghcr.io/owner/image:v1.74	v1.74" \
+    "ghcr.io/owner/image:v1.75	v1.75" \
+    "ghcr.io/owner/image:latest	v1.74"
+
+  local OUTPUT
+  OUTPUT="$(run_reconciliation docker.io ghcr.io)"
+
+  assert_equals "v1.75" "$(published_version "ghcr.io/owner/image:latest")" \
+    "the registry left behind has to be brought onto the highest published version"
+  assert_equals "v1.75" "$(published_version "docker.io/owner/image:latest")" \
+    "the registry that was already right has to stay right"
+  assert_contains "$OUTPUT" "ghcr.io" "the registry it repointed should be named"
+
+  # Only the registry that was wrong is written to : a release published on its
+  # own must cost no write at all
+  assert_equals "ghcr.io/owner/image:latest <- ghcr.io/owner/image:v1.75" \
+    "$(cat "$REGISTRY_CREATE_LOG")" \
+    "only the registry that disagreed should have been written to"
+
+  teardown_reconciliation_sandbox
+}
+
+function test_a_latest_already_on_the_highest_version_is_left_untouched() {
+  if ! latest_tag_reconciliation_can_run; then
+    skip_test "no .github next to the scripts, or no jq"
+    return 0
+  fi
+
+  setup_reconciliation_sandbox "v1.74 v1.75" \
+    "docker.io/owner/image:v1.75	v1.75" \
+    "docker.io/owner/image:latest	v1.75"
+
+  run_reconciliation docker.io > /dev/null
+
+  assert_empty "$(cat "$REGISTRY_CREATE_LOG")" \
+    "nothing should be written when the registry already serves the highest published version"
+
+  teardown_reconciliation_sandbox
+}
+
+function test_reconciling_twice_writes_once() {
+  if ! latest_tag_reconciliation_can_run; then
+    skip_test "no .github next to the scripts, or no jq"
+    return 0
+  fi
+
+  # The property the whole approach rests on. Two releases publishing seconds
+  # apart both reach this script, and the second one must not undo the first
+  # nor write again : once the images are published the answer no longer
+  # depends on who asks, or when
+  setup_reconciliation_sandbox "v1.74 v1.75" \
+    "docker.io/owner/image:v1.74	v1.74" \
+    "docker.io/owner/image:v1.75	v1.75" \
+    "docker.io/owner/image:latest	v1.74"
+
+  run_reconciliation docker.io > /dev/null
+  run_reconciliation docker.io > /dev/null
+
+  assert_equals "1" "$(grep -c . "$REGISTRY_CREATE_LOG")" \
+    "the second run should find nothing left to do"
+  assert_equals "v1.75" "$(published_version "docker.io/owner/image:latest")" \
+    "the second run should not move latest off the highest published version"
+
+  teardown_reconciliation_sandbox
+}
+
+function test_a_version_tagged_in_git_but_never_published_does_not_hold_latest_back() {
+  if ! latest_tag_reconciliation_can_run; then
+    skip_test "no .github next to the scripts, or no jq"
+    return 0
+  fi
+
+  # v1.76 is exactly what v1.60 and v1.61 are : a tag whose build never pushed
+  # anything. Treating it as the highest version is what froze "latest" on the
+  # v1.46 image for two days, and this script must not reintroduce it
+  setup_reconciliation_sandbox "v1.74 v1.75 v1.76" \
+    "docker.io/owner/image:v1.75	v1.75" \
+    "docker.io/owner/image:latest	v1.74"
+
+  run_reconciliation docker.io > /dev/null
+
+  assert_equals "v1.75" "$(published_version "docker.io/owner/image:latest")" \
+    "a tag that published nothing outranks nothing"
+
+  teardown_reconciliation_sandbox
+}
+
+function test_an_unreadable_registry_is_left_alone_rather_than_treated_as_empty() {
+  if ! latest_tag_reconciliation_can_run; then
+    skip_test "no .github next to the scripts, or no jq"
+    return 0
+  fi
+
+  # A rate limit, an expired token, an outage : none of them is an answer to
+  # "which version is published ?". Reading one as "nothing is published" is
+  # how "latest" would walk backwards, so the registry is skipped, loudly.
+  #
+  # The state is arranged so that reading it wrong does damage rather than
+  # nothing : "latest" is already right, and the version that cannot be read is
+  # the one holding it there. Skip v1.75 and v1.74 becomes the highest thing
+  # visible, which would drag "latest" back a release. A test where the
+  # mistaken answer happens to be harmless proves nothing about the guard
+  setup_reconciliation_sandbox "v1.74 v1.75" \
+    "docker.io/owner/image:v1.74	v1.74" \
+    "docker.io/owner/image:v1.75	!UNREADABLE" \
+    "docker.io/owner/image:latest	v1.75"
+
+  local OUTPUT EXIT_CODE=0
+  OUTPUT="$(run_reconciliation docker.io)" || EXIT_CODE=$?
+
+  assert_equals "v1.75" "$(published_version "docker.io/owner/image:latest")" \
+    "an unreadable registry must not have its latest moved, least of all backwards"
+  assert_empty "$(cat "$REGISTRY_CREATE_LOG")" \
+    "an unreadable registry must not be written to"
+  assert_contains "$OUTPUT" "::warning::" \
+    "skipping a registry has to be said out loud"
+  assert_equals "0" "$EXIT_CODE" \
+    "a registry that could not be read must not redden a release that did go out"
+
+  teardown_reconciliation_sandbox
+}
+
+function test_a_write_that_did_not_take_is_reported_rather_than_assumed() {
+  if ! latest_tag_reconciliation_can_run; then
+    skip_test "no .github next to the scripts, or no jq"
+    return 0
+  fi
+
+  # "latest" pointing at the wrong version is silent : every pull succeeds, they
+  # just get an older image. Nothing downstream notices, and the run that caused
+  # it is green. Reading the tag back is the one cheap moment it can be caught,
+  # so a registry that accepts the write and serves the old image anyway has to
+  # come out red here
+  setup_reconciliation_sandbox "v1.74 v1.75" \
+    "docker.io/owner/image:v1.74	v1.74" \
+    "docker.io/owner/image:v1.75	v1.75" \
+    "docker.io/owner/image:latest	v1.74"
+  export MOCK_REGISTRY_CREATE_IS_A_NOOP=true
+
+  local OUTPUT EXIT_CODE=0
+  OUTPUT="$(run_reconciliation docker.io)" || EXIT_CODE=$?
+
+  assert_not_equals "0" "$EXIT_CODE" \
+    "a latest that did not move has to fail the run"
+  assert_contains "$OUTPUT" "::error::" \
+    "and it has to say so where the run summary shows it"
+
+  unset MOCK_REGISTRY_CREATE_IS_A_NOOP
+  teardown_reconciliation_sandbox
+}
+
+function test_the_workflow_reconciles_latest_through_the_script_that_exists() {
+  # The workflow and the script only meet at a path written in both, and the
+  # step that joins them runs on a version tag, where no pull request looks
+  if [ ! -f "$REPO_ROOT/$RECONCILIATION_WORKFLOW" ]; then
+    skip_test "no .github/workflows next to the scripts"
+    return 0
+  fi
+
+  local -r WORKFLOW_CONTENT="$(cat "$REPO_ROOT/$RECONCILIATION_WORKFLOW")"
+
+  assert_contains "$WORKFLOW_CONTENT" "$RECONCILIATION_SCRIPT" \
+    "the release workflow has to reconcile latest through $RECONCILIATION_SCRIPT"
+
+  local REGISTRY
+  for REGISTRY in docker.io ghcr.io; do
+    assert_contains "$WORKFLOW_CONTENT" "$REGISTRY" \
+      "$REGISTRY receives the image, so its latest has to be reconciled too"
+  done
+
+  if [ -x "$REPO_ROOT/$RECONCILIATION_SCRIPT" ]; then
+    pass
+  else
+    fail "$RECONCILIATION_SCRIPT is run as a command by the workflow, it has to be executable"
+  fi
+}


### PR DESCRIPTION
Closes #325.

## The problem

`Is a higher version already published ?` is decided before a single layer moves, and the answer stops being true about ninety seconds later.

`v1.73`, `v1.74` and `v1.75` went out twenty-eight seconds apart. None of them had published when the others asked, so all three got "no", all three claimed `latest`, and which push landed last was settled separately inside each registry's half of one buildx export. `latest` resolved to **v1.75 on Docker Hub and v1.74 on GHCR at the same moment**, with three green runs behind it.

## What this does *not* do

It does not trade the registry check back for the comparison against git tags it replaced. That one left `latest` on the v1.46 image for two days: five perfectly published versions all declined it over a `v1.69` that existed in git and had pushed nothing. Git never changes its mind — the registry does. The check stays exactly as it is.

## What it does

The question is asked a second time, **after** the pushes, by `.github/reconcile_latest_tag.sh`. Not because the window is narrower there — it is, a little — but because it has *closed*: once the images are published the answer no longer depends on who asks or when, so two concurrent releases reaching this step compute the same version and write the same thing. **The race stops mattering rather than being avoided more carefully.**

The script walks the version tags highest first, asks each registry which of them it actually serves, and points `latest` at the highest through a manifest copy rather than a rebuild — so `latest` and that version tag resolve to the same bytes.

Choices worth reviewing:

- **The version is read off `org.opencontainers.image.version`, not compared on digests.** An index re-created under a second name can be re-marshalled into different bytes for the same content; comparing those would rewrite `latest` on every release forever without ever settling. The label is already what `Base image refresh` reads for the same purpose.
- **An unreadable registry is skipped with a warning, a failed write is not.** Reading a rate limit as "nothing is published" is exactly how `latest` walks backwards, and a registry hiccup must not redden a release whose image did go out. A write that did not take *does* fail the run — `latest` on the wrong version is silent by nature: every pull succeeds and simply returns an older image.
- **`latest` is never moved backwards.** Found while re-reading rather than by a run: a `latest` already ahead of every version that resolves — a deleted tag, something pushed by hand — was being pointed back at the highest version still published, handing every user an older image than the one they already have. It now refuses, and warns where `Base image refresh` errors on the same state: that one is a maintenance run with nothing to withhold, this one stands behind a release whose image did go out.

It reads before it writes and writes nothing when the two already agree, so an ordinary release costs two reads per registry and no write at all.

## Tests

`tests/cases/14_latest_tag_reconciliation.sh` — eight cases against a stubbed registry (a fake `docker` first in the `PATH`, scoped to the test, plus a throwaway git repository holding the version tags): the repointing, the no-op, idempotence across two runs, a tag that published nothing not outranking one that did, an unreadable registry, a `latest` ahead of everything published, a write that silently did not take, and the workflow-to-script wiring.

Every guard was checked by **removing it and watching a case go red**, rather than assumed to be covered:

| Guard removed | Caught by |
| --- | --- |
| the write itself | 3 cases |
| unreadable registry treated as empty | `an unreadable registry is left alone rather than treated as empty` |
| read-back after writing | `a write that did not take is reported rather than assumed` |
| refusal to move `latest` backwards | `a latest ahead of every published version is not dragged backwards` |

The first version of the unreadable-registry case did **not** catch its mutation — the mistaken answer happened to be harmless there. Its fixture is now arranged so that getting it wrong drags `latest` back a release.

Cases skip where `jq` is missing, the one dependency the script has and the suite does not; `tests/README.md` says so. Full suite: **372 cases, 1997 assertions, green.** Script and test file are `shellcheck -x` clean.

## Not included

Option A from #325 — re-checking between the version push and a separate `latest` push — is not here. It shrinks the window; this makes the window irrelevant. They compose, but if only one gets written this is the one.