### PR TITLE
Tell an account that may not run the command from a server that lacks it

### DIFF
--- a/Dell_iDRAC_fan_controller.sh
+++ b/Dell_iDRAC_fan_controller.sh
@@ -530,6 +530,18 @@ while true; do
       # this container runs, so stop sending it
       IS_THIRD_PARTY_PCIE_CARD_COOLING_RESPONSE_SUPPORTED=false
       THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE_STATUS="Not supported by this server"
+    elif does_the_command_need_a_higher_privilege_level "$THIRD_PARTY_PCIE_CARD_COOLING_RESPONSE_STDERR"; then
+      # The BMC answered too, and answered that this account may not run the command. Also permanent for
+      # this run -- the credentials do not change while the container does -- so it stops being sent for
+      # the same reason as above, and the column says so rather than repeating "could not be applied on
+      # this cycle" for the life of the container on a condition no cycle will ever clear.
+      #
+      # What it must NOT say is "not supported by this server" : the server has the command, this account
+      # may not use it, and naming the hardware sends the reader to check a server that is fine instead
+      # of the iDRAC user they can actually fix. Reported on an R550 in #29, where every raw command --
+      # the fan control ones included -- answered "Insufficient privilege level"
+      IS_THIRD_PARTY_PCIE_CARD_COOLING_RESPONSE_SUPPORTED=false
+      THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE_STATUS="Refused: this account lacks the privilege level"
     else
       # The command did not go through, but nothing says the server refused it : an unreachable iDRAC, a
       # busy BMC, an answer this controller does not recognize. Report the cycle and try again on the next

--- a/functions.sh
+++ b/functions.sh
@@ -1324,6 +1324,24 @@ function does_the_server_lack_this_command() {
   [[ "$IPMITOOL_STDERR" == *"rsp=0xc1"* || "$IPMITOOL_STDERR" == *"rsp=0xd5"* ]]
 }
 
