### PR TITLE
Ask a server for its fans once, and say what it answered

### DIFF
--- a/Dell_iDRAC_fan_controller.sh
+++ b/Dell_iDRAC_fan_controller.sh
@@ -12,6 +12,16 @@ source constants.sh
 # guessing from the model name
 IS_THIRD_PARTY_PCIE_CARD_COOLING_RESPONSE_SUPPORTED=true
 
+# The fan control commands themselves are found out the same way, and for the same reason : Dell removed
+# them from the 14th generation on, an iDRAC 9 refusing them from firmware 3.34.34.34 onwards, and no
+# model name says which firmware a server is running. Without this the controller kept sending them and
+# reporting the same two failures every cycle, for the life of the container.
+#
+# The second flag is what keeps the first one safe : a refusal only settles anything while nothing has
+# ever been accepted. Both are declared here, before the trap below, because graceful_exit reads them
+IS_FAN_CONTROL_SUPPORTED=true
+HAS_FAN_CONTROL_EVER_BEEN_ACCEPTED=false
+
 # Trap the signals for container exit and run graceful_exit function
 trap 'graceful_exit' SIGINT SIGQUIT SIGTERM
 
@@ -144,12 +154,17 @@ if [[ ! $SERVER_MANUFACTURER == "DELL" ]]; then
   print_error_and_exit "Your server isn't a Dell product"
 fi
 
+# Asked once the server is known to be a Dell, next to the model it belongs with, and never treated as a
+# reason not to start : an iDRAC that will not say which firmware it runs still drives fans
+get_iDRAC_firmware_version
+
 # CPU temperature indexes are gone: retrieve_temperatures() now locates each CPU by its IPMI entity ID
 # instead of counting values, which no longer depends on the server generation
 
 # Log main informations
 echo "Server model: $SERVER_MANUFACTURER $SERVER_MODEL"
 echo "iDRAC/IPMI host: $IDRAC_HOST"
+echo "iDRAC firmware version: $IDRAC_FIRMWARE_VERSION"
 
 # Log the fan speed objective, CPU temperature threshold and check interval
 echo "Fan speed objective: $DECIMAL_FAN_SPEED%"
