### PR TITLE
Add the GitHub Sponsors link (#302)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,15 @@
+# These are supported funding model platforms
+
+github: tigerblue77 # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
+#patreon: # Replace with a single Patreon username
+#open_collective: # Replace with a single Open Collective username
+#ko_fi: # Replace with a single Ko-fi username
+#tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+#community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
+#liberapay: # Replace with a single Liberapay username
+#issuehunt: # Replace with a single IssueHunt username
+#lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
+#polar: # Replace with a single Polar username
+#buy_me_a_coffee: # Replace with a single Buy Me a Coffee username
+#thanks_dev: # Replace with a single thanks.dev username
+#custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']


### PR DESCRIPTION
Closes #302.

The branch has existed since 2026-08-09 and no pull request was ever opened for it, so the commit has been sitting unmerged. Nothing in it is mine — this only gives it a pull request.

Adds `.github/FUNDING.yml`, GitHub's own template with a single line uncommented:

```yaml
github: tigerblue77
```

That is what puts the **Sponsor** button on the repository page and on each release. Every other platform stays commented out, as the template ships it.

One file, 15 lines, nothing else touched. Applies cleanly to `master`.

## Possibly worth deciding

- The commented-out platform list is GitHub's boilerplate. Plenty of repositories keep it as documentation of what else is available; it can be trimmed to the one active line if you would rather.
- This adds the button, not a mention in the README. Say so if you want a line there too.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y4jdnzs3FoBoGdBmwThR7y)_