### PR TITLE
Write a release note once instead of appending to the one already there (#337)

### DIFF
--- a/.github/release_note_already_exists.sh
+++ b/.github/release_note_already_exists.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+# Answers "does this version already have its release note ?", which is the
+# question the release build has to ask before handing a tag to
+# softprops/action-gh-release.
+#
+# Why it has to be asked at all :
+#
+# The action does not update a release note in place, it appends to it. A step
+# that only asks it to generate notes hands it no body of its own, so on a tag
+# that already has a release it re-sends the body already there ("body =
+# workflowBody || existingReleaseBody", src/github.ts) and then appends the notes
+# it has just generated to that ("body = `${body}\n\n${releaseNotes.data.body}`",
+# in prepareReleaseMutation). First run, nothing is there, and one copy comes
+# out. Second run, the copy the first one wrote is what gets appended to. v1.71
+# was re-fired once and carries its changelog twice ; v1.75 did too and was
+# repaired by hand. The "append_body" input is not what does this, and setting it
+# to false changes nothing : it only ever applies to a body the step supplies
+# itself.
+#
+# Re-firing a release build is the documented recovery path for a build that died
+# before publishing, and what it is fired for is the image. The changelog of a
+# version that has already announced itself is not what a re-fire is asked to
+# refresh, and refreshing it would rewrite a published note out of today's pull
+# request titles and today's contributor names. So the note is written once, when
+# the version has none, and a re-fire leaves the release it finds alone.
+#
+# Nothing being rewritten is also what makes anything hand-written safe. v1.72
+# and v1.75 carry an upgrade note above their changelog, written for the readers
+# of exactly those versions : it survives here by construction, rather than by a
+# rule about where in the body it is allowed to be written.
+#
+# What this deliberately does not cover : GitHub answers this question about
+# PUBLISHED releases only, and a draft is where a note drafted by hand waits for
+# its tag to be pushed. The action does find drafts - it lists the releases,
+# "Because GitHub does not expose draft releases through that endpoint" - and
+# appends to what it finds there, which is what makes a hand-drafted note come
+# out as its own words followed by the changelog. The same path is the one window
+# where a re-fire can still duplicate one : a run cancelled between the draft the
+# action creates and the moment it publishes it leaves a draft already carrying
+# the generated notes, and the next run appends to that. One copy at most, once,
+# and visible on the release page.
+#
+# Exit 0 : it already has one, and nothing has to be written.
+# Exit 1 : it has none, or GitHub could not be asked. Write it.
+# Exit 2 : called wrong.
+#
+# Which answer sits on which code is not arbitrary. Under "set -e" the status a
+# script exits with when something inside it breaks is 1, so 1 is deliberately
+# the answer that costs the least to be wrong about : a run that dies here writes
+# a release note that may already exist, where the other way round it would leave
+# a published version announced by nothing, on a green run.
+#
+# Usage : STATUS=0; .github/release_note_already_exists.sh <owner/repository> <tag> || STATUS=$?
+
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+  printf 'Usage : %s <owner/repository> <tag>\n' "${0##*/}" >&2
+  exit 2
+fi
+
+readonly REPOSITORY="$1"
+readonly TAG="$2"
+
+# Whatever gh has to say about the call, kept without a temporary file to write
+# it into : there is no scratch file here to fail to create, and no failure
+# before the question is asked to be mistaken for an answer to it.
+# "2>&1 >/dev/null" and not the other order : the first sends the diagnostics to
+# the substitution, the second drops the release gh would otherwise print
+if DIAGNOSTICS="$(gh api "repos/$REPOSITORY/releases/tags/$TAG" 2>&1 > /dev/null)"; then
+  printf '%s already has a release, its note is left exactly as it is\n' "$TAG"
+  exit 0
+fi
+
+# Three answers and not two, the way every other decision in this repository
+# reads a registry or an API : "there is no release" and "GitHub did not answer"
+# are not the same thing. They lead to the same place here, and they are still
+# told apart, because only one of them is worth a warning
+if printf '%s' "$DIAGNOSTICS" | grep -q 'HTTP 404'; then
+  printf '%s has no release, its note is written now\n' "$TAG"
+  exit 1
+fi
+
+# Unlike every other unreadable answer in this repository this one goes on rather
+# than stops, because the two mistakes are not the same size. A note written
+# twice shows on the release page and is repaired in one edit ; a note never
+# written at all is a version that announces itself nowhere, which is what left
+# seventeen of them behind a GitHub release with nothing to pull
+printf '%s\n' "$DIAGNOSTICS" >&2
+printf '::warning::Could not tell whether %s already has a release, so its note is written rather than risk a version that announces itself nowhere. If it had one, it now carries its changelog twice and one copy has to be deleted by hand\n' \
+  "$TAG"
+exit 1

--- a/.github/workflows/build_and_publish_docker_image.yml
+++ b/.github/workflows/build_and_publish_docker_image.yml
@@ -11,9 +11,10 @@ on:
 
 # Without this block the whole workflow runs on the repository-wide default
 # token. This one grants only what its two publishing steps need : "contents"
-# for the GitHub release "Generate release note" creates, "packages" for the
-# image pushed to ghcr.io. Everything else the default token may carry
-# (issues, pull requests, deployments...) is dropped
+# for the GitHub release "Generate release note" creates and for the lookup that
+# decides whether it has to, "packages" for the image pushed to ghcr.io.
+# Everything else the default token may carry (issues, pull requests,
+# deployments...) is dropped
 permissions:
   contents: write
   packages: write
@@ -356,9 +357,45 @@ jobs:
       # v1.52 to v1.69, behind a GitHub release with nothing to pull from
       # either registry. Published only once the push went through, a release
       # that fails simply does not exist, and re-firing the workflow from the
-      # Actions tab publishes it for real : re-firing a tag that already has a
-      # release updates that release in place, so recovering them costs nothing
+      # Actions tab publishes it for real.
+      #
+      # What re-firing a tag that ALREADY has a release costs is the part this
+      # comment used to get wrong. It does not update the release in place : the
+      # action appends to it. Asked only to generate notes it is handed no body
+      # of its own, so it re-sends the body already there and appends the notes
+      # it generates to that, and every re-fire added one more copy of the
+      # changelog - v1.71 still carries two - which would eventually have
+      # happened to the upgrade notes v1.72 and v1.75 carry above theirs
+      # (issue #337).
+      #
+      # So the note is written once, when the version has none, and a re-fire
+      # leaves the release it finds alone : what a re-fire is fired for is the
+      # image, and a changelog that has already gone out is not something to
+      # rewrite out of today's pull request titles. Deleting the release is what
+      # asks for a new note. See .github/release_note_already_exists.sh
+      - name: Check whether this version already has its release note
+        id: release_note
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # The two answers are told apart by exit code, and which one sits on 1
+          # is deliberate : 1 is also what a script exits with when something
+          # inside it breaks under "set -e", so it carries the answer that costs
+          # the least to be wrong about. A run that dies in there writes a note
+          # that may already exist ; the other way round it would leave a
+          # published version announced by nothing, on a green run. Anything
+          # else is not an answer at all and fails the step
+          STATUS=0
+          .github/release_note_already_exists.sh "$GITHUB_REPOSITORY" "$GITHUB_REF_NAME" || STATUS=$?
+          case "$STATUS" in
+            0) echo "value=false" >> "$GITHUB_OUTPUT" ;;
+            1) echo "value=true" >> "$GITHUB_OUTPUT" ;;
+            *) exit "$STATUS" ;;
+          esac
+
       - name: Generate release note
