### PR TITLE
Lint the three scripts under .github/ too, and keep the list from falling behind (#351)

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,9 +1,17 @@
 name: Shellcheck
 
-# Scoped to the 5 scripts actually shipped in the Docker image, not the tests/ tree : those are the ones
-# a finding here can affect at runtime, on real hardware. -x resolves the "source functions.sh" /
-# "source constants.sh" lines so shared declarations are understood correctly instead of reported as
-# unknown or unused when the sourcing file is linted on its own.
+# Scoped to the scripts nothing else would catch a mistake in, which is two groups and not one.
+#
+# The 5 shipped in the Docker image, because a finding there affects runtime, on real hardware. And the 3
+# under .github/, because they decide what gets published - which version "latest" points at, whether a
+# release note is written, what the Docker Hub page says - and the first time any of them runs is on the
+# tag or the push that publishes it. Neither of the workflows carrying them fires on a pull request.
+#
+# The tests/ tree stays out for the reason those three do not have : the suite runs on every pull request,
+# so a mistake in it is found the moment it is pushed rather than at release time.
+#
+# -x resolves the "source functions.sh" / "source constants.sh" lines so shared declarations are understood
+# correctly instead of reported as unknown or unused when the sourcing file is linted on its own.
 #
 # See .shellcheckrc for the two codes disabled project-wide, and the "shellcheck disable" comments at the
 # handful of call sites where a warning is intentional rather than fixed.
@@ -33,4 +41,7 @@ jobs:
             functions.sh \
             constants.sh \
             healthcheck.sh \
-            supervisor.sh
+            supervisor.sh \
+            .github/generate_dockerhub_description.sh \
+            .github/reconcile_latest_tag.sh \
+            .github/release_note_already_exists.sh

--- a/tests/cases/10_shell_scripts.sh
+++ b/tests/cases/10_shell_scripts.sh
@@ -24,6 +24,39 @@ function test_every_shell_script_has_a_valid_syntax() {
   done
 }
 
+function test_the_shellcheck_workflow_lints_every_script_it_is_scoped_to() {
+  local -r SHELLCHECK_WORKFLOW="$REPO_ROOT/.github/workflows/shellcheck.yml"
+
+  if [ ! -f "$SHELLCHECK_WORKFLOW" ]; then
+    # The suite is running inside the built image, which does not carry the
+    # workflows that built it
+    skip_test "no .github/workflows next to the scripts"
+    return 0
+  fi
+
+  # That workflow names its scripts one by one rather than globbing them, which
+  # is what lets it leave the tests/ tree out - and what let two scripts added
+  # to .github/ afterwards stay out of it for months without a word. The list is
+  # hand-maintained, so it is worth a guard : nothing else lints these files.
+  # "bash -n" above is a syntax check and the suite invokes shellcheck nowhere,
+  # so a script missing from that list is analysed by nothing at all, and the
+  # ones under .github/ run first on the tag or the push that publishes
+  local -r LINTED_SCRIPTS="$(sed -n 's/^ *\([A-Za-z0-9_./-]*\.sh\) *\\\{0,1\}$/\1/p' "$SHELLCHECK_WORKFLOW")"
+
+  local SCRIPT RELATIVE_PATH
+  for SCRIPT in "$REPO_ROOT"/*.sh "$REPO_ROOT"/.github/*.sh; do
+    [ -f "$SCRIPT" ] || continue
+
+    RELATIVE_PATH="${SCRIPT#$REPO_ROOT/}"
+    if printf '%s\n' "$LINTED_SCRIPTS" | grep -qxF "$RELATIVE_PATH"; then
+      pass
+    else
+      fail "$RELATIVE_PATH is linted by nothing, the Shellcheck workflow does not name it" \
+        "it checks : $(printf '%s' "$LINTED_SCRIPTS" | tr '\n' ' ')"
+    fi
+  done
+}
+
 function test_no_statement_expands_two_command_substitutions() {
   # Bash re-parses the text of every $( ) at expansion time, and it runs pending
   # trap handlers from inside that same reader loop. A SIGTERM landing there gets


### PR DESCRIPTION
Closes #351.

## What was unlinted

`.github/workflows/shellcheck.yml` names the files it checks one by one, and the list is the five scripts shipped in the Docker image. Three are missing, and nothing else covers them — `cases/10_shell_scripts.sh` runs `bash -n` over `.github/*.sh`, which is a syntax check, and the suite invokes shellcheck nowhere at all.

| Script | Runs on | On a pull request? |
| --- | --- | :-: |
| `.github/release_note_already_exists.sh` | a version tag push, or a re-fire from the Actions tab | **no** |
| `.github/reconcile_latest_tag.sh` | same | **no** |
| `.github/generate_dockerhub_description.sh` | a push to `master` touching `README.md`, the renderer, or its own workflow | **no** |

Neither workflow declares a `pull_request` trigger — the one occurrence of the string in the release workflow is inside a comment.

## Why the scoping needed extending rather than replacing

The workflow's stated reason for excluding `tests/` still holds, and it is not the one written down: the suite runs on **every** pull request, so a mistake in it is found the moment it is pushed. That is exactly what the three scripts above do not have. They carry decisions rather than assertions — which version `latest` points at, whether a release note is written, what the Docker Hub page says — and the first time any of them runs is on the tag or the push that publishes.

It is the same blind spot `cases/12_github_workflows.sh` opens with: *"A mistake in either is found at release time, or the morning after, by which point it has already cost a release or a night's rebuild."* Two of the three scripts did not exist when the shellcheck list was written; it simply had not caught up.

The comment above the list now gives both reasons, so the next reader knows why `tests/` is out and `.github/` is in.

## No backlog to work through

All three are already clean. Running the exact command the workflow will now run:

```
$ shellcheck -x Dell_iDRAC_fan_controller.sh functions.sh constants.sh healthcheck.sh supervisor.sh \
    .github/generate_dockerhub_description.sh .github/reconcile_latest_tag.sh .github/release_note_already_exists.sh
$ echo $?
0
```

So this buys coverage from here on rather than a cleanup, and the first run is green.

## Keeping the list from falling behind again

The list is hand-maintained, which is what let it go stale. `test_the_shellcheck_workflow_lints_every_script_it_is_scoped_to` now reads the script paths back out of the workflow and asserts that every `*.sh` at the repository root and under `.github/` is named there — 8 assertions today, one per script. A script that escapes the linter is caught by the run that adds it rather than by the release that runs it.

Mutation-checked both ways: removing a script from the workflow's list turns it red, and adding a new `.github/*.sh` that nobody listed turns it red.

It skips inside the Docker image, which carries the shipped scripts but not the `.github` directory, the same way the other workflow-reading cases do.

## One thing deliberately not changed

The job's `name: Lint the shipped scripts` is now slightly narrow, and I left it alone on purpose: a required status check is matched **by name**, so renaming it would leave every later pull request waiting on a check that never reports. Worth renaming in a separate change if you know no branch protection references it.

Full suite: **391 test cases, 2068 assertions, green.**

---
_Generated by [Claude Code](https://claude.ai/code/session_01VpagBdyUd6zugCL1opzhs3)_