### PR TITLE
Write the refusal block in one go, so no signal can cut it in half

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -1733,23 +1733,37 @@ function print_configuration_error_and_exit() {
 section of your docker-compose.yml, then start the container again.}"
   local -r RESTARTING_WOULD_MEET_THE_SAME_REFUSAL="${5:-true}"
 
-  printf "\n/!\\ Error /!\\ Invalid configuration, the container will not start.\n\n" >&2
-  printf "  Parameter : %s\n" "$PARAMETER_NAME" >&2
-  printf "  Value     : \"%s\"\n" "$VALUE" >&2
-  printf "  Expected  : %s\n\n" "$EXPECTED" >&2
+  # Assembled whole, then written once. The block is a unit -- half of it is worse than none, the
+  # parameter being named without what is accepted, or what is accepted without where to fix it -- and
+  # printing it piecemeal made it interruptible : a SIGTERM landing between two of the printfs cut it
+  # off mid-block, and the tail went through a pipeline, i.e. a subshell, which is exactly where a
+  # signal is most likely to land. The test suite reproduced it by design, awaiting the first line and
+  # stopping the controller as soon as it appeared. Docker sends the same signal to the same process
+  local BLOCK PIECE
+  printf -v BLOCK "\n/!\\ Error /!\\ Invalid configuration, the container will not start.\n\n"
+  printf -v PIECE "  Parameter : %s\n" "$PARAMETER_NAME"
+  BLOCK+="$PIECE"
+  printf -v PIECE "  Value     : \"%s\"\n" "$VALUE"
+  BLOCK+="$PIECE"
+  printf -v PIECE "  Expected  : %s\n\n" "$EXPECTED"
+  BLOCK+="$PIECE"
   # No exit status could carry this instead : "always" and "unless-stopped" restart on the policy
   # rather than on the code, and those are the two the README's own examples recommend. Saying it is
   # therefore the only thing that can spare the user the wait
   if [ "$RESTARTING_WOULD_MEET_THE_SAME_REFUSAL" == "true" ]; then
-    printf "  Restarting will not help : this is read the same way on every start, so a container under\n" >&2
-    printf "  an \"always\", \"unless-stopped\" or \"on-failure\" restart policy stops here again on every\n" >&2
-    printf "  attempt, until the configuration itself is corrected.\n\n" >&2
+    printf -v PIECE "  Restarting will not help : this is read the same way on every start, so a container under\n  an \"always\", \"unless-stopped\" or \"on-failure\" restart policy stops here again on every\n  attempt, until the configuration itself is corrected.\n\n"
+    BLOCK+="$PIECE"
   fi
-  # Indented line by line so a closing sentence written across several lines keeps the block's margin
-  printf "%s\n" "$WHERE_TO_FIX_IT" | while IFS= read -r LINE; do
-    printf "  %s\n" "$LINE" >&2
-  done
-  printf "\n" >&2
+
+  # Indented line by line so a closing sentence written across several lines keeps the block's margin.
+  # Fed by a here-string rather than a pipe, a pipeline being the subshell this used to lose
+  local LINE
+  while IFS= read -r LINE; do
+    printf -v PIECE "  %s\n" "$LINE"
+    BLOCK+="$PIECE"
+  done <<< "$WHERE_TO_FIX_IT"
+
+  printf "%s\n" "$BLOCK" >&2
 
   exit 1
 }

--- a/tests/cases/27_configuration_error_format.sh
+++ b/tests/cases/27_configuration_error_format.sh
@@ -163,6 +163,31 @@ function test_the_missing_device_error_points_at_device_rather_than_at_e() {
     "the environment variable wording would send the user to the wrong place here"
 }
 