+        if: steps.release_note.outputs.value == 'true'
         uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true

--- a/tests/README.md
+++ b/tests/README.md
@@ -25,6 +25,7 @@ It exits `0` when every test case passed, `1` otherwise.
 | `cases/13_dockerhub_description.sh` | The page Docker Hub shows on the image's repository, rendered from `README.md` by a workflow no pull request fires either |
 | `cases/14_latest_tag_reconciliation.sh` | Which version `latest` ends up on after a release, against a stubbed registry. Skipped where `jq` is missing, the one thing the script needs that the suite does not |
 | `cases/15_test_runner.sh` | The runner itself : the ways it used to stay green while nothing had been verified |
+| `cases/16_release_note_publication.sh` | Whether a version tag still needs its GitHub release note written, against a stubbed GitHub : the decision that keeps a re-fired release from appending a second copy of its changelog to the one it already carries |
 | `cases/17_reports.sh` | The JUnit XML and Markdown reports, whose consumer is a parser rather than a reader |
 | `cases/20_fan_speed_conversions.sh` | `FAN_SPEED` given as a percentage or as a hexadecimal byte |
 | `cases/21_fan_speed_validation.sh` | `FAN_SPEED` values that would reach `ipmitool` as an unintended duty cycle, refused before the first command |

--- a/tests/cases/16_release_note_publication.sh
+++ b/tests/cases/16_release_note_publication.sh
@@ -1,0 +1,299 @@
+#!/bin/bash
+
+# A release note is the announcement that a version is out, and the only artefact
+# of a release a human writes into by hand. It is also written by a step that
+# only ever runs on a version tag, where no pull request looks : issue #337 was
+# found by reading a release page weeks later, and by then v1.71 carried its
+# changelog twice and every hand-written upgrade note was standing on the same
+# trapdoor.
+#
+# GitHub is stubbed here, so these exercise the decision and not the API : a fake
+# "gh" first in the PATH answers for a repository whose releases the test states.
+
+readonly RELEASE_NOTE_SCRIPT=".github/release_note_already_exists.sh"
+readonly RELEASE_NOTE_WORKFLOW=".github/workflows/build_and_publish_docker_image.yml"
+readonly RELEASE_NOTE_REPOSITORY="owner/repository"
+
+# The suite also runs inside the built image, which carries the shipped scripts
+# but not the .github directory
+# Usage : if ! release_note_decision_can_run; then skip_test "..."; return 0; fi
+function release_note_decision_can_run() {
+  [ -x "$REPO_ROOT/$RELEASE_NOTE_SCRIPT" ]
+}
+
+# Builds the world the script runs in : a GitHub it can only see through a
+# stubbed gh, which answers for the one release lookup the script makes.
+# Usage : setup_release_note_sandbox
+function setup_release_note_sandbox() {
+  SANDBOX="$(mktemp -d)"
+  export MOCK_RELEASE_EXISTS=false
+  export MOCK_RELEASE_LOOKUP_ERROR=""
+  export MOCK_GH_CALL_LOG="$SANDBOX/gh_calls.log"
+  : > "$MOCK_GH_CALL_LOG"
+
+  mkdir -p "$SANDBOX/bin"
+  cat > "$SANDBOX/bin/gh" << 'STUB'
+#!/bin/bash
+# Answers the one API call the script makes, and nothing else. Positional rather
+# than parsed : the script calls this with a fixed shape, and a stub that
+# accepted more shapes than the real command would hide a call gh itself would
+# refuse
+#   gh api repos/<repository>/releases/tags/<tag>
+set -uo pipefail
+
+printf '%s\n' "$*" >> "$MOCK_GH_CALL_LOG"
+
+case "${1:-}:${2:-}" in
+  api:*/releases/tags/*)
+    if [ -n "${MOCK_RELEASE_LOOKUP_ERROR:-}" ]; then
+      printf '%s\n' "$MOCK_RELEASE_LOOKUP_ERROR" >&2
+      exit 1
+    fi
+    # The wording gh reports a release that does not exist with, and the only
+    # one the script may read as "there is none"
+    if [ "${MOCK_RELEASE_EXISTS:-false}" != true ]; then
+      printf 'gh: Not Found (HTTP 404)\n' >&2
+      exit 1
+    fi
+    ;;
+  *)
+    printf 'the stub was called in a shape the script is not supposed to use : %s\n' "$*" >&2
+    exit 64
+    ;;
+esac
+STUB
+  chmod 0755 "$SANDBOX/bin/gh"
+  export PATH="$SANDBOX/bin:$PATH"
+}
+
+function teardown_release_note_sandbox() {
+  [ -n "${SANDBOX:-}" ] && rm -rf "$SANDBOX"
+}
+
+# Everything the stubbed gh was asked, so a lookup about something other than
+# the release it was given cannot pass for one about it
+# Usage : assert_contains "$(recorded_gh_calls)" "..."
+function recorded_gh_calls() {
+  cat "$MOCK_GH_CALL_LOG"
+}
+
+# The block of one step of the release workflow, from its "- name:" line to the
+# line that starts the next step. An assertion against the whole file cannot say
+# which step a line belongs to, and "the gate is somewhere in the file" is not
+# what has to be true : it has to be on the step that writes the note
+# Usage : BLOCK="$(release_workflow_step "Generate release note")"
+function release_workflow_step() {
+  awk -v WANTED="      - name: $1" '
+    $0 == WANTED { inside = 1; next }
+    inside && /^      - name: / { exit }
+    inside { print }
+  ' "$REPO_ROOT/$RELEASE_NOTE_WORKFLOW"
+}
+
+# The id a step declares for itself, out of its block
+# Usage : DECLARED="$(declared_step_id "$CHECKING_STEP")"
+function declared_step_id() {
+  printf '%s\n' "$1" | sed -n 's/^ *id: *\([A-Za-z0-9_-]*\) *$/\1/p'
+}
+
+# The step id, and the output name, that a gate reads : "steps.<id>.outputs.<name>"
+# Usage : GATED_ON="$(gate_reads "$WRITING_STEP" 1)"   # 1 the id, 2 the output
+function gate_reads() {
+  printf '%s\n' "$1" |
+    sed -n "s/^ *if: *steps\.\([A-Za-z0-9_-]*\)\.outputs\.\([A-Za-z0-9_-]*\) *==.*/\\$2/p"
+}
+
+# Usage : OUTPUT="$(release_note_already_exists v1.76)"; EXIT_CODE=$?
+function release_note_already_exists() {
+  "$REPO_ROOT/$RELEASE_NOTE_SCRIPT" "$RELEASE_NOTE_REPOSITORY" "$1" 2>&1
+}
+
+function test_a_version_with_no_release_yet_has_its_note_written() {
+  if ! release_note_decision_can_run; then
+    skip_test "no .github next to the scripts"
+    return 0
+  fi
+
+  # The ordinary release, and the recovery the workflow documents : a build that
+  # died before publishing left no release behind, so re-firing it writes the
+  # note for the first time. That path was never the broken one and has to stay
+  # exactly as it was
+  setup_release_note_sandbox
+
+  local OUTPUT EXIT_CODE=0
+  OUTPUT="$(release_note_already_exists v1.76)" || EXIT_CODE=$?
+
+  assert_equals "1" "$EXIT_CODE" \
+    "a version whose release does not exist has to get its release note"
+  assert_contains "$OUTPUT" "no release" \
+    "and the run log should say which of the two situations it found"
+
+  teardown_release_note_sandbox
+}
+
+function test_a_version_that_already_has_a_release_keeps_the_note_it_has() {
+  if ! release_note_decision_can_run; then
+    skip_test "no .github next to the scripts"
+    return 0
+  fi
+
+  # Issue #337 itself. The release action appends to a body rather than
+  # replacing it, so handing it a tag that already has a release added one more
+  # copy of the changelog every time - and would eventually have done the same
+  # to the upgrade note written above it by hand
+  setup_release_note_sandbox
+  export MOCK_RELEASE_EXISTS=true
+
+  local OUTPUT EXIT_CODE=0
+  OUTPUT="$(release_note_already_exists v1.71)" || EXIT_CODE=$?
+
+  assert_equals "0" "$EXIT_CODE" \
+    "a release that exists must not be handed to a step that appends to it"
+  assert_contains "$OUTPUT" "left exactly as it is" \
+    "and the run log has to say the note was left alone"
+  assert_not_contains "$OUTPUT" "::error::" \
+    "leaving a release note alone is the ordinary outcome of a re-fire, not a failure"
+
+  teardown_release_note_sandbox
+}
+
+function test_a_lookup_that_fails_writes_the_note_rather_than_risk_a_version_without_one() {
+  if ! release_note_decision_can_run; then
+    skip_test "no .github next to the scripts"
+    return 0
+  fi
+
+  # "GitHub did not answer" is not "there is no release", and this is the one
+  # decision in this repository where the unreadable answer goes on rather than
+  # stops : the two mistakes are not the same size. A changelog written twice
+  # shows on the release page and is repaired in one edit ; a version announced
+  # nowhere is what left seventeen of them behind a release with nothing to pull
+  setup_release_note_sandbox
+  export MOCK_RELEASE_LOOKUP_ERROR="gh: Resource not accessible by integration (HTTP 403)"
+
+  local OUTPUT EXIT_CODE=0
+  OUTPUT="$(release_note_already_exists v1.76)" || EXIT_CODE=$?
+
+  assert_equals "1" "$EXIT_CODE" \
+    "an unreadable answer must not withhold the announcement of a published version"
+  assert_contains "$OUTPUT" "::warning::" \
+    "but going on without an answer has to be said out loud"
+
+  teardown_release_note_sandbox
+}
+
+function test_the_release_lookup_refuses_to_guess_which_tag_it_is_about() {
+  if ! release_note_decision_can_run; then
+    skip_test "no .github next to the scripts"
+    return 0
+  fi
+
+  setup_release_note_sandbox
+
+  local EXIT_CODE=0
+  "$REPO_ROOT/$RELEASE_NOTE_SCRIPT" "$RELEASE_NOTE_REPOSITORY" > /dev/null 2>&1 || EXIT_CODE=$?
+
+  assert_equals "2" "$EXIT_CODE" \
+    "called without a tag it has to refuse rather than answer about something else"
+
+  teardown_release_note_sandbox
+}
+
+function test_a_lookup_that_cannot_even_run_writes_the_note() {
+  if ! release_note_decision_can_run; then
+    skip_test "no .github next to the scripts"
+    return 0
+  fi
+
+  # Not "gh answered something unexpected" but "gh was never there to answer".
+  # It matters which way a broken lookup falls, and under "set -e" a script that
+  # breaks exits 1 : that is the code carrying "write the note", so any failure
+  # inside this one lands on the side that costs the least to be wrong about
+  setup_release_note_sandbox
+  local -r EMPTY_DIRECTORY="$SANDBOX/no_commands"
+  mkdir -p "$EMPTY_DIRECTORY"
+
+  local OUTPUT EXIT_CODE=0
+  OUTPUT="$(PATH="$EMPTY_DIRECTORY" "$REPO_ROOT/$RELEASE_NOTE_SCRIPT" \
+    "$RELEASE_NOTE_REPOSITORY" v1.76 2>&1)" || EXIT_CODE=$?
+
+  assert_equals "1" "$EXIT_CODE" \
+    "a lookup that could not run at all must not read as a release that already has its note"
+  assert_contains "$OUTPUT" "::warning::" \
+    "and going on without an answer has to be said out loud rather than assumed"
+
+  teardown_release_note_sandbox
+}
+
+function test_the_lookup_asks_github_about_the_release_it_was_given() {
+  if ! release_note_decision_can_run; then
+    skip_test "no .github next to the scripts"
+    return 0
+  fi
+
+  # Every answer below is the same whatever is asked, so nothing else in this
+  # file would notice a lookup about the wrong repository or the wrong tag - two
+  # arguments of the same shape, one line apart, in a step no pull request runs
+  setup_release_note_sandbox
+  export MOCK_RELEASE_EXISTS=true
+
+  release_note_already_exists v1.71 > /dev/null || true
+
+  assert_equals "api repos/$RELEASE_NOTE_REPOSITORY/releases/tags/v1.71" \
+    "$(recorded_gh_calls)" \
+    "the release it asks GitHub about has to be the one it was given, and it has to ask once"
+
+  teardown_release_note_sandbox
+}
+
+function test_the_release_note_step_runs_only_when_that_lookup_says_so() {
+  # The workflow and the script only meet at a path written in both, and the
+  # step that joins them runs on a version tag, where no pull request looks
+  if [ ! -f "$REPO_ROOT/$RELEASE_NOTE_WORKFLOW" ]; then
+    skip_test "no .github/workflows next to the scripts"
+    return 0
+  fi
+
+  local -r CHECKING_STEP="$(release_workflow_step "Check whether this version already has its release note")"
+  local -r WRITING_STEP="$(release_workflow_step "Generate release note")"
+
+  assert_contains "$CHECKING_STEP" "$RELEASE_NOTE_SCRIPT" \
+    "the release workflow has to ask $RELEASE_NOTE_SCRIPT before writing a note"
+  assert_contains "$WRITING_STEP" "softprops/action-gh-release" \
+    "the step that writes the note is the one that runs the release action"
+
+  # The gate and the step it reads are two strings fifteen lines apart that have
+  # to name the same thing, and asserting either one on its own cannot say that :
+  # "id: release_note_check" contains "id: release_note". So both sides are
+  # pulled out and compared. An id that resolves to nothing is not an error in
+  # Actions - the expression is simply empty, the gate is false forever, and
+  # every release goes out with no note at all, on green runs
+  local -r DECLARED_ID="$(declared_step_id "$CHECKING_STEP")"
+  local -r GATED_ON_ID="$(gate_reads "$WRITING_STEP" 1)"
+  local -r GATED_ON_OUTPUT="$(gate_reads "$WRITING_STEP" 2)"
+
+  assert_not_empty "$GATED_ON_ID" \
+    "the step that writes the note has to be gated on a step output, which is the whole of issue #337"
+  assert_equals "$DECLARED_ID" "$GATED_ON_ID" \
+    "the gate has to name the id the checking step declares for itself"
+
+  # The case statement in between is the whole translation from the exit code to
+  # that gate, and swapping its two arms passes every other test in this file :
+  # every version that already had a note would be handed to the step that
+  # appends to it, and every version that had none would be gated out of it
+  assert_contains "$CHECKING_STEP" "0) echo \"$GATED_ON_OUTPUT=false\"" \
+    "a release that already has its note has to map to not writing one"
+  assert_contains "$CHECKING_STEP" "1) echo \"$GATED_ON_OUTPUT=true\"" \
+    "and a release that has none, or could not be asked about, has to map to writing one"
+
+  # The generation itself is right where it is : the path it runs on is the one
+  # that creates a release, and there it produces exactly one copy
+  assert_contains "$WRITING_STEP" "generate_release_notes: true" \
+    "a release being created for the first time still gets its changelog generated"
+
+  if [ -x "$REPO_ROOT/$RELEASE_NOTE_SCRIPT" ]; then
+    pass
+  else
+    fail "$RELEASE_NOTE_SCRIPT is run as a command by the workflow, it has to be executable"
+  fi
+}


