### PR TITLE
Name the lint job for the scripts it actually checks (#354)

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   shellcheck:
-    name: Lint the shipped scripts
+    name: Lint the shell scripts
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:


### PR DESCRIPTION
Closes #354.

One line: `name: Lint the shipped scripts` → `name: Lint the shell scripts`. Nothing else, in any file.

Since #352 that job checks eight scripts — the five shipped in the Docker image and the three under `.github/` — and its name is the string every pull request shows as the check name. A reader who trusts it concludes `reconcile_latest_tag.sh`, `release_note_already_exists.sh` and `generate_dockerhub_description.sh` are linted by nothing, which is the belief that let them go unlinted until #351.

> [!IMPORTANT]
> **This pull request cannot merge on its own, and that is expected, not a failure.** It needs one ruleset edit, in the order below. Read this before clicking anything.

## Why it blocks itself

#352 left the name alone deliberately and said so. That reason has now been checked rather than assumed: the **Protect master branch** ruleset requires this check under its **old** name, and its **bypass list is empty**.

A required status check is matched by the job's `name:` and nothing else — *"Workflow: the name format is &lt;job name&gt;. Required status checks do not take workflow, matrix, or event trigger types into account."* ([troubleshooting rules][rules])

On this pull request the workflow runs from the PR's own merge commit, so it reports **`Lint the shell scripts`** (green) and `Lint the shipped scripts` is never created on that SHA. A required check with no check run is not ignored — GitHub's *About status checks* page defines that state as `expected`, *"the check run is waiting for a status to be reported"*, and a required check sitting there blocks the merge. With nobody on the bypass list, not even an administrator can merge past it. The ruleset does not protect itself: the only exit is a settings edit.

Note the contrast that makes this counter-intuitive — a **skipped** job reports success and never blocks; a **renamed** job creates its check run under a different name, so the required name has no check run at all. Opposite outcomes.

## The order to do it in

1. **Leave this pull request alone until its checks finish.** `Lint the shell scripts` then exists, green, and GitHub will offer it in the ruleset picker instead of making you type a name it has never seen — a required check *"must have completed successfully in the chosen repository during the past seven days"*.
2. **Edit the ruleset once**: in *Settings → Rules → Protect master branch → Require status checks to pass*, **remove** `Lint the shipped scripts` **and add** `Lint the shell scripts` in the same form, then save. One save is one atomic update — the required set never passes through a state where lint is unenforced.
3. **Merge this pull request.** It is mergeable the moment the rule changes: the green check run already exists on its head commit.
4. **Nothing to do for the other open pull requests.** Strict mode plus `auto_update_pull_request_branches.yml` will update them onto the renamed workflow, after which they report the new name. It has already done exactly that to this branch twice while the pull request was open.

The only window is between steps 2 and 3, where every pull request is blocked for the seconds it takes to click Merge. That is the safe direction to fail in, and it is unavoidable in any correct ordering.

**Do not add the new name before merging** — the two names would both be required, no branch in the repository could satisfy both, and nothing at all could merge, including this. **Do not remove the old name and merge later either** — that leaves a window with no lint requirement, and `dependabot-auto-merge.yml` runs `gh pr merge --auto`, which would merge minor and patch updates lint-free, unattended, inside it.

## Blast radius

Before this change the old name appeared **exactly once in the repository**, at its own definition in `.github/workflows/shellcheck.yml`; after it, the new name appears exactly once in the same place. Nothing else reads it: no other workflow waits on it, the only `workflow_run` in the repository points at `Tests` and not at Shellcheck, no documentation or badge names it, and the `check_name:` keys in `tests.yml` and `test-results.yml` both belong to the unrelated `Test results` check.

The suite is **blind** to the job name. Run on this branch's head with the new name and again with the old one restored, it produces **410 test cases, 2135 assertions** either way, and the two outputs are byte-identical (`md5 37efb576aafd7807705a6701fad00036` both times). That is why this had to be read off the ruleset rather than tested, and it is worth knowing that no future rename of a required check will be caught locally either.

[rules]: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/troubleshooting-rules