+function test_the_refusal_block_is_written_in_a_single_write() {
+  # What the block is for is being readable in a "docker logs" scroll, and half of
+  # it is worse than none : the parameter named without what is accepted, or what
+  # is accepted without where to fix it. Printed piecemeal it was interruptible,
+  # and a container refusing to start is precisely a container something is about
+  # to signal -- Docker on the way down, the test harness as soon as the first
+  # line appears. That is how it broke : the block stopped after "Expected" and the
+  # closing sentence, which went through a pipeline and therefore a subshell, was
+  # lost with it.
+  #
+  # Asserted structurally rather than by racing a signal, which would only fail
+  # some of the time : one redirection to stderr is one write, and one write cannot
+  # be cut in half
+  local -r BODY=$(sed -n '/^function print_configuration_error_and_exit()/,/^}/p' "$REPO_ROOT/functions.sh")
+
+  assert_not_empty "$BODY" "print_configuration_error_and_exit should be defined in functions.sh" || return 1
+
+  local -r WRITES=$(printf '%s\n' "$BODY" | grep -c '>&2' || true)
+  assert_equals 1 "$WRITES" \
+    "the block should reach stderr in one write, so no signal can cut it in half"
+
+  assert_not_contains "$BODY" "| while" \
+    "and not through a pipeline, a subshell being where a signal lands most easily"
+}
+
 function test_no_configuration_refusal_is_left_reporting_as_a_single_line() {
   # The point of the block is that it is the only form a refused parameter takes.
   # A refusal added later and wired to print_error_and_exit out of habit is exactly


### PR DESCRIPTION
Fixes master, red since `e1f166d` on the **Docker image** test job only. The rendered output is byte-for-byte unchanged.

## What actually happened

`test_a_failed_ipmi_connection_reports_as_a_configuration_error` failed on `docker-compose.yml` being absent from the output. The captured text says why:

```
  Parameter : IDRAC_HOST / IDRAC_USERNAME / IDRAC_PASSWORD
  Value     : "192.168.1.100"
  Expected  : credentials that can open an IPMI session. ipmitool exited with code 1 and said: [...]

/!\ Warning /!\ Container stopped (monitoring only mode, [...]). Exiting.
```

The block stops after `Expected` and continues with `graceful_exit`'s message. It was not printed short — **the process was signalled half way through printing it.**

## Why it is not a test artefact

`print_configuration_error_and_exit()` emitted its block as five separate writes, the last one through a **pipeline**:

```bash
printf "%s\n" "$WHERE_TO_FIX_IT" | while IFS= read -r LINE; do
  printf "  %s\n" "$LINE" >&2
done
```

A pipeline is a subshell, which is the likeliest place for a signal to land — the same reasoning `test_no_statement_expands_two_command_substitutions` already encodes for command substitutions and issue #188.

And a container refusing to start is *precisely* a container something is about to signal: Docker on the way down, and the harness as soon as the first line matches its awaited pattern. The window was always there; the in-image job, which runs right after building the image, is simply loaded enough to hit it.

The half it eats is the half that matters: the parameter named without what is accepted, or what is accepted without where to fix it.

## The fix

The block is assembled into one string and written once:

```bash
printf "%s\n" "$BLOCK" >&2
```

and the closing sentence is fed by a here-string rather than a pipe, so nothing in the path is a subshell any more. Rendering diffed against `master` before and after — **strictly identical**, for both the with-notice and without-notice shapes.

## Guard

`test_the_refusal_block_is_written_in_a_single_write()` asserts it structurally rather than by racing a signal, which would only fail some of the time: **one redirection to stderr is one write, and one write cannot be cut in half.** It also refuses `| while` in that function.

## Verification

- `./tests/run_tests.sh` — **381 passed** (2023 assertions), up from 380/2020.
- `shellcheck -x` on the five shipped scripts — clean.
- The previously failing case run **30 times in a row: 0 failures**.
- Mutation-tested: adding a second `>&2` to the function turns the guard red.

## Note on how this reached master

The in-image job was still `in_progress` when #338 was merged — I reported the other checks green and did not wait for that one. On a failure this specific to a loaded runner, that was the wrong moment to call it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y4jdnzs3FoBoGdBmwThR7y)_