### PR DESCRIPTION
Closes #337.

## The mechanism, read against the action rather than guessed from its inputs

`softprops/action-gh-release` does not update a release body in place, it **appends** to it. A step that only asks it to generate notes hands it no body of its own, so on a tag that already has a release it re-sends the body already there and then appends the notes it has just generated to that. Two lines, three hundred apart:

```ts
// update path — src/github.ts:655-661 at the v3 ref
const workflowBody = releaseBody(config) || '';          // '' : the step supplies no body
const existingReleaseBody = existingRelease.body || '';
body = workflowBody || existingReleaseBody;              // → the body already there

// prepareReleaseMutation — src/github.ts:196-208, reached by BOTH create and update
releaseParams.generate_release_notes = false;
if (releaseParams.body) {
  releaseParams.body = `${releaseParams.body}\n\n${releaseNotes.data.body}`;   // ← the second copy
}
```

Checked at the ref the workflow actually pins, not at `master`: `v3` → `v3.0.2` → commit `3d0d988`, whose `dist/index.js` — the file the action runs — carries the same expression minified: ``r.generate_release_notes=!1,r.body?r.body=`${r.body}\n\n${i.data.body}`:r.body=i.data.body``.

So a first fire produced one copy and every re-fire produced one more. That is exactly the `\n\n` join v1.71's body still shows between its two identical changelogs.

