### PR TITLE
Hold the cooling response column's justification to the code (#344)

### DIFF
--- a/constants.sh
+++ b/constants.sh
@@ -79,8 +79,14 @@ readonly FAN_CONTROL_PROFILE_COLUMN_WIDTH=54
 readonly MONITORING_ONLY_MODE_FAN_CONTROL_PROFILE_COLUMN_WIDTH=71
 
 # The cooling response column is sized by its own heading, "Third-party PCIe card Dell default cooling
-# response", which is longer than anything that column ever holds : its widest value is "Disabled (not
-# applied: monitoring only mode)" at 44. So, unlike the profile column, it does not move with the mode
+# response", which is 51 characters and longer than anything that column ever holds : its widest value
+# is "Refused: this account lacks the privilege level" at 47. So, unlike the profile column, it does not
+# move with the mode.
+#
+# That sentence used to name a value of 44 that a later status overtook, and nothing went red over it --
+# the suite asserted every status fits, which stayed true, but never that this number is the heading's
+# length nor that the heading beats every value, which is what the sentence actually claims. Both are
+# asserted now, in test_no_fan_control_profile_can_outgrow_the_column_reserved_for_it() (issue #344)
 readonly COOLING_RESPONSE_COLUMN_WIDTH=51
 
 # How long the supervisor gives the monitoring process to stop on its own after forwarding it the signal,

--- a/tests/cases/60_cpu_topologies.sh
+++ b/tests/cases/60_cpu_topologies.sh
@@ -646,13 +646,28 @@ function test_no_fan_control_profile_can_outgrow_the_column_reserved_for_it() {
   done
 
   local COOLING_RESPONSE_STATUS
+  local WIDEST_COOLING_RESPONSE_WIDTH=0
   for COOLING_RESPONSE_STATUS in "Enabled" "Disabled" "Not supported by this server" \
     "Could not be applied on this cycle" "Refused: this account lacks the privilege level" \
     "Enabled (not applied: monitoring only mode)" \
     "Disabled (not applied: monitoring only mode)"; do
+    (( ${#COOLING_RESPONSE_STATUS} > WIDEST_COOLING_RESPONSE_WIDTH )) && WIDEST_COOLING_RESPONSE_WIDTH=${#COOLING_RESPONSE_STATUS}
     assert_equals "true" "$([ "${#COOLING_RESPONSE_STATUS}" -le "$COOLING_RESPONSE_COLUMN_WIDTH" ] && echo true || echo false)" \
       "\"$COOLING_RESPONSE_STATUS\" (${#COOLING_RESPONSE_STATUS}) must fit in $COOLING_RESPONSE_COLUMN_WIDTH"
   done
+
+  # Every status fitting is not the whole invariant, and asserting only that is how the comment beside
+  # the constant came to name a widest value a later status had overtaken : it stayed green throughout.
+  # What that comment claims is that the number is the heading's length, and that the heading is wider
+  # than anything the column holds. Both are read from the source rather than repeated here, so the
+  # sentence is held to the code
+  local -r COOLING_RESPONSE_HEADING=$(grep -oE "center_column_heading COOLING_RESPONSE_HEADING '[^']*'" "$REPO_ROOT/functions.sh" | sed -E "s/.*'([^']*)'.*/\1/")
+
+  assert_not_empty "$COOLING_RESPONSE_HEADING" "the cooling response heading should be findable in functions.sh" || return 1
+  assert_equals "${#COOLING_RESPONSE_HEADING}" "$COOLING_RESPONSE_COLUMN_WIDTH" \
+    "the column is sized by its heading, so it should be exactly as wide as it"
+  assert_equals "true" "$([ "$WIDEST_COOLING_RESPONSE_WIDTH" -le "${#COOLING_RESPONSE_HEADING}" ] && echo true || echo false)" \
+    "the heading ($((${#COOLING_RESPONSE_HEADING}))) should stay wider than the widest status ($WIDEST_COOLING_RESPONSE_WIDTH), or the column has to be sized on the status instead"
 }
 
 function test_the_header_is_refused_when_the_profile_column_width_is_unresolved() {


### PR DESCRIPTION
Closes #344. Small: a comment figure and two assertions. **No behaviour change, no width change** — `COOLING_RESPONSE_COLUMN_WIDTH` stays 51.

## The stale figure

The comment argues the number from the heading being wider than anything the column holds, and names that widest value:

> its widest value is `"Disabled (not applied: monitoring only mode)"` **at 44**

#340 added a fifth status that overtook it:

| Value | Length |
| --- | --- |
| `Disabled (not applied: monitoring only mode)` | 44 ← what the comment claimed |
| **`Refused: this account lacks the privilege level`** | **47** ← actual widest since #340 |
| *(heading)* `Third-party PCIe card Dell default cooling response` | 51 |

The conclusion still holds — 51 > 47 — but the figure quoted to reach it does not. That sentence is the recorded argument for `51`: someone trimming the column to "44 and a little" would truncate the new status, which is what #170 was about.

## Why nothing went red

The suite asserted every status **fits**, which stayed true throughout, and #340 correctly added its new value to that list. What the comment actually claims was asserted nowhere:

1. that the number **is** the heading's length;
2. that the heading is at least as wide as the widest status.

The profile column, by contrast, is already held to its widest value exactly. This closes the same gap on its neighbour.

Both claims are now read from the source rather than repeated in the test — the heading is grepped out of `functions.sh`, the widest status computed from the list already being iterated — so the sentence cannot outlive the code again.

## Verification

- `./tests/run_tests.sh` — **383 passed** (2037 assertions, +3 on the same 383 cases).
- `shellcheck -x` on the five shipped scripts — clean.
- Mutation-tested both new assertions:
  - width to 52 → *"the column is sized by its heading, so it should be exactly as wide as it"* goes red;
  - heading shortened to `Cooling response` → *"the heading (16) should stay wider than the widest status (47)"* goes red.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y4jdnzs3FoBoGdBmwThR7y)_