+# Whether the given ipmitool stderr says the BMC itself answered and refused the command for want of
+# privilege, rather than not having it at all.
+# Usage : does_the_command_need_a_higher_privilege_level "$THIRD_PARTY_PCIE_CARD_COOLING_RESPONSE_STDERR"
+#
+# 0xd4 is "insufficient privilege level" : the command is there and this account may not run it. It is
+# deliberately kept out of does_the_server_lack_this_command() above, because concluding "not supported
+# by this server" from it would send a user to look at their hardware for something that lives in their
+# iDRAC account -- the same shape of wrong diagnosis #195 set out to remove, on a different input.
+#
+# It is a verdict all the same, and a permanent one for this run : the credentials this container was
+# given do not change while it runs, so neither will the answer. Concluded once and never retried,
+# where a 0xc0 node busy or an unreachable host keep being sent the command on every cycle
+function does_the_command_need_a_higher_privilege_level() {
+  local -r IPMITOOL_STDERR="$1"
+
+  [[ "$IPMITOOL_STDERR" == *"rsp=0xd4"* ]]
+}
+
 # Prepare traps in case of container exit
 function graceful_exit() {
   if "$MONITORING_ONLY_MODE"; then

--- a/tests/cases/60_cpu_topologies.sh
+++ b/tests/cases/60_cpu_topologies.sh
@@ -647,7 +647,8 @@ function test_no_fan_control_profile_can_outgrow_the_column_reserved_for_it() {
 
   local COOLING_RESPONSE_STATUS
   for COOLING_RESPONSE_STATUS in "Enabled" "Disabled" "Not supported by this server" \
-    "Could not be applied on this cycle" "Enabled (not applied: monitoring only mode)" \
+    "Could not be applied on this cycle" "Refused: this account lacks the privilege level" \
+    "Enabled (not applied: monitoring only mode)" \
     "Disabled (not applied: monitoring only mode)"; do
     assert_equals "true" "$([ "${#COOLING_RESPONSE_STATUS}" -le "$COOLING_RESPONSE_COLUMN_WIDTH" ] && echo true || echo false)" \
       "\"$COOLING_RESPONSE_STATUS\" (${#COOLING_RESPONSE_STATUS}) must fit in $COOLING_RESPONSE_COLUMN_WIDTH"

--- a/tests/cases/70_fan_control_profiles.sh
+++ b/tests/cases/70_fan_control_profiles.sh
@@ -17,6 +17,10 @@ readonly THIRD_PARTY_PCIE_CARD_COMMAND="raw 0x30 0xce 0x00 0x16 0x05"
 # What an iDRAC 9 running firmware >= 3.30.30.30 answers to a fan control command
 readonly REJECTED_BY_FIRMWARE_STDERR="Unable to send RAW command (channel=0x0 netfn=0x30 lun=0x0 cmd=0x30 rsp=0xd5): Command not supported in present state"
 
+# What a BMC answers when the command exists but the account may not run it. Reported on an R550 in
+# issue #29, where every raw command answered "Insufficient privilege level"
+readonly REFUSED_FOR_PRIVILEGE_STDERR="Unable to send RAW command (channel=0x0 netfn=0x30 lun=0x0 cmd=0xce rsp=0xd4): Insufficient privilege level"
+
 function test_the_user_fan_control_profile_enables_manual_control_then_sets_the_speed() {
   DECIMAL_FAN_SPEED=30
   HEXADECIMAL_FAN_SPEED="0x1e"
@@ -158,6 +162,31 @@ function test_an_unsupported_third_party_pcie_card_command_stays_silent() {
 
   capture_output disable_third_party_PCIe_card_Dell_default_cooling_response
   assert_empty "$CAPTURED_OUTPUT" "an unsupported disable command must not flood the logs"
+}
+
+function test_a_privilege_refusal_is_told_apart_from_a_command_the_server_does_not_have() {
+  # Two answers that both come from the BMC and both stop the command being sent, but that mean
+  # opposite things to whoever reads the table. 0xc1 and 0xd5 say the server has no such command ;
+  # 0xd4 says it has it and this account may not run it. Reporting the second as the first sends a
+  # user to check hardware that is fine instead of the iDRAC account they can actually change
+  local -r LACKS_IT="Unable to send RAW command (channel=0x0 netfn=0x30 lun=0x0 cmd=0xce rsp=0xc1): Invalid command"
+
+  assert_command_succeeds "0xc1 is the server saying it does not have the command" \
+    does_the_server_lack_this_command "$LACKS_IT"
+  assert_command_fails "0xc1 is not a privilege problem" \
+    does_the_command_need_a_higher_privilege_level "$LACKS_IT"
+
+  assert_command_succeeds "0xd4 is the account lacking the privilege level" \
+    does_the_command_need_a_higher_privilege_level "$REFUSED_FOR_PRIVILEGE_STDERR"
+  assert_command_fails "0xd4 must never be read as the server lacking the command" \
+    does_the_server_lack_this_command "$REFUSED_FOR_PRIVILEGE_STDERR"
+
+  # And neither of them is a verdict, so that the command keeps being retried
+  local -r NEVER_REACHED="Error: Unable to establish IPMI v2 / RMCP+ session"
+  assert_command_fails "a BMC that was never reached said nothing about the command" \
+    does_the_server_lack_this_command "$NEVER_REACHED"
+  assert_command_fails "nor about the privilege level" \
+    does_the_command_need_a_higher_privilege_level "$NEVER_REACHED"
 }
 
 function test_monitoring_only_mode_never_changes_the_third_party_pcie_card_cooling_response() {

--- a/tests/cases/90_integration.sh
+++ b/tests/cases/90_integration.sh
@@ -254,6 +254,34 @@ function test_the_controller_stops_sending_a_command_the_server_refused() {
     "an answered refusal settles it, so the command is never sent again"
 }
 
+function test_a_cooling_response_refused_for_want_of_privilege_names_the_account_and_stops() {
+  # An iDRAC account without the privilege level answers 0xd4 to this command, on every cycle, for
+  # ever : the credentials do not change while the container runs. Before this was told apart, it fell
+  # into the "could not be applied on this cycle" branch and was re-sent for the life of the container,
+  # so the column repeated a transient-sounding message about a condition no cycle would ever clear.
+  #
+  # What matters just as much is what it must NOT say. The server has the command -- this is not a Gen
+  # 14+ machine that dropped it -- so reporting "not supported by this server" would send the reader to
+  # check hardware that is perfectly fine instead of the iDRAC user they can actually fix
+  export DISABLE_THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE=true
+  simulate_server "PowerEdge R730xd" --cpus 2
+  export MOCK_IPMITOOL_RAW_FAIL_PATTERN="0x30 0xce"
+  export MOCK_IPMITOOL_RAW_FAIL_STDERR="Unable to send RAW command (channel=0x0 netfn=0x30 lun=0x0 cmd=0xce rsp=0xd4): Insufficient privilege level"
+
+  local -r OUTPUT=$(run_controller "" 5)
+
+  assert_matches "$OUTPUT" "fan control profile.*Refused: this account lacks the privilege level" \
+    "the column has to name the account, which is the thing the user can change"
+  assert_not_contains "$OUTPUT" "Not supported by this server" \
+    "the server has the command : saying otherwise points at hardware that is fine"
+  assert_not_contains "$OUTPUT" "Could not be applied on this cycle" \
+    "nothing about this clears on a later cycle, so it must not be reported as if it might"
+  # The one asked on the first cycle, plus the one graceful_exit sends on the way out, exactly as an
+  # answered "I do not have this command" behaves
+  assert_equals "2" "$(count_ipmitool_calls_matching "raw 0x30 0xce")" \
+    "an answered refusal settles it, so the command is never sent again"
+}
+
 function test_a_transient_ipmi_failure_does_not_disable_the_cooling_response_for_good() {
   # ipmitool exits non-zero both for a command the BMC does not implement and for
   # a BMC it could not reach. Only the completion code it prints tells the two


### PR DESCRIPTION
Closes #339. Came out of closing #263, whose table predicted this row and which turned out to have a reported instance older than itself.

## What changed

`ipmitool` answers `rsp=0xd4` when the BMC **has** the command and the account may not run it. `does_the_server_lack_this_command()` matches `0xc1` and `0xd5` only, so that answer fell into the branch written for an unreachable iDRAC or a busy BMC:

- the column repeated **"Could not be applied on this cycle"** for the life of the container — wording meant for something transient, on a condition no cycle can clear, since the credentials do not change while the container runs;
- and the command was re-sent every `CHECK_INTERVAL`, one wasted IPMI call per cycle against a BMC that is not fast.

Reported on a **PowerEdge R550** in [#29](https://github.com/tigerblue77/Dell_iDRAC_fan_controller_Docker/issues/29#issuecomment-1355286396), where every raw command — the fan control ones included — answered `Insufficient privilege level`, [from the server's own OS too](https://github.com/tigerblue77/Dell_iDRAC_fan_controller_Docker/issues/29#issuecomment-1356461418).

## Why a second predicate rather than a wider list

Adding `0xd4` to the existing one would have reported **"Not supported by this server"** on a server that supports the command perfectly well, sending the reader to check hardware that is fine instead of the iDRAC user they can actually change. That is the shape of wrong diagnosis #195 removed and #263 exists to guard against.

So the two answers stay apart, and both stop the command being sent because both are verdicts rather than a cycle that went badly:

| Answer | Branch | Column |
|---|---|---|
| `rsp=0xc1`, `rsp=0xd5` | `does_the_server_lack_this_command` | `Not supported by this server` |
| `rsp=0xd4` | `does_the_command_need_a_higher_privilege_level` *(new)* | `Refused: this account lacks the privilege level` |
| no completion code | neither | `Could not be applied on this cycle`, retried |

The new status is **47 characters** against the 51 the column reserves, and the guard in `60_cpu_topologies.sh` now holds it there alongside the existing ones rather than leaving the next reader to check by hand.

## Tests

Two cases, chosen so that each fails for a different reason if the fix regresses:

- **`70_fan_control_profiles.sh`** — the two predicates against the same three inputs, asserting the *distinction* rather than either half of it: `0xc1` is a missing command and not a privilege problem, `0xd4` is a privilege problem and **must never** read as a missing command, and a BMC that was never reached is neither, so it keeps being retried. This is the case that would catch someone "simplifying" the two predicates back into one.
- **`90_integration.sh`** — the whole controller against a BMC answering `0xd4`, over five cycles: the column names the account, never says `Not supported by this server`, never says `Could not be applied on this cycle`, and the command is sent exactly twice — once on the first cycle, once by `graceful_exit` on the way out, which is how an answered "I do not have this command" already behaves.

## Verification

- **`./tests/run_tests.sh` — 381 cases, 2026 assertions, passing.**
- **Mutation-tested.** With `functions.sh` and `Dell_iDRAC_fan_controller.sh` reverted to `master` and these tests kept, **both new cases turn red** and nothing else moves (379 passed / 2026 assertions). `master` on its own is 379 / 2015, so the two cases and their eleven assertions are the whole of the difference.
- **`shellcheck -x`** on the five shipped scripts, run exactly as `shellcheck.yml` does — clean.
- No change to any workflow, to the `Dockerfile`, or to what is published.

## What this does not claim

Nobody has pasted the literal `rsp=0xd4` string. @Qlii256 quoted the human-readable `Insufficient privilege level`, and the mapping to `0xd4` comes from the IPMI specification, where `0xD4` is defined as "Insufficient privilege level". The match is specification-derived rather than observed, and #339 says so as well. If a real capture ever shows a different spelling, the predicate is one line to widen — and the failure mode meanwhile is the behaviour that exists today, not a worse one.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DhruzPPRcWf5sp8VsPSve3

---
_Generated by [Claude Code](https://claude.ai/code/session_01DhruzPPRcWf5sp8VsPSve3)_