**`append_body` is not what does this.** Its guard is `if (config.input_append_body && workflowBody && existingReleaseBody)`, which needs a body the step supplied itself; the step supplies none, so that branch never runs and setting the input to `false` changes nothing. The issue was right to flag the input name as misleading.

## The fix

A re-fire is fired for the **image**. The changelog of a version that has already announced itself is not what it is asked to refresh — and refreshing it would rewrite a published note out of today's pull request titles and today's contributor logins. So the note is written once, when the version has none, and a re-fire leaves the release it finds alone.

`.github/release_note_already_exists.sh` asks the question; the step that writes the note is gated on its answer. The generation itself stays exactly as it was on the path where it was always correct — the one that creates a release.

This answers the issue's four actionable points:

| | |
| --- | --- |
| 1. Establish the real mechanism | Above, against the v3 sources and the shipped bundle, not the input names |
| 2. Make a re-fire produce the same body as a first fire | It produces *no change* to a body a first fire already wrote — the same thing, without a rewrite |
| 3. Decide what happens to a hand-written preamble | Nothing is ever rewritten, so the `> [!NOTE]` preambles on v1.72 and v1.75 are safe **by construction**, not by a rule about where in the body they may be written |
| 4. Fix the workflow comment | Replaced: it now says what the action does, why a re-fire leaves an existing note alone, and that deleting the release is what asks for a new one |