@@ -475,7 +490,7 @@ while true; do
       if (( ${#OVERHEATING_CPUS_AND_TEMPERATURES[@]} > 0 )); then
         COMMENT=$(build_fan_control_fallback_comment "${OVERHEATING_CPUS_AND_TEMPERATURES[@]}")
       else
-        COMMENT="No CPU temperature could be read, Dell default dynamic fan control profile applied for safety"
+        COMMENT="No CPU temperature could be read, $(fan_control_comment_clause "Dell default dynamic fan control profile applied for safety")"
       fi
     fi
   else
@@ -489,9 +504,9 @@ while true; do
       # is also applied when a reading can't be parsed : claiming a temperature dropped would contradict
       # the "could not be read" comment printed when that happened
       if [ "$NUMBER_OF_DETECTED_CPUS" -eq 1 ]; then
-        COMMENT="CPU temperature is now OK (<= $CPU_TEMPERATURE_THRESHOLD°C), user's fan control profile applied."
+        COMMENT="CPU temperature is now OK (<= $CPU_TEMPERATURE_THRESHOLD°C), $(fan_control_comment_clause "user's fan control profile applied")."
       else
-        COMMENT="All CPU temperatures are now OK (<= $CPU_TEMPERATURE_THRESHOLD°C), user's fan control profile applied."
+        COMMENT="All CPU temperatures are now OK (<= $CPU_TEMPERATURE_THRESHOLD°C), $(fan_control_comment_clause "user's fan control profile applied")."
       fi
     fi
   fi

--- a/README.md
+++ b/README.md
@@ -26,7 +26,24 @@
 ## Requirements
 ### iDRAC version
 
-This Docker container only works on Dell PowerEdge servers that support IPMI commands, i.e. < iDRAC 9 firmware 3.30.30.30.
+This container drives the fans with two IPMI raw commands Dell removed from its recent hardware. What decides whether yours takes them is the iDRAC firmware, not the model :
+
+| iDRAC | Dell's IPMI raw fan control commands |
+| --- | --- |
+| iDRAC 6, 7 and 8 (generations 11 to 13) | Available |
+| iDRAC 9 up to firmware `3.30.30.30` | Available, that being the newest version they are confirmed to work on |
+| iDRAC 9 from firmware `3.34.34.34` on | **Removed by Dell**, deliberately and for good |
+| iDRAC 10 (17th generation) | Never had them |
+
+`3.31.31.31` and `3.32.32.32` sit between those two versions and what either answers has never been reported. Blades and modular servers refuse them whatever their generation, their fans belonging to the enclosure.
+
+**Downgrading is no longer a way out** : an iDRAC 9 that has installed Dell's June 2024 release or any later one [cannot go back to `4.40.10.00` or older](https://www.dell.com/support/kbdoc/en-us/000225924/rac0181-idrac9-firmware-downgrade-failures-on-14-15g-poweredge-servers).
+
+None of it has to be worked out in advance : the container asks the server, logs its iDRAC firmware version at startup and [says what it was answered](#your-fan-speed-never-changes-and-the-log-says-the-server-refused-fan-control).
+
+### iDRAC user privileges
+
+The account this container uses must be an **Administrator** on the iDRAC : fan control is not read-only, and a lesser account is refused it with the very completion code (`0xd4`) a firmware that removed the commands returns.
 
 ### To access iDRAC over LAN (not needed in "local" mode) :
 
@@ -323,6 +340,28 @@ Read its log rather than its restart count: a container that stops on a **config
 Nothing about that can self-correct — the value is the same on every attempt — so the restart policy the [Usage](#usage) examples recommend, which is what protects you against a transient failure, turns a permanent refusal into an endless loop. `docker logs --tail 40 Dell_iDRAC_fan_controller` shows the block; fix what it names and the loop ends. The most common case is a `CPU_TEMPERATURE_THRESHOLD` above 125, which versions up to v1.27 accepted (see the [Parameters](#parameters) section).
 
 A refusal **without** that "Restarting will not help" line is the opposite case, and the only one worth waiting out: an iDRAC that did not answer this time may answer the next, so the restart policy is what recovers it without you doing anything.
+
+### Your fan speed never changes and the log says the server refused fan control
+
+That server does not let its fans be driven over IPMI. The container says so once, in full, and then stops asking :
+
+```
+/!\ Warning /!\ This server refused fan control, so the container will stop asking and keep reading temperatures instead.
+ Its fans are not left in an unknown state : the command that was refused is the one that takes them away from Dell's own dynamic fan control profile, so they never left it.
+ [...]
+```
+
+Three things are worth knowing about it.
+
+**Nothing is left half-done.** The refused command is the one that takes the fans *from* Dell's own dynamic profile, so they never left it : the server cools itself exactly as it did before the container started, and stopping the container changes nothing either.
+
+**It is a verdict about this server, not about this cycle.** An iDRAC that answers with an IPMI completion code answers with the same one every time, so re-sending the command only fills the log. An iDRAC that could not be *reached* prints no completion code at all, and that case is never treated as a refusal — the commands keep being sent for as long as the outage lasts.
+
+**Two things produce this answer**, and the completion code does not say which : a firmware that removed the commands, or an iDRAC account that is not an Administrator. The [iDRAC version](#idrac-version) and [iDRAC user privileges](#idrac-user-privileges) sections cover both. Check the account first if this server used to work — that is the half you can fix.
+
+The container keeps running, keeps reading the temperatures and keeps logging them, which is what `MONITORING_ONLY_MODE` does on purpose.
+
+**If it is the firmware, downgrading will not get you out of it.** Dell removed the commands on purpose — *"going forward access is not going to be allowed as it affects the thermal algorithms and cooling the system"*, [on its own forum](https://www.dell.com/community/en/conversations/poweredge-hardware-general/dell-eng-is-taking-away-fan-speed-control-away-from-users-idrac-3343434/647f8593f4ccf8a8de47aa9b) — and since the June 2024 release (`7.00.00.172` on the 14th generation, `7.10.50.00` on the 15th) an iDRAC 9 [cannot be downgraded to `4.40.10.00` or older](https://www.dell.com/support/kbdoc/en-us/000225924/rac0181-idrac9-firmware-downgrade-failures-on-14-15g-poweredge-servers), the bootloader having changed in a way older firmware cannot boot. The restriction carries forward to every version since, and Dell documents that *"while the firmware downgrade job may reflect a successful status, the Lifecycle Log records a RAC0181 informational event on iDRAC9 reboot"* : check the version the iDRAC reports afterwards rather than the job's outcome.
 
 ### Your server frequently switches back to the default Dell fan mode:
 1. Check `Tcase` (case temperature) of your CPU on Intel Ark website and then set `CPU_TEMPERATURE_THRESHOLD` to a slightly lower value. Example with my CPUs ([Intel Xeon E5-2630L v2](https://www.intel.com/content/www/us/en/products/sku/75791/intel-xeon-processor-e52630l-v2-15m-cache-2-40-ghz/specifications.html)) : Tcase = 63°C, I set `CPU_TEMPERATURE_THRESHOLD` to 60(°C). Note that the default "auto" value does **not** do this for you : Tcase is a case (heat spreader) temperature, while "auto" uses the junction-scale "high" value, which is usually well above Tcase (on a Xeon Gold 5122 for instance, Tcase is 71°C but "high" is around 94°C). If you want a Tcase-derived threshold, set it explicitly. The startup log always states which threshold was picked and where it comes from.

--- a/functions.sh
+++ b/functions.sh
@@ -9,6 +9,13 @@ function apply_Dell_default_fan_control_profile() {
     CURRENT_FAN_CONTROL_PROFILE="Dell default dynamic fan control profile (monitoring only, not applied)"
     return
   fi
+  # A server that answered "I will not do this" answers it again every cycle, so the command is not sent
+  # any more once it has. The fans are Dell's own -- they are what the refused command would have taken
+  # them from -- which is what the badge says
+  if has_the_server_refused_fan_control; then
+    CURRENT_FAN_CONTROL_PROFILE="Dell default dynamic fan control profile (refused)"
+    return 1
+  fi
   # Use ipmitool to send the raw command to set fan control to Dell default.
   # Some iDRAC/BMC firmwares print a harmless protocol warning on stderr (e.g. "Received an Unexpected
   # message...") even when the command actually succeeds. Rather than discard stderr unconditionally (which
@@ -19,11 +26,13 @@ function apply_Dell_default_fan_control_profile() {
   # shellcheck disable=SC2181  # $? here is the command substitution above, already run; there is no direct command left to negate
   if [ $? -ne 0 ]; then
     print_error "Failed to apply Dell default fan control profile. ipmitool said: $ipmitool_stderr"
+    note_that_the_server_refuses_fan_control "$ipmitool_stderr"
     # The table says what the server is actually doing, not what was attempted : this profile is the
     # safety fallback, so claiming it while the command was refused is the one lie that matters here
     CURRENT_FAN_CONTROL_PROFILE="Dell default dynamic fan control profile (not applied)"
     return 1
   fi
+  HAS_FAN_CONTROL_EVER_BEEN_ACCEPTED=true
   CURRENT_FAN_CONTROL_PROFILE="Dell default dynamic fan control profile"
 }
 
@@ -34,6 +43,13 @@ function apply_user_fan_control_profile() {
     CURRENT_FAN_CONTROL_PROFILE="User static fan control profile ($DECIMAL_FAN_SPEED%) (monitoring only, not applied)"
     return
   fi
+  # Same as above : a server that refused to hand its fans over is not asked again, and the profile it
+  # is actually running -- Dell's own, since the refused command is the one that would have taken the
+  # fans from it -- is what the table reports rather than a user profile that was never applied
+  if has_the_server_refused_fan_control; then
+    CURRENT_FAN_CONTROL_PROFILE="Dell default dynamic fan control profile (refused)"
+    return 1
+  fi
   # Use ipmitool to send the raw command to set fan control to user-specified value.
   # Same reasoning as apply_Dell_default_fan_control_profile: only surface stderr if the command
   # actually failed, instead of always discarding it (this profile changes real fan speed)
@@ -43,18 +59,33 @@ function apply_user_fan_control_profile() {
   # drive -- so either failure means the profile was not applied
   local ipmitool_stderr
   local IS_PROFILE_APPLIED=true
+  # What the server answered to the command that takes the fans, kept until both commands have run so
+  # that the verdict below is drawn after everything this cycle had to say, rather than between two
+  # error lines it would then look like it did not cover
+  local MANUAL_FAN_CONTROL_STDERR=""
 
   ipmitool_stderr=$(ipmitool -I $IDRAC_LOGIN_STRING raw 0x30 0x30 0x01 0x00 2>&1 >/dev/null)
   # shellcheck disable=SC2181  # $? here is the command substitution above, already run; there is no direct command left to negate
   if [ $? -ne 0 ]; then
     print_error "Failed to enable manual fan control. ipmitool said: $ipmitool_stderr"
+    MANUAL_FAN_CONTROL_STDERR="$ipmitool_stderr"
     IS_PROFILE_APPLIED=false
+  else
+    HAS_FAN_CONTROL_EVER_BEEN_ACCEPTED=true
   fi
   ipmitool_stderr=$(ipmitool -I $IDRAC_LOGIN_STRING raw 0x30 0x30 0x02 0xff $HEXADECIMAL_FAN_SPEED 2>&1 >/dev/null)
   # shellcheck disable=SC2181  # $? here is the command substitution above, already run; there is no direct command left to negate
   if [ $? -ne 0 ]; then
     print_error "Failed to set fan speed to $DECIMAL_FAN_SPEED%. ipmitool said: $ipmitool_stderr"
     IS_PROFILE_APPLIED=false
+  fi
+
+  # Only the first of the two commands can settle whether this server lets its fans be taken at all.
+  # The speed command runs on fans the controller already holds, so its refusal is a failure to obey and
+  # not a refusal to hand anything over : concluding from it would stop the controller from ever giving
+  # back fans it had already taken, which is the one outcome that leaves them pinned with nobody watching
+  if [ -n "$MANUAL_FAN_CONTROL_STDERR" ]; then
+    note_that_the_server_refuses_fan_control "$MANUAL_FAN_CONTROL_STDERR"
   fi
 
   if ! $IS_PROFILE_APPLIED; then
@@ -1342,6 +1373,51 @@ function does_the_command_need_a_higher_privilege_level() {
   [[ "$IPMITOOL_STDERR" == *"rsp=0xd4"* ]]
 }
 
+# Whether this server has been seen to refuse fan control outright, in which case the controller stops
+# sending it. The fan control profile functions at the top of this file are the ones that stop on it ;
+# graceful_exit() and fan_control_comment_clause() only read it to word what they report.
+# Usage : has_the_server_refused_fan_control
+#
+# The default matters, and the supervisor is why. functions.sh is also sourced by the healthcheck, which
+# sends no fan control command at all, by the test harness, and by supervisor.sh, which sends exactly one
+# -- the hand-back of apply_Dell_default_fan_control_profile(), on the path issues #188 and #249 exist
+# for -- from a process that never watched a single answer and therefore never reached a verdict. Left
+# undefined there, the guard would read empty and the safety net would skip the one command it exists to
+# send. Nowhere the verdict was never made can be a place where it was made against the server
+function has_the_server_refused_fan_control() {
+  ! "${IS_FAN_CONTROL_SUPPORTED:-true}"
+}
+
+# Read a refused fan control command and, if the server itself refused it, record that it is not worth
+# sending again and say so once.
+# Usage : note_that_the_server_refuses_fan_control "$IPMITOOL_STDERR"
+# Returns : IS_FAN_CONTROL_SUPPORTED, and 0 if the verdict was reached on this call
+#
+# Two conditions, and the second is the one that keeps this safe. A refusal only settles anything while
+# nothing has ever been accepted : once a fan control command has landed, the fans are the controller's
+# and a later refusal is a failure to give them back rather than a server that never let them go. Giving
+# up there would leave them pinned at the user's speed with nobody raising them, which is the accident
+# this whole container exists to avoid
+function note_that_the_server_refuses_fan_control() {
+  local -r IPMITOOL_STDERR="$1"
+
+  if "${HAS_FAN_CONTROL_EVER_BEEN_ACCEPTED:-false}"; then
+    return 1
+  fi
+
+  if ! does_the_server_lack_this_command "$IPMITOOL_STDERR" && ! does_the_command_need_a_higher_privilege_level "$IPMITOOL_STDERR"; then
+    return 1
+  fi
+
+  IS_FAN_CONTROL_SUPPORTED=false
+
+  print_warning "This server refused fan control, so the container will stop asking and keep reading temperatures instead.
+ Its fans are not left in an unknown state : the command that was refused is the one that takes them away from Dell's own dynamic fan control profile, so they never left it.
+ Two things answer like this, and the completion code does not say which. Dell removed these commands from the 14th generation on -- an iDRAC 9 refuses them from firmware 3.34.34.34 onwards, and an iDRAC 10 has never had them -- and an iDRAC also refuses them to an account that is not an Administrator. This iDRAC reports firmware version ${IDRAC_FIRMWARE_VERSION:-unknown}.
+ If your iDRAC is one that used to accept them, check the privilege level of IDRAC_USERNAME before concluding that the firmware is the reason. The README's \"iDRAC version\" section covers both.
+ Nothing else changes : temperatures keep being read and logged every cycle, as MONITORING_ONLY_MODE would"
+}
+
 # Prepare traps in case of container exit
 function graceful_exit() {
   if "$MONITORING_ONLY_MODE"; then
@@ -1358,6 +1434,13 @@ function graceful_exit() {
   # nothing; a setting left behind on a server nothing is monitoring any more does
   if ! "$KEEP_THIRD_PARTY_PCIE_CARD_COOLING_RESPONSE_STATE_ON_EXIT"; then
     enable_third_party_PCIe_card_Dell_default_cooling_response
+  fi
+
+  # Nothing was handed back on a server that never let anything be taken, and saying otherwise would be
+  # the same lie as naming a profile the server is not running. The verdict itself only holds while no
+  # fan control command has ever been accepted, so there is no state left behind for this line to hide
+  if has_the_server_refused_fan_control; then
+    print_warning_and_exit "Container stopped (this server refused fan control, so no profile was ever applied and its fans never left Dell's own dynamic fan control profile)"
   fi
 
   print_warning_and_exit "Container stopped, Dell default dynamic fan control profile applied for safety"
@@ -1447,6 +1530,40 @@ container again. Alternatively, set IDRAC_HOST to your iDRAC's address to use ne
   # through. It is also the escalation MAXIMUM_IPMI_UNREACHABLE_DURATION relies on once the loop is
   # running, and the README already tells its readers to run under a restart policy because of it
   print_configuration_error_and_exit "IDRAC_HOST / IDRAC_USERNAME / IDRAC_PASSWORD" "$IDRAC_HOST" "credentials that can open an IPMI session. $IPMITOOL_REPORT" "" "false"
+}
+
+# Read the firmware version the iDRAC reports about itself, for the startup log.
+# Usage : get_iDRAC_firmware_version
+# Returns : IDRAC_FIRMWARE_VERSION, or "unknown" when the iDRAC reported none
+#
+# Also helps debugging when people are posting their output : the firmware version is the first thing
+# asked for on every report about fan control not being applied, and it was the one thing about the
+# server this container never printed.
+#
+# "ipmitool mc info" reports two numbers where Dell's own firmware bundles carry four -- an iDRAC 9 on
+# 6.10.30.00 answers "6.10" -- and that is a property of IPMI rather than of Dell : the Get Device ID
+# response spends one byte on the major version and one on the minor one, and leaves the rest to a
+# vendor-specific auxiliary field this does not try to decode. Two numbers are enough for what this is
+# for, which is a log line a human reads, and the exact build is one "racadm getversion" away for
+# anyone who needs it.
+#
+# /!\ What it is NOT for is deciding whether this server accepts fan control. Nothing here compares the
+# version against 3.34.34.34, because the numbering restarted at 1.x with the iDRAC 10 of the 17th
+# generation : every comparison that reads "below 3.34.34.34, so the commands are there" calls the
+# newest hardware Dell makes the oldest. The controller settles that question the way it settles every
+# other one, by sending the command and reading the answer
+function get_iDRAC_firmware_version() {
+  local IPMI_MC_INFO
+  # stderr is discarded : this is a read-only diagnostic call, some iDRAC firmwares print a harmless
+  # protocol warning on every call, and a version that could not be read is reported as unknown rather
+  # than turned into an error. Nothing the controller does depends on it
+  IPMI_MC_INFO=$(ipmitool -I $IDRAC_LOGIN_STRING mc info 2>/dev/null)
+
+  IDRAC_FIRMWARE_VERSION=$(echo "$IPMI_MC_INFO" | grep -m 1 "Firmware Revision" | awk -F ':' '{print $2}' | tr -d '[:space:]')
+
+  if [ -z "$IDRAC_FIRMWARE_VERSION" ]; then
+    IDRAC_FIRMWARE_VERSION="unknown"
+  fi
 }
 
 # Settle the width of the "Active fan speed profile" column, which the header and the rows both lay
@@ -1684,6 +1801,25 @@ function join_with_and() {
   echo "$result"
 }
 
+# The clause a comment ends on, naming what the controller did about the fans.
+# Usage : fan_control_comment_clause "$WHAT_THE_CONTROLLER_ASKED_FOR"
+#
+# The comment column explains a profile change, and on a server that refused fan control there is none
+# to explain : the fans have been Dell's own since before the container started and no command of its
+# own reached them. The reason the profile would have changed is still worth printing -- a hot CPU is
+# news whoever drives the fans -- so only the half of the sentence that names an applied profile is
+# replaced, rather than the whole comment being dropped
+function fan_control_comment_clause() {
+  local -r APPLIED_CLAUSE="$1"
+
+  if has_the_server_refused_fan_control; then
+    echo "and this server refused fan control, so its fans stay Dell's own to drive"
+    return
+  fi
+
+  echo "$APPLIED_CLAUSE"
+}
+
 # Build the comment explaining why the Dell default fan control profile was applied.
 # Usage : build_fan_control_fallback_comment $CPU_NAME $CPU_TEMPERATURE [$CPU_NAME $CPU_TEMPERATURE]...
 #
@@ -1717,7 +1853,10 @@ function build_fan_control_fallback_comment() {
     reasons+=("$(join_with_and "${unreadable[@]}") temperatures could not be read")
   fi
 
-  echo "$(join_with_and "${reasons[@]}"), Dell default dynamic fan control profile applied for safety"
+  local FAN_CONTROL_CLAUSE
+  FAN_CONTROL_CLAUSE=$(fan_control_comment_clause "Dell default dynamic fan control profile applied for safety")
+
+  echo "$(join_with_and "${reasons[@]}"), $FAN_CONTROL_CLAUSE"
 }
 
 # Stop the container on an invalid configuration parameter, with everything needed to fix it

--- a/tests/README.md
+++ b/tests/README.md
@@ -38,10 +38,11 @@ It exits `0` when every test case passed, `1` otherwise.
 | `cases/30_idrac_login_string.sh` | Local (`/dev/ipmi0`) and network (`lanplus`) modes, password handling |
 | `cases/35_message_output.sh` | How error and warning messages reach the log, read at their junction with the line that follows |
 | `cases/40_temperature_parsing.sh` | Reading the sensors out of `ipmitool sdr type temperature` |
+| `cases/45_idrac_firmware_version.sh` | Reading the iDRAC's own firmware version out of `ipmitool mc info`, and never turning it into a verdict about fan control |
 | `cases/50_server_model_detection.sh` | Reading the manufacturer and model out of the FRU inventory, and refusing to run on an unreachable iDRAC |
 | `cases/55_enclosure_housed_servers.sh` | Blades and modular servers, whose fans belong to their enclosure |
 | `cases/60_cpu_topologies.sh` | 1, 2 and 4 socket servers, missing sensors, table layout |
-| `cases/70_fan_control_profiles.sh` | The raw commands sent to the server, and their rejections |
+| `cases/70_fan_control_profiles.sh` | The raw commands sent to the server, what their rejections mean, and the one refusal that must never stop the controller from trying again |
 | `cases/80_temperature_thresholds.sh` | The overheating decision, including its fail-safe behavior |
 | `cases/85_power_state.sh` | Skipping the cycle when the target server is powered off |
 | `cases/90_integration.sh` | The whole controller, started like its Docker image does |

--- a/tests/cases/45_idrac_firmware_version.sh
+++ b/tests/cases/45_idrac_firmware_version.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+# The firmware version the iDRAC reports about itself, read from "ipmitool mc info"
+# and printed once at startup.
+#
+# It is the first thing asked for on every report about fan control not being
+# applied, and the container used to print everything about the server except it.
+#
+# What it is NOT is a way to decide whether this server accepts fan control : the
+# numbering restarted at 1.x with the iDRAC 10 of the 17th generation, so every
+# comparison against 3.34.34.34 calls the newest hardware Dell makes the oldest.
+# That question is settled by sending the command and reading the answer, and
+# test_a_recent_firmware_version_is_never_turned_into_a_verdict below pins it.
+
+function test_the_firmware_version_the_idrac_reports_is_read() {
+  export MOCK_IPMITOOL_MC_INFO_OUTPUT
+  MOCK_IPMITOOL_MC_INFO_OUTPUT=$(make_mc_info_output --firmware-revision "2.86")
+
+  get_iDRAC_firmware_version
+
+  assert_equals "2.86" "$IDRAC_FIRMWARE_VERSION"
+}
+
+function test_the_firmware_version_is_read_from_every_generation_of_idrac() {
+  # The two numbers "ipmitool mc info" reports for the firmwares this container
+  # meets : an iDRAC 6 to 8 on the generations where the raw commands work, an
+  # iDRAC 9 on both sides of the 3.34.34.34 boundary, and the iDRAC 10 whose
+  # numbering starts over at 1.x
+  local FIRMWARE_REVISION
+  for FIRMWARE_REVISION in "1.66" "2.86" "3.21" "3.30" "3.34" "6.10" "7.00" "1.30"; do
+    export MOCK_IPMITOOL_MC_INFO_OUTPUT
+    MOCK_IPMITOOL_MC_INFO_OUTPUT=$(make_mc_info_output --firmware-revision "$FIRMWARE_REVISION")
+
+    get_iDRAC_firmware_version
+
+    assert_equals "$FIRMWARE_REVISION" "$IDRAC_FIRMWARE_VERSION" \
+      "firmware $FIRMWARE_REVISION should be read exactly as the iDRAC reports it"
+  done
+}
+
+function test_the_auxiliary_revision_bytes_are_not_mistaken_for_the_version() {
+  # "ipmitool mc info" ends on the vendor-specific auxiliary firmware revision,
+  # printed as four hexadecimal bytes on four lines of their own. They hold the
+  # two numbers the version line drops, undecoded, and a parse that read one line
+  # too far would report "0x00" as the firmware version
+  export MOCK_IPMITOOL_MC_INFO_OUTPUT
+  MOCK_IPMITOOL_MC_INFO_OUTPUT=$(make_mc_info_output --firmware-revision "6.10")
+
+  get_iDRAC_firmware_version
+
+  assert_equals "6.10" "$IDRAC_FIRMWARE_VERSION"
+  assert_not_contains "$IDRAC_FIRMWARE_VERSION" "0x" \
+    "the auxiliary revision bytes are not the firmware version"
+}
+
+function test_an_idrac_that_reports_no_firmware_version_is_reported_as_unknown() {
+  # Nothing the controller does depends on this value, so a BMC that does not
+  # report one is logged as unknown rather than treated as a failure
+  export MOCK_IPMITOOL_MC_INFO_OUTPUT
+  MOCK_IPMITOOL_MC_INFO_OUTPUT=$(make_mc_info_output --no-firmware-revision)
+
+  get_iDRAC_firmware_version
+
+  assert_equals "unknown" "$IDRAC_FIRMWARE_VERSION"
+}
+
+function test_an_idrac_that_answers_nothing_at_all_is_reported_as_unknown() {
+  # The controller is already running against this iDRAC by the time this is
+  # asked -- the server was identified from its FRU inventory two calls earlier --
+  # so a failed call here is a curiosity, not a reason to refuse to start
+  export MOCK_IPMITOOL_MC_INFO_OUTPUT=""
+  export MOCK_IPMITOOL_MC_INFO_EXIT_CODE=1
+
+  assert_command_succeeds "an unanswered mc info must not fail the caller" get_iDRAC_firmware_version
+  assert_equals "unknown" "$IDRAC_FIRMWARE_VERSION"
+}
+
+function test_the_firmware_noise_some_idracs_print_is_not_read_as_a_version() {
+  # Some iDRAC firmwares print a protocol warning on stderr on every single call,
+  # even when the call succeeds. It is discarded here rather than parsed
+  export MOCK_IPMITOOL_MC_INFO_OUTPUT
+  MOCK_IPMITOOL_MC_INFO_OUTPUT=$(make_mc_info_output --firmware-revision "2.65")
+  export MOCK_IPMITOOL_MC_INFO_STDERR="Received an Unexpected message with sequence number 12"
+
+  capture_output get_iDRAC_firmware_version
+
+  assert_equals "2.65" "$IDRAC_FIRMWARE_VERSION"
+  assert_empty "$CAPTURED_OUTPUT" "the protocol warning must not reach the log through this call"
+}

--- a/tests/cases/55_enclosure_housed_servers.sh
+++ b/tests/cases/55_enclosure_housed_servers.sh
@@ -116,10 +116,15 @@ function test_every_enclosure_housed_server_reports_its_rejected_fan_control_com
     get_Dell_server_model
     assert_equals "$MODEL" "$SERVER_MODEL" "$MODEL should be identified"
 
+    # A refusal settles the question for the rest of a container's life, and each of the two calls
+    # below stands for the cycle that reached the command first, on another server. So the verdict is
+    # reset before each of them rather than letting one model, or one code path, answer for the others
+    IS_FAN_CONTROL_SUPPORTED=true
     capture_output apply_Dell_default_fan_control_profile
     assert_contains "$CAPTURED_OUTPUT" "Failed to apply Dell default fan control profile" \
       "$MODEL should report the rejected safety profile"
 
+    IS_FAN_CONTROL_SUPPORTED=true
     capture_output apply_user_fan_control_profile
     assert_contains "$CAPTURED_OUTPUT" "Failed to enable manual fan control" \
       "$MODEL should report the rejected user profile"
@@ -156,10 +161,13 @@ function test_the_controller_keeps_monitoring_a_server_it_cannot_cool() {
   done
 }
 
-function test_an_overheating_blade_still_falls_back_on_dells_profile() {
-  # The fallback is a request the CMC is free to refuse, but the controller must
-  # still make it, and say so : that log line is what tells the user their blade
-  # is hot and that nothing this container does will cool it
+function test_an_overheating_blade_is_reported_although_nothing_here_can_cool_it() {
+  # The fallback is a request the CMC refuses, and it refuses it identically on
+  # every cycle : the controller asks once, is told the command is not there, and
+  # from then on says why rather than repeating the same failure forever.
+  # What must survive that is the news itself -- this blade is hot and nothing
+  # this container does will cool it -- which is the whole reason the comment is
+  # printed at all
   simulate_enclosure_housed_server "PowerEdge M640" --cpus 2 --cpu-temperatures "42 44"
   export MOCK_IPMITOOL_SDR_SECOND_OUTPUT
   MOCK_IPMITOOL_SDR_SECOND_OUTPUT=$(make_sdr_output --cpus 2 --cpu-temperatures "42 79" --no-exhaust)
@@ -167,13 +175,16 @@ function test_an_overheating_blade_still_falls_back_on_dells_profile() {
 
   local -r OUTPUT=$(run_controller "temperature is too high")
 
-  assert_contains "$OUTPUT" "CPU 2 temperature is too high, Dell default dynamic fan control profile applied for safety"
-  assert_contains "$OUTPUT" "Failed to apply Dell default fan control profile"
-  if [ "$(count_ipmitool_calls_matching "raw 0x30 0x30 0x01 0x01")" -ge 1 ]; then
-    pass
-  else
-    fail "the overheating blade should have been sent Dell's dynamic fan control profile"
-  fi
+  assert_contains "$OUTPUT" "CPU 2 temperature is too high, and this server refused fan control" \
+    "the hot CPU must still be named, and the comment must not claim a profile the CMC never applied"
+  assert_contains "$OUTPUT" "This server refused fan control" \
+    "the refusal must be explained once, in full"
+  assert_contains "$OUTPUT" "Failed to enable manual fan control" \
+    "the answer the blade actually gave must be quoted before any conclusion is drawn from it"
+  assert_equals "1" "$(count_ipmitool_calls_matching "raw 0x30 0x30 0x01 0x00")" \
+    "the command is sent once and not on every cycle afterwards"
+  assert_equals "0" "$(count_ipmitool_calls_matching "raw 0x30 0x30 0x01 0x01")" \
+    "there is nothing to hand back to Dell on fans this container was never given"
 }
 
 function test_aiming_the_controller_at_the_enclosure_instead_of_a_blade_fails_safe() {

--- a/tests/cases/60_cpu_topologies.sh
+++ b/tests/cases/60_cpu_topologies.sh
@@ -609,6 +609,10 @@ function test_no_fan_control_profile_can_outgrow_the_column_reserved_for_it() {
   # Leaving it out is how #170's overflow came back : the column was still sized on the bare name while
   # the rows had started printing 14 characters more into it
   local -r NOT_APPLIED_BADGE=" (not applied)"
+  # And once the server has been seen to refuse fan control outright, the controller stops sending
+  # anything and reports the profile the server is actually running -- Dell's own, whatever profile was
+  # asked for -- with the reason it is that one. Another string the code really produces
+  local -r REFUSED_BADGE=" (refused)"
   local SPEED PROFILE VARIANT
   local IS_MONITORING_ONLY_MODE
 
@@ -630,6 +634,12 @@ function test_no_fan_control_profile_can_outgrow_the_column_reserved_for_it() {
         VARIANTS=("$PROFILE$MONITORING_ONLY_MODE_BADGE")
       else
         VARIANTS=("$PROFILE" "$PROFILE$NOT_APPLIED_BADGE")
+        # The refused form only ever carries Dell's own profile name : nothing is sent any more, so the
+        # user profile is not what the server is running and naming it would be the lie the badge exists
+        # to stop. Monitoring only mode reaches no verdict at all, having sent nothing to be refused
+        if [ "$PROFILE" == "Dell default dynamic fan control profile" ]; then
+          VARIANTS+=("$PROFILE$REFUSED_BADGE")
+        fi
       fi
 
       for VARIANT in "${VARIANTS[@]}"; do

--- a/tests/cases/70_fan_control_profiles.sh
+++ b/tests/cases/70_fan_control_profiles.sh
@@ -19,6 +19,10 @@ readonly REJECTED_BY_FIRMWARE_STDERR="Unable to send RAW command (channel=0x0 ne
 
 # What a BMC answers when the command exists but the account may not run it. Reported on an R550 in
 # issue #29, where every raw command answered "Insufficient privilege level"
+# The same answer on a fan control command, which is what an iDRAC 9 running firmware 3.34.34.34 or
+# newer gives : Dell removed a privilege there rather than a command
+readonly FAN_CONTROL_REFUSED_FOR_PRIVILEGE_STDERR="Unable to send RAW command (channel=0x0 netfn=0x30 lun=0x0 cmd=0x30 rsp=0xd4): Insufficient privilege level"
+
 readonly REFUSED_FOR_PRIVILEGE_STDERR="Unable to send RAW command (channel=0x0 netfn=0x30 lun=0x0 cmd=0xce rsp=0xd4): Insufficient privilege level"
 
 function test_the_user_fan_control_profile_enables_manual_control_then_sets_the_speed() {
@@ -128,10 +132,15 @@ function test_every_recent_generation_that_rejects_the_commands_is_reported_the_
     get_Dell_server_model
     assert_equals "$MODEL" "$SERVER_MODEL" "$MODEL should be identified"
 
+    # A refusal settles the question for the rest of a container's life, and each of the two calls
+    # below stands for the cycle that reached the command first, on another server. So the verdict is
+    # reset before each of them rather than letting one model, or one code path, answer for the others
+    IS_FAN_CONTROL_SUPPORTED=true
     capture_output apply_Dell_default_fan_control_profile
     assert_contains "$CAPTURED_OUTPUT" "Failed to apply Dell default fan control profile" \
       "$MODEL should report the rejected safety profile"
 
+    IS_FAN_CONTROL_SUPPORTED=true
     capture_output apply_user_fan_control_profile
     assert_contains "$CAPTURED_OUTPUT" "Failed to enable manual fan control" \
       "$MODEL should report the rejected user profile"
@@ -301,4 +310,156 @@ function test_an_applied_profile_still_reports_itself_as_applied() {
 
   assert_equals "0" "$EXIT_CODE"
   assert_equals "User static fan control profile (5%)" "$CURRENT_FAN_CONTROL_PROFILE"
+}
+
+function test_every_other_answer_a_bmc_can_give_settles_nothing() {
+  # test_a_privilege_refusal_is_told_apart_from_a_command_the_server_does_not_have above covers 0xc1,
+  # 0xd4 and an iDRAC that was never reached. This covers the rest of what comes back : the second
+  # code that does settle something, and the ones that must never be allowed to. A busy BMC, a code
+  # neither predicate knows and an empty answer are not a server refusing anything, and concluding
+  # from them would silence the fan control commands for good over a network glitch
+  assert_command_succeeds "0xd5 is the server saying it will not run the command in this state" \
+    does_the_server_lack_this_command "$REJECTED_BY_FIRMWARE_STDERR"
+  assert_command_fails "0xd5 is not a privilege problem either" \
+    does_the_command_need_a_higher_privilege_level "$REJECTED_BY_FIRMWARE_STDERR"
+
+  local ANSWER
+  for ANSWER in \
+    "Unable to send RAW command (channel=0x0 netfn=0x30 lun=0x0 cmd=0x30 rsp=0xc0): Node busy" \
+    "Unable to send RAW command (channel=0x0 netfn=0x30 lun=0x0 cmd=0x30 rsp=0xff): Unspecified error" \
+    ""; do
+    assert_command_fails "\"$ANSWER\" does not say the command is absent" \
+      does_the_server_lack_this_command "$ANSWER"
+    assert_command_fails "\"$ANSWER\" does not say the account may not run it" \
+      does_the_command_need_a_higher_privilege_level "$ANSWER"
+  done
+}
+
+function test_a_server_that_refused_fan_control_is_not_asked_again() {
+  # The defect this closes : the same two commands were sent, and the same two
+  # errors printed, on every cycle for the life of the container -- twelve times a
+  # minute at the default check interval, on a server that answered the first time
+  export MOCK_IPMITOOL_RAW_FAIL_PATTERN="0x30 0x30"
+  export MOCK_IPMITOOL_RAW_FAIL_STDERR="$REJECTED_BY_FIRMWARE_STDERR"
+
+  capture_output apply_user_fan_control_profile
+  assert_contains "$CAPTURED_OUTPUT" "This server refused fan control" \
+    "the verdict must be explained the once it is reached"
+
+  forget_recorded_ipmitool_calls
+  capture_output apply_user_fan_control_profile
+
+  assert_equals "0" "$(count_ipmitool_calls_matching "raw 0x30 0x30")" \
+    "not a single command must be sent on the cycles that follow"
+  assert_empty "$CAPTURED_OUTPUT" "nor a single line printed"
+  assert_equals "Dell default dynamic fan control profile (refused)" "$CURRENT_FAN_CONTROL_PROFILE" \
+    "the table must name the profile the server is actually running, and say why it is that one"
+}
+
+function test_a_server_that_refuses_the_safety_profile_is_not_asked_again() {
+  # The same verdict, reached through the other door. The overheating branch of
+  # the monitoring loop only ever calls this function, so a server that is
+  # already too hot on the cycle it starts on reaches the verdict here and
+  # nowhere else -- and would otherwise keep being asked, and keep refusing,
+  # for as long as it stayed hot
+  export MOCK_IPMITOOL_RAW_FAIL_PATTERN="0x30 0x30"
+  export MOCK_IPMITOOL_RAW_FAIL_STDERR="$REJECTED_BY_FIRMWARE_STDERR"
+
+  capture_output apply_Dell_default_fan_control_profile
+  assert_contains "$CAPTURED_OUTPUT" "This server refused fan control" \
+    "the verdict must be reached on the path the overheating branch takes too"
+
+  forget_recorded_ipmitool_calls
+  capture_output apply_Dell_default_fan_control_profile
+
+  assert_equals "0" "$(count_ipmitool_calls_matching "raw 0x30 0x30")" \
+    "not a single command must be sent on the cycles that follow"
+  assert_empty "$CAPTURED_OUTPUT" "nor a single line printed"
+  assert_equals "Dell default dynamic fan control profile (refused)" "$CURRENT_FAN_CONTROL_PROFILE"
+}
+
+function test_a_forbidden_fan_control_command_settles_it_too() {
+  # 0xd4 rather than 0xd5 : the answer of an iDRAC 9 on 3.34.34.34 or newer, and
+  # the one this container will meet most often from now on
+  export MOCK_IPMITOOL_RAW_FAIL_PATTERN="0x30 0x30"
+  export MOCK_IPMITOOL_RAW_FAIL_STDERR="$FAN_CONTROL_REFUSED_FOR_PRIVILEGE_STDERR"
+
+  capture_output apply_user_fan_control_profile
+
+  assert_contains "$CAPTURED_OUTPUT" "This server refused fan control"
+  assert_contains "$CAPTURED_OUTPUT" "not an Administrator" \
+    "0xd4 has two causes and only one of them is the firmware, so both must be named"
+
+  forget_recorded_ipmitool_calls
+  apply_user_fan_control_profile 2>/dev/null
+
+  assert_equals "0" "$(count_ipmitool_calls_matching "raw 0x30 0x30")"
+}
+
+function test_an_unreachable_idrac_never_stops_the_controller_from_trying() {
+  # No completion code at all : the BMC was never reached, and an outage that
+  # silenced the fan control commands for good would leave the fans wherever they
+  # were with nobody raising them once it ended
+  export MOCK_IPMITOOL_RAW_FAIL_PATTERN="0x30 0x30"
+  export MOCK_IPMITOOL_RAW_FAIL_STDERR="Error: Unable to establish IPMI v2 / RMCP+ session"
+
+  apply_user_fan_control_profile 2>/dev/null
+  forget_recorded_ipmitool_calls
+  apply_user_fan_control_profile 2>/dev/null
+
+  assert_equals "1" "$(count_ipmitool_calls_matching "raw 0x30 0x30 0x01 0x00")" \
+    "the controller must keep asking an iDRAC it merely could not reach"
+  assert_equals "1" "$(count_ipmitool_calls_matching "raw 0x30 0x30 0x02")"
+}
+
+function test_a_refused_fan_speed_never_stops_the_controller_from_trying() {
+  # The one refusal that must never settle anything. Manual fan control was taken
+  # successfully, so the fans are the controller's : giving up here would leave
+  # them pinned at a speed nothing raises, on a server that is heating up. Only
+  # the command that takes them away from Dell's profile can settle whether this
+  # server hands them over at all
+  export MOCK_IPMITOOL_RAW_FAIL_PATTERN="0x30 0x30 0x02"
+  export MOCK_IPMITOOL_RAW_FAIL_STDERR="$FAN_CONTROL_REFUSED_FOR_PRIVILEGE_STDERR"
+
+  apply_user_fan_control_profile 2>/dev/null
+  forget_recorded_ipmitool_calls
+  apply_user_fan_control_profile 2>/dev/null
+
+  assert_equals "1" "$(count_ipmitool_calls_matching "raw 0x30 0x30 0x01 0x00")" \
+    "the fans are already the controller's, it must keep driving them"
+  assert_equals "1" "$(count_ipmitool_calls_matching "raw 0x30 0x30 0x02")"
+}
+
+function test_a_refusal_that_follows_an_accepted_command_never_settles_anything() {
+  # The same hazard from the other end : a server that accepted the commands and
+  # starts refusing them mid-run holds fans the controller took. Every refusal
+  # from then on is a failure to give them back, and each retry is another attempt
+  # to -- so the controller keeps asking, however long it takes
+  apply_user_fan_control_profile
+  assert_equals "User static fan control profile (5%)" "$CURRENT_FAN_CONTROL_PROFILE" \
+    "the fans must have been taken for this test to mean anything"
+
+  export MOCK_IPMITOOL_RAW_FAIL_PATTERN="0x30 0x30"
+  export MOCK_IPMITOOL_RAW_FAIL_STDERR="$REJECTED_BY_FIRMWARE_STDERR"
+  apply_Dell_default_fan_control_profile 2>/dev/null
+
+  forget_recorded_ipmitool_calls
+  apply_Dell_default_fan_control_profile 2>/dev/null
+
+  assert_equals "1" "$(count_ipmitool_calls_matching "raw 0x30 0x30 0x01 0x01")" \
+    "handing the fans back must be retried for as long as the container runs"
+}
+
+function test_monitoring_only_mode_reaches_no_verdict_because_it_asks_nothing() {
+  # Nothing is sent in this mode, so nothing can be refused : the badge must stay
+  # the monitoring only one rather than become a refusal the server never uttered
+  export MONITORING_ONLY_MODE=true
+  export MOCK_IPMITOOL_RAW_FAIL_PATTERN="0x30 0x30"
+  export MOCK_IPMITOOL_RAW_FAIL_STDERR="$REJECTED_BY_FIRMWARE_STDERR"
+
+  apply_user_fan_control_profile
+  apply_user_fan_control_profile
+
+  assert_contains "$CURRENT_FAN_CONTROL_PROFILE" "monitoring only, not applied"
+  assert_equals "0" "$(count_ipmitool_calls_matching "raw 0x30 0x30")"
 }

--- a/tests/cases/70_fan_control_profiles.sh
+++ b/tests/cases/70_fan_control_profiles.sh
@@ -2,8 +2,10 @@
 
 # The commands actually sent to the server, and what happens when the server
 # refuses them - which is the normal situation on an iDRAC 9 running firmware
-# 3.30.30.30 or newer (Gen 15, 16) and on the iDRAC 10 of a Gen 17 server, where
-# Dell removed the IPMI raw fan control commands altogether.
+# 3.34.34.34 or newer (Gen 15, 16) and on the iDRAC 10 of a Gen 17 server, where
+# Dell removed the IPMI raw fan control commands altogether. 3.30.30.30 is the
+# newest firmware they are confirmed to still work on, and what the two releases
+# between the two, 3.31.31.31 and 3.32.32.32, answer has never been reported.
 #
 # Applying a fan control profile is the one thing the controller exists for, so
 # a silent failure here is the worst possible outcome : the user believes their
@@ -14,7 +16,7 @@ readonly FAN_SPEED_COMMAND="raw 0x30 0x30 0x02 0xff"
 readonly DELL_DEFAULT_FAN_CONTROL_COMMAND="raw 0x30 0x30 0x01 0x01"
 readonly THIRD_PARTY_PCIE_CARD_COMMAND="raw 0x30 0xce 0x00 0x16 0x05"
 
-# What an iDRAC 9 running firmware >= 3.30.30.30 answers to a fan control command
+# What an iDRAC 9 running firmware >= 3.34.34.34 answers to a fan control command
 readonly REJECTED_BY_FIRMWARE_STDERR="Unable to send RAW command (channel=0x0 netfn=0x30 lun=0x0 cmd=0x30 rsp=0xd5): Command not supported in present state"
 
 # What a BMC answers when the command exists but the account may not run it. Reported on an R550 in
@@ -76,7 +78,7 @@ function test_harmless_firmware_noise_is_not_reported_when_the_command_succeeds(
 }
 
 function test_a_rejected_manual_fan_control_command_is_reported() {
-  # A Gen 15/16/17 server, or a Gen 14 whose firmware was updated past 3.30.30.30
+  # A Gen 15/16/17 server, or a Gen 14 whose firmware was updated to 3.34.34.34 or newer
   export MOCK_IPMITOOL_RAW_FAIL_PATTERN="0x30 0x30 0x01 0x00"
   export MOCK_IPMITOOL_RAW_FAIL_STDERR="$REJECTED_BY_FIRMWARE_STDERR"
 

--- a/tests/cases/90_integration.sh
+++ b/tests/cases/90_integration.sh
@@ -569,3 +569,88 @@ function test_an_unreachable_idrac_does_not_open_the_cpu_removal_window() {
   assert_not_contains "$OUTPUT" "considered removed" \
     "no CPU may be dropped : the server never powered off, so none can have left"
 }
+
+function test_the_controller_logs_the_firmware_version_of_the_idrac_it_talks_to() {
+  # The line every report about fan control not being applied starts by asking
+  # for, printed next to the model it belongs with
+  simulate_server "PowerEdge R640" --cpus 2 --cpu-temperatures "40 41"
+  export MOCK_IPMITOOL_MC_INFO_OUTPUT
+  MOCK_IPMITOOL_MC_INFO_OUTPUT=$(make_mc_info_output --firmware-revision "3.21")
+
+  local -r OUTPUT=$(run_controller)
+
+  assert_contains "$OUTPUT" "Server model: DELL PowerEdge R640"
+  assert_contains "$OUTPUT" "iDRAC firmware version: 3.21"
+  assert_equals "1" "$(count_ipmitool_calls_matching "mc info")" \
+    "the iDRAC is asked once at startup, not on every cycle"
+}
+
+function test_a_recent_firmware_version_is_never_turned_into_a_verdict() {
+  # The trap this pins shut : an iDRAC 10 reports 1.x, an iDRAC 9 that removed the
+  # commands reports 7.00, and both are "below 3.34.34.34" or "above" it depending
+  # only on which of the two numbering schemes you assume. So the version is
+  # logged and nothing else -- a server whose BMC accepts the commands is driven
+  # whatever it calls its firmware
+  simulate_server "PowerEdge R760" --cpus 2 --cpu-temperatures "40 41"
+  export MOCK_IPMITOOL_MC_INFO_OUTPUT
+  MOCK_IPMITOOL_MC_INFO_OUTPUT=$(make_mc_info_output --firmware-revision "7.00")
+
+  local -r OUTPUT=$(run_controller)
+
+  assert_contains "$OUTPUT" "iDRAC firmware version: 7.00"
+  assert_contains "$OUTPUT" "User static fan control profile (5%)" \
+    "the fans must be driven on a server that accepts the commands, whatever its firmware says"
+  assert_equals "1" "$(count_ipmitool_calls_matching "raw 0x30 0x30 0x01 0x00")" \
+    "the version must not gate the command"
+  assert_not_contains "$OUTPUT" "This server refused fan control" \
+    "nothing was refused here"
+}
+
+function test_the_controller_says_once_that_the_server_refuses_fan_control() {
+  # A Gen 14 server on a firmware from which Dell removed the commands. Before
+  # this, the controller printed the same two errors on every cycle for the life
+  # of the container ; now it explains it once and keeps doing the half of its job
+  # that is still possible
+  simulate_server "PowerEdge R740" --cpus 2 --cpu-temperatures "45 46"
+  export MOCK_IPMITOOL_MC_INFO_OUTPUT
+  MOCK_IPMITOOL_MC_INFO_OUTPUT=$(make_mc_info_output --firmware-revision "7.00")
+  export MOCK_IPMITOOL_RAW_FAIL_PATTERN="0x30 0x30"
+  export MOCK_IPMITOOL_RAW_FAIL_STDERR="Unable to send RAW command (channel=0x0 netfn=0x30 lun=0x0 cmd=0x30 rsp=0xd4): Insufficient privilege level"
+
+  # Well past the cycle the verdict is reached on, so anything still being re-sent
+  # or re-printed shows up
+  local -r OUTPUT=$(run_controller "$CONTROLLER_TEMPERATURE_LINE_PATTERN" 5)
+
+  assert_equals "1" "$(count_ipmitool_calls_matching "raw 0x30 0x30 0x01 0x00")" \
+    "the command must be sent once and never again"
+  assert_equals "1" "$(grep -c "This server refused fan control" <<< "$OUTPUT")" \
+    "and explained once, not on every cycle"
+  assert_equals "1" "$(grep -c "Failed to enable manual fan control" <<< "$OUTPUT")" \
+    "the answer it was refused with is quoted once too"
+  assert_contains "$OUTPUT" "firmware version 7.00" \
+    "the explanation must carry the firmware version, it is what the reader will be asked for"
+  assert_contains "$OUTPUT" "45°C" "the temperatures must still be read and logged"
+  assert_matches "$OUTPUT" "Dell default dynamic fan control profile \(refused\)" \
+    "the table must name the profile the server is running, and say why it is that one"
+  assert_contains "$OUTPUT" "are now OK (<= 50°C), and this server refused fan control" \
+    "the comment must not claim a user profile this server refused to hand its fans over for"
+}
+
+function test_a_server_that_refuses_fan_control_is_not_told_it_was_handed_anything_back() {
+  # graceful_exit's line is the last thing in the log, and on this server it used
+  # to claim a profile had been applied for safety while the command it names was
+  # refused. Nothing was ever taken from Dell here, so nothing is given back
+  simulate_server "PowerEdge R750" --cpus 2 --cpu-temperatures "44 45"
+  export MOCK_IPMITOOL_RAW_FAIL_PATTERN="0x30 0x30"
+  export MOCK_IPMITOOL_RAW_FAIL_STDERR="Unable to send RAW command (channel=0x0 netfn=0x30 lun=0x0 cmd=0x30 rsp=0xd5): Command not supported in present state"
+
+  local -r OUTPUT=$(run_controller)
+
+  assert_contains "$OUTPUT" "Container stopped (this server refused fan control" \
+    "the exit line must say what actually happened"
+  assert_not_contains "$OUTPUT" "Dell default dynamic fan control profile applied for safety" \
+    "nothing was applied for safety, and claiming it is the one lie that matters here"
+  assert_equals "0" "$(count_ipmitool_calls_matching "raw 0x30 0x30 0x01 0x01")" \
+    "there is nothing to hand back"
+}
+

--- a/tests/lib/dell_server_catalogue.sh
+++ b/tests/lib/dell_server_catalogue.sh
@@ -9,7 +9,7 @@
 #   3. maximum number of CPU sockets of that model
 #   4. whether Dell's IPMI raw fan control commands work on that server :
 #        supported          - iDRAC 6/7/8, the raw commands work
-#        firmware-dependent - iDRAC 9, works below firmware 3.30.30.30 only
+#        firmware-dependent - iDRAC 9, works up to firmware 3.30.30.30 only
 #        unsupported        - iDRAC 9 (recent firmware) / iDRAC 10, the raw
 #                             commands are rejected by the BMC
 #        chassis-managed    - the server carries no fan of its own : they belong

--- a/tests/lib/fixtures.sh
+++ b/tests/lib/fixtures.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
-# Builders for the two ipmitool outputs the controller parses: the FRU inventory
-# ("ipmitool fru", used to identify the server) and the temperature sensor
-# records ("ipmitool sdr type temperature").
+# Builders for the ipmitool outputs the controller parses: the FRU inventory
+# ("ipmitool fru", used to identify the server), the controller's own description
+# ("ipmitool mc info", used to log the iDRAC firmware version) and the temperature
+# sensor records ("ipmitool sdr type temperature").
 #
 # Both are generated rather than stored as flat files because the interesting
 # dimension is combinatorial: every generation from 9 to 17, in 1, 2 and 4 CPU
@@ -145,6 +146,55 @@ function simulate_partially_readable_fru_inventory() {
   MOCK_IPMITOOL_FRU_OUTPUT="$(make_fru_output --with-unreadable-devices "$@")"
   MOCK_IPMITOOL_FRU_STDERR="$UNREADABLE_FRU_DEVICES_STDERR"
   MOCK_IPMITOOL_FRU_EXIT_CODE=1
+}
+
+# Build an "ipmitool mc info" output, the one the iDRAC's own firmware version is read from
+# Usage : make_mc_info_output [--firmware-revision VERSION] [--no-firmware-revision]
+#
+# --firmware-revision takes the two numbers the command reports, not the four a Dell firmware bundle is
+# named after : an iDRAC 9 on 6.10.30.00 answers "6.10", the IPMI Get Device ID response having one byte
+# for the major version and one for the minor one. The remaining two live in the vendor-specific
+# auxiliary field reproduced below, undecoded, exactly as ipmitool prints it -- one hex byte per line,
+# which is also what makes it a line the version parser must not pick up
+#
+# --no-firmware-revision drops the line entirely, for the BMCs that report none
+function make_mc_info_output() {
+  local FIRMWARE_REVISION="2.86"
+  local WITH_FIRMWARE_REVISION=true
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --firmware-revision) FIRMWARE_REVISION="$2"; shift 2 ;;
+      --no-firmware-revision) WITH_FIRMWARE_REVISION=false; shift ;;
+      *) printf 'make_mc_info_output: unknown option "%s"\n' "$1" >&2; return 1 ;;
+    esac
+  done
+
+  printf 'Device ID                 : 32\n'
+  printf 'Device Revision           : 1\n'
+  if $WITH_FIRMWARE_REVISION; then
+    printf 'Firmware Revision         : %s\n' "$FIRMWARE_REVISION"
+  fi
+  printf 'IPMI Version              : 2.0\n'
+  printf 'Manufacturer ID           : 674\n'
+  printf 'Manufacturer Name         : DELL Inc\n'
+  printf 'Product ID                : 256 (0x0100)\n'
+  printf 'Product Name              : Unknown (0x100)\n'
+  printf 'Device Available          : yes\n'
+  printf 'Provides Device SDRs      : yes\n'
+  printf 'Additional Device Support :\n'
+  printf '    Sensor Device\n'
+  printf '    SDR Repository Device\n'
+  printf '    SEL Device\n'
+  printf '    FRU Inventory Device\n'
+  printf '    IPMB Event Receiver\n'
+  printf '    IPMB Event Generator\n'
+  printf '    Chassis Device\n'
+  printf 'Aux Firmware Rev Info     : \n'
+  printf '    0x00\n'
+  printf '    0x1d\n'
+  printf '    0x1e\n'
+  printf '    0x00\n'
 }
 
 # Build a single "ipmitool sdr type temperature" line

--- a/tests/lib/harness.sh
+++ b/tests/lib/harness.sh
@@ -35,6 +35,10 @@ function setup_test_context() {
   CONTROLLER_WORKING_DIRECTORY="$REPO_ROOT"
   # Set before the trap by the controller, so graceful_exit can read it whenever a signal lands
   IS_THIRD_PARTY_PCIE_CARD_COOLING_RESPONSE_SUPPORTED=true
+  # Same, for the fan control commands : a test starts against a server that has refused nothing and
+  # accepted nothing, which is what the controller starts from too
+  IS_FAN_CONTROL_SUPPORTED=true
+  HAS_FAN_CONTROL_EVER_BEEN_ACCEPTED=false
   # Settled once at startup by the controller, and read by build_header() and by every row it prints
   resolve_fan_control_profile_column_width
 
@@ -45,6 +49,8 @@ function setup_test_context() {
   MOCK_IPMITOOL_FRU_OUTPUT="$(make_fru_output)"
   export MOCK_IPMITOOL_SDR_OUTPUT
   MOCK_IPMITOOL_SDR_OUTPUT="$(make_sdr_output)"
+  export MOCK_IPMITOOL_MC_INFO_OUTPUT
+  MOCK_IPMITOOL_MC_INFO_OUTPUT="$(make_mc_info_output)"
   export MOCK_IPMITOOL_POWER_STATUS="Chassis Power is on"
   export MOCK_SENSORS_CALL_LOG="$TEST_TEMPORARY_DIRECTORY/sensors_calls.log"
   : > "$MOCK_SENSORS_CALL_LOG"

--- a/tests/mocks/ipmitool
+++ b/tests/mocks/ipmitool
@@ -67,7 +67,7 @@
 #                                  MOCK_IPMITOOL_RAW_FAIL_STDERR /
 #                                  MOCK_IPMITOOL_RAW_FAIL_EXIT_CODE. This is how
 #                                  a specific command is made to fail (an iDRAC 9
-#                                  firmware >= 3.30.30.30 rejecting 0x30 0x30, or
+#                                  firmware >= 3.34.34.34 rejecting 0x30 0x30, or
 #                                  a Gen 14+ server rejecting 0x30 0xce) while
 #                                  the others keep succeeding
 

--- a/tests/mocks/ipmitool
+++ b/tests/mocks/ipmitool
@@ -22,6 +22,14 @@
 #                                  is the partial failure of a healthy server whose
 #                                  empty bays answer "Device not present", and it comes
 #                                  with a non-zero MOCK_IPMITOOL_FRU_EXIT_CODE
+#   MOCK_IPMITOOL_MC_INFO_OUTPUT   stdout of "ipmitool mc info", where the iDRAC
+#                                  describes itself and reports its firmware version
+#   MOCK_IPMITOOL_MC_INFO_STDERR   stderr of the same command, for the firmwares
+#                                  that print a protocol warning on every call
+#   MOCK_IPMITOOL_MC_INFO_EXIT_CODE  its exit code (default 0). A non-zero one with
+#                                  no output is an iDRAC that never answered, which
+#                                  must leave the version unknown rather than stop
+#                                  the controller
 #   MOCK_IPMITOOL_SDR_OUTPUT       stdout of "ipmitool sdr type temperature"
 #   MOCK_IPMITOOL_SDR_STDERR       stderr of the same command (firmware noise)
 #   MOCK_IPMITOOL_SDR_EXIT_CODE    its exit code (default 0)
@@ -103,6 +111,16 @@ case "$SUB_COMMAND" in
       exit "${MOCK_IPMITOOL_FRU_EXIT_CODE}"
     fi
     printf '%s\n' "${MOCK_IPMITOOL_FRU_OUTPUT:-}"
+    ;;
+
+  mc)
+    if [ -n "${MOCK_IPMITOOL_MC_INFO_STDERR:-}" ]; then
+      printf '%s\n' "$MOCK_IPMITOOL_MC_INFO_STDERR" >&2
+    fi
+    if [ -n "${MOCK_IPMITOOL_MC_INFO_OUTPUT:-}" ]; then
+      printf '%s\n' "$MOCK_IPMITOOL_MC_INFO_OUTPUT"
+    fi
+    exit "${MOCK_IPMITOOL_MC_INFO_EXIT_CODE:-0}"
     ;;
 
   sdr)


### PR DESCRIPTION
Closes #346. Closes #347. Closes #348.

Came out of the iDRAC 9 compatibility question raised in [#263 (comment)](https://github.com/tigerblue77/Dell_iDRAC_fan_controller_Docker/issues/263#issuecomment-5244599846) — *"I think they may have brought IPMI access back in a later iDRAC version"*. They did not. IPMI over LAN never left, and is still there on the iDRAC 10 of the 17th generation ; what left, at iDRAC 9 firmware `3.34.34.34`, is the **privilege** to run the fan control commands. Reading Dell's KBs to settle that turned up three things this repository was getting wrong, and this is them.

> [!NOTE]
> Rebased onto `a47ceae`. #340 landed `rsp=0xd4` while this branch was being written, and the two could not see each other : everything this had for the **cooling response** command is dropped in favour of master's, which is better named and better worded. What remains of it here is the half #340 did not cover — `0xd4` on the **fan control** commands — and it now goes through master's `does_the_command_need_a_higher_privilege_level()`. #349 is closed as a duplicate of #339.

## What a refusing server looked like

Both blocks below are captures, not illustrations : same mocked R740 answering `rsp=0xd4` to `raw 0x30 0x30`, run through the suite's own harness, once against `a47ceae` and once against this branch.

**Before** — the same two errors on every cycle, for the life of the container, and an exit line claiming the profile it had just been refused :

```
/!\ Error /!\ Failed to enable manual fan control. ipmitool said: [...] rsp=0xd4): Insufficient privilege level.
/!\ Error /!\ Failed to set fan speed to 5%. ipmitool said: [...] rsp=0xd4): Insufficient privilege level.
10-08-2026 23:50:16   23°C   45°C   46°C     34°C      User static fan control profile (5%) (not applied)     Enabled  All CPU temperatures are now OK (<= 50°C), user's fan control profile applied.
/!\ Error /!\ Failed to enable manual fan control. ipmitool said: [...] rsp=0xd4): Insufficient privilege level.
/!\ Error /!\ Failed to set fan speed to 5%. ipmitool said: [...] rsp=0xd4): Insufficient privilege level.
10-08-2026 23:50:17   23°C   45°C   46°C     34°C      User static fan control profile (5%) (not applied)     Enabled   -
/!\ Error /!\ Failed to enable manual fan control. ipmitool said: [...] rsp=0xd4): Insufficient privilege level.
/!\ Error /!\ Failed to set fan speed to 5%. ipmitool said: [...] rsp=0xd4): Insufficient privilege level.
10-08-2026 23:50:17   23°C   45°C   46°C     34°C      User static fan control profile (5%) (not applied)     Enabled   -
/!\ Error /!\ Failed to apply Dell default fan control profile. ipmitool said: [...] rsp=0xd4): Insufficient privilege level.
/!\ Warning /!\ Container stopped, Dell default dynamic fan control profile applied for safety. Exiting.
```

At the default `CHECK_INTERVAL=5` that is two error lines every five seconds : about 34 000 a day.

**After** — the answer is read once, and the container keeps doing the half of its job that is still possible :

```
Server model: DELL PowerEdge R740
iDRAC/IPMI host: 192.168.1.100
iDRAC firmware version: 7.00
[...]
/!\ Error /!\ Failed to enable manual fan control. ipmitool said: [...] rsp=0xd4): Insufficient privilege level.
/!\ Error /!\ Failed to set fan speed to 5%. ipmitool said: [...] rsp=0xd4): Insufficient privilege level.
/!\ Warning /!\ This server refused fan control, so the container will stop asking and keep reading temperatures instead.
 Its fans are not left in an unknown state : the command that was refused is the one that takes them away from Dell's own dynamic fan control profile, so they never left it.
 Two things answer like this, and the completion code does not say which. Dell removed these commands from the 14th generation on -- an iDRAC 9 refuses them from firmware 3.34.34.34 onwards, and an iDRAC 10 has never had them -- and an iDRAC also refuses them to an account that is not an Administrator. This iDRAC reports firmware version 7.00.
 If your iDRAC is one that used to accept them, check the privilege level of IDRAC_USERNAME before concluding that the firmware is the reason. The README's "iDRAC version" section covers both.
 Nothing else changes : temperatures keep being read and logged every cycle, as MONITORING_ONLY_MODE would.
                     ------- Temperatures -------
    Date & time      Inlet  CPU 1  CPU 2  Exhaust                 Active fan speed profile                 Third-party PCIe card Dell default cooling response  Comment
10-08-2026 23:49:53   23°C   45°C   46°C     34°C      User static fan control profile (5%) (not applied)                                              Enabled  All CPU temperatures are now OK (<= 50°C), and this server refused fan control, so its fans stay Dell's own to drive.
10-08-2026 23:49:53   23°C   45°C   46°C     34°C      Dell default dynamic fan control profile (refused)                                              Enabled   -
/!\ Warning /!\ Container stopped (this server refused fan control, so no profile was ever applied and its fans never left Dell's own dynamic fan control profile). Exiting.
```

The first row is the cycle the verdict is reached on — the commands were really sent, and really refused, so the table says the user profile was not applied. From the second row on, nothing is sent : the column names the profile the server is actually running and why it is that one, and the comment stops claiming a profile was applied.

## Commits

| Commit | What |
|---|---|
| `8c12547` | The behaviour : the verdict, the two guards that keep it safe, the firmware version line, and every string that stopped being true once the controller knows it is not driving anything |
| `d8fe624` | The documentation : the firmware boundary, the downgrade that is no longer possible, the privilege level, and the five comments in `tests/` repeating the old boundary |

## The two rules that keep the verdict safe

This is the part worth reviewing hardest, because "stop retrying" is a hazard if it is done naively.

1. **Only the command that takes the fans can settle anything.** `raw 0x30 0x30 0x01 0x0X` is the one that takes fan control from Dell's profile or gives it back ; `raw 0x30 0x30 0x02` runs on fans the controller *already holds*, so its refusal is a failure to obey, not a refusal to hand anything over. Concluding from it would stop the controller from ever giving back fans it had taken.
2. **A refusal settles nothing once anything has been accepted.** `HAS_FAN_CONTROL_EVER_BEEN_ACCEPTED` guards it. From the moment a fan control command has landed, the fans are the controller's, every later refusal is a failure to *give them back*, and each retry is another attempt to — so the controller keeps asking, for as long as the container runs.

Consequences, stated so they can be checked rather than trusted :

- an unreachable iDRAC prints no completion code, so it never reaches a verdict, however long the outage lasts (`test_an_unreachable_idrac_never_stops_the_controller_from_trying`) ;
- the supervisor is a different process and never observes an answer, so `has_the_server_refused_fan_control` defaults to "not refused" there : its SIGKILL-path hand-back (#188, #249) is sent exactly as before, which `test_a_monitoring_process_killed_by_the_signal_gets_the_fans_handed_back_for_it` and `test_a_wedged_monitoring_process_is_killed_and_the_fans_handed_back` still pin ;
- `MONITORING_ONLY_MODE` sends nothing, so it can reach no verdict and keeps its own badge (`test_monitoring_only_mode_reaches_no_verdict_because_it_asks_nothing`).

## Why the firmware version is logged and never read

`ipmitool mc info` gives two numbers where Dell's bundles carry four — `6.10` for `6.10.30.00` — because the IPMI `Get Device ID` response spends one byte on the major version and one on the minor. That is enough for the log line every bug report starts from, and #263 currently collects by hand.

Nothing compares it against `3.34.34.34`, and `test_a_recent_firmware_version_is_never_turned_into_a_verdict` holds that shut : **the numbering restarted at `1.x` with the iDRAC 10**, so any such test would classify the newest hardware Dell makes as the oldest. The question is settled the way #195 settled the cooling response one — by sending the command and reading the answer.

## The documentation

- `< 3.30.30.30` → **up to `3.30.30.30`** works, **from `3.34.34.34`** refuses, with `3.31.31.31` and `3.32.32.32` named as never reported rather than silently assumed ;
- the downgrade the old sentence implied is a one-way door since June 2024 ([KB 000225924](https://www.dell.com/support/kbdoc/en-us/000225924/rac0181-idrac9-firmware-downgrade-failures-on-14-15g-poweredge-servers)), and Dell says the job can report success while the Lifecycle Log records `RAC0181` ;
- the iDRAC account has to be an **Administrator**, which was documented nowhere and is indistinguishable from unsupported hardware from the outside ;
- a troubleshooting entry reading the container's own refusal message, which is where the long form of all three lives — that section never reaches the Docker Hub page, so it costs nothing there.

## Tests

`390 → 408` cases, `2060 → 2126` assertions, measured on `a47ceae` and on this branch.

| Where | What is pinned |
|---|---|
| `tests/cases/45_idrac_firmware_version.sh` *(new)* | The version is read for every iDRAC generation ; the auxiliary revision bytes are not mistaken for it ; a BMC that reports none, or answers nothing, leaves it `unknown` instead of stopping the controller |
| `tests/cases/70_fan_control_profiles.sh` | The verdict reached through **both** profile functions ; the three answers that must never settle anything — an unreachable iDRAC, a refused speed command, a refusal following an acceptance ; and the completion codes #340's own case does not walk (`0xd5`, `0xc0`, an unknown code, an empty answer) |
| `tests/cases/90_integration.sh` | The whole controller against a refusing server : asked once, explained once, temperatures still logged, exit line honest, and a `7.00` firmware still being driven when the BMC accepts |
| `tests/cases/60_cpu_topologies.sh` | The new `(refused)` badge declared to the column guard #345 tightened, so the profile column stays exactly as wide as its widest producible string |
| `tests/cases/55_enclosure_housed_servers.sh` | A blade is still reported as hot although nothing here can cool it, and is asked once rather than every cycle |

## Verification

- **Suite green : 408 cases, 2126 assertions**, on the runner and **inside the built Docker image** — both jobs of the `Tests` workflow passed on `edafe95`, the commit this one only amends a comment and a commit message over.
- **`shellcheck -x` exits 0** on the five shipped scripts, and the `Shellcheck` workflow agrees.
- **No case passes vacuously.** Reverting `functions.sh` and `Dell_iDRAC_fan_controller.sh` to `a47ceae` while keeping the tests fails **14** cases. Targeted mutations were run individually and each is killed : dropping the verdict from `apply_Dell_default_fan_control_profile`, dropping it from `apply_user_fan_control_profile`, and reverting the three comment-column call sites.

## The Docker Hub page is at its ceiling, and that is worth knowing

Not caused by this branch, but this branch is what made it visible. The page is rendered from this README by dropping whole sections from the end until it fits in 25 000 characters :

| | Rendered | Last section that fits | Headroom |
|---|---|---|---|
| `a47ceae` alone | 24 849 | `Stopping the container` | **151** characters |
| this branch | 24 351 | `Parameters` | 649 characters |

`Stopping the container` now falls off the page and into the footer link list. It is not one of the four sections `13_dockerhub_description.sh` requires to survive — `Requirements`, `Supported architectures`, `Usage`, `Parameters` are all still there — but it used to be on that page and now is not, so it is said here rather than left to be noticed.

The new prose was cut to 1 548 characters and everything that could move went to `Troubleshooting`, which is dropped long before the cut. What that buys is 649 characters instead of master's 151, and the next drop after that one is `Parameters`, which fails the suite. The real fix is a decision about the page itself — the four `docker run` / `docker-compose` blocks in `Usage` are ~9 000 characters of near-duplicates — and it is not this pull request's to make.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DeUE63BGiummXRm2R7Rg11