### PR TITLE
Stop the release note from holding the "latest" reconciliation hostage

### DIFF
--- a/.github/workflows/build_and_publish_docker_image.yml
+++ b/.github/workflows/build_and_publish_docker_image.yml
@@ -412,7 +412,17 @@ jobs:
       # answer that no longer depends on when it is asked : concurrent releases
       # reaching this step agree, and whichever writes last writes the same
       # thing. See .github/reconcile_latest_tag.sh
+      #
+      # Guarded so that a failure above cannot withhold it. The ordering serves
+      # the release note ; it must not hand it a veto. A run that dies writing
+      # the announcement leaves "latest" wherever the racing pushes put it, on a
+      # version whose image did go out -- the state #325 was filed for, reached
+      # through another door. Running this after a failed build is safe by
+      # construction : the script walks the versions the registry actually
+      # serves, so a release that never pushed is not a candidate, and it writes
+      # nothing when the tag already agrees
       - name: Point "latest" at the highest published version
+        if: ${{ !cancelled() }}
         run: |
           set -euo pipefail
           IMAGE="${{ steps.docker_image_name.outputs.value }}"

--- a/tests/cases/12_github_workflows.sh
+++ b/tests/cases/12_github_workflows.sh
@@ -6,6 +6,35 @@
 # after, by which point it has already cost a release or a night's rebuild.
 # This is where they get read anyway.
 
+function test_the_latest_reconciliation_survives_a_failure_above_it() {
+  # It is placed after the release note so that a registry hiccup in it cannot
+  # withhold the announcement of a version whose image did go out. Without a
+  # guard the ordering also hands the release note a veto : a run that dies
+  # writing the announcement skips the reconciliation and leaves "latest"
+  # wherever the racing pushes put it, which is the state issue #325 was filed
+  # for, reached through another door (issue #355).
+  #
+  # Running it after a failure is safe by construction -- the script walks the
+  # versions the registry actually serves, so a release that never pushed is not
+  # a candidate -- so the guard costs nothing and closes the window
+  local -r RELEASE_WORKFLOW="$REPO_ROOT/.github/workflows/build_and_publish_docker_image.yml"
+  if [ ! -f "$RELEASE_WORKFLOW" ]; then
+    skip_test "no .github/workflows next to the scripts"
+    return 0
+  fi
+
+  # The two lines of the step, in order : its name, then whatever follows before
+  # the next key. A guard placed anywhere else in the file would not apply to it
+  local -r GUARD_AFTER_THE_STEP=$(awk '
+    /- name: Point "latest" at the highest published version/ { found = 1; next }
+    found && /^ *if:/ { print; exit }
+    found && /^ *- name:/ { exit }
+  ' "$RELEASE_WORKFLOW")
+
+  assert_contains "$GUARD_AFTER_THE_STEP" "cancelled()" \
+    "the latest reconciliation has to run even when a step above it failed"
+}
+
 function test_no_docker_action_list_entry_ends_with_a_comment() {
   # docker/metadata-action reads its multi-line inputs with a CSV parser it asks
   # to treat "#" as a comment. Up to v5 that stripped a "#" found anywhere on the


### PR DESCRIPTION
Closes #355.

`Point "latest" at the highest published version` carried no `if:`, so it ran only when every step before it had succeeded. The comment above it explains the ordering — the release note first, so that a registry hiccup in the reconciliation cannot withhold the announcement of a version whose image did go out.

Sound, but the converse came with it: **a failed announcement withheld the reconciliation.** A run dying in `Generate release note`, or in the step that decides whether the note already exists, left `latest` wherever the racing pushes put it — the state #325 was filed for, reached through another door.

```diff
       - name: Point "latest" at the highest published version
+        if: ${{ !cancelled() }}
         run: |
```

`!cancelled()` is the guard this repository already uses for work that has to happen whatever went wrong above it (`tests.yml` and `base_image_refresh.yml`, on their artefact uploads).

## Why running it after a failure is safe

By construction rather than by luck. `reconcile_latest_tag.sh` walks the versions the **registry** actually serves, refuses to move `latest` backwards, and writes nothing when the tag already agrees. A release whose push failed is not published, so it is not a candidate and the script does nothing new — it is the same read-only pass an ordinary release already costs.

## Test

One case in `12_github_workflows.sh`, the file that exists because these two workflows are the only ones no pull request ever runs.

It reads the guard **off the step itself** — `awk` from the step's `name:` to the next key — rather than grepping the file for `cancelled()`. A guard placed on any other step would satisfy a file-wide grep while leaving this one exposed, which is exactly the regression worth catching.

## Verification

- **Suite green: 392 cases, 2069 assertions** (391 / 2068 on `master` at `5334a20`).
- **Mutation-tested**: with the workflow reverted and the test kept, the case fails; restored, it passes.
- YAML re-parsed after the edit.
- No shell script touched, nothing in the built image changes.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DhruzPPRcWf5sp8VsPSve3

---
_Generated by [Claude Code](https://claude.ai/code/session_01DhruzPPRcWf5sp8VsPSve3)_