### Two places where the direction of a mistake was chosen deliberately

**When GitHub cannot be asked.** "GitHub did not answer" is not "there is no release". Every other decision in this repository stops when it cannot read an external system; this one **goes on**, because the two mistakes are not the same size. A changelog written twice shows on the release page and is repaired in one edit. A version that announces itself nowhere is what left seventeen of them behind a GitHub release with nothing to pull. It warns loudly and publishes.

**Which answer sits on which exit code.** Under `set -e` the status a script exits with when something inside it breaks is `1` — so `1` carries *"it has no release note, write it"*, and `0` carries *"it already has one"*. A lookup that dies before it can answer therefore writes a note that may already exist, rather than silently withholding one on a green run. Anything else (`2`, called wrong) is not an answer at all and fails the step. The lookup keeps gh's diagnostics in a variable rather than a scratch file, so there is nothing to fail to create before the question is even asked.

## What this deliberately does not do

- **v1.71 still needs its duplicate deleted by hand.** Point 5 of the issue stands, and not only because no future run repairs an existing body: re-firing `v1.71` runs the workflow **as it stood at that tag**, not this one, so no change here can reach it.
- **One duplication window is left open, knowingly.** The action creates every release as a draft before publishing it, and GitHub does not expose drafts through the by-tag endpoint this lookup uses. A run cancelled between those two moments leaves a draft that the next run appends to — one extra copy at most, once, and visible on the release page. Closing it would mean not appending to drafts at all, and appending to a draft is precisely what makes a note drafted by hand come out as its own words followed by the changelog. That path is left alone on purpose.

## Why not compose the body ourselves

The first version of this change did: it generated the notes through `POST /releases/generate-notes`, fenced them between two HTML comments, and rewrote only what sat between them. It worked, and it kept hand-written text — but it cost ~380 lines of script plus ~700 of tests, and every guard it grew (marker ambiguity, a contributor's pull request title containing a marker, CRLF from the web editor, drafts invisible to one lookup and visible to the action, retries the action used to provide, text typed inside the fence) existed only because it rewrote a body it had not written. It also silently rewrote shipped changelogs from live data on every re-fire, which is a thing this repository should not do. Not touching an existing release delivers both guarantees unconditionally, in 93 lines.

## Tests

`tests/cases/16_release_note_publication.sh`, seven cases against a stubbed `gh`:

- a version with no release yet has its note written — the ordinary release, and the recovery path the workflow documents
- a version that already has a release keeps the note it has — issue #337 itself
- a lookup that fails writes the note rather than risk a version without one, and warns
- a lookup that cannot even run does the same, which is what the exit-code choice above buys
- the lookup refuses to run without a repository and a tag
- the lookup asks GitHub about the release it was given — every stubbed answer is the same whatever is asked, so nothing else here would notice two same-shaped arguments swapped
- the workflow's two steps are read one at a time rather than grepped as one file, and the gate is checked by **comparing both sides** rather than by looking for either: the id the checking step declares is compared with the id the gate names, and the output name the gate reads is what both arms of the case statement are then required to write. Grepping for `id: release_note` would have matched `id: release_note_check`, and an id that resolves to nothing is not an error in Actions — the gate is simply false forever and every release goes out with no note at all, on green runs.

Mutation-checked, ten of them, each turning a test red: reversing the "already has one" answer; reading a 404 as "it already has one"; reading an unreadable answer as "it already has one"; swapping the two arms of the case statement; reversing the `2>&1 >/dev/null` order that captures gh's diagnostics; swapping the script's two arguments; removing the `if:`; renaming the step `id` on one side only; pointing the gate at an id that does not exist; and renaming the step output on either side alone.

Full suite: **390 test cases, 2060 assertions, green.** `shellcheck -S style` clean on both new files (`.github/*.sh` is already covered by the syntax check in `cases/10_shell_scripts.sh`).