### PR TITLE
Say how close the Docker Hub page is to dropping a section it needs

### DIFF
--- a/tests/cases/13_dockerhub_description.sh
+++ b/tests/cases/13_dockerhub_description.sh
@@ -18,6 +18,25 @@ readonly DOCKERHUB_DESCRIPTION_REPOSITORY_URL="https://github.com/$DOCKERHUB_DES
 # its own constant should fail here, not agree with itself
 readonly DOCKERHUB_DESCRIPTION_SIZE_LIMIT=25000
 
+# How close the page may come to losing its next section before this suite says
+# so. The renderer never overflows : it drops whole sections from the end until
+# what is left fits, so the room measured here is not room before a broken page
+# but room before the next section leaves it. Once the section next in line is
+# one the page cannot do without, that distance is the only warning there is.
+#
+# 500 is chosen against what documentation changes to this README actually
+# weigh, not against the limit : of the thirteen that touched it before this
+# guard was written, eleven added more than 500 characters and the median added
+# about 1 500. So this fires while there is still less than a third of an
+# ordinary paragraph in hand -- deliberately, because by then the next edit is
+# what removes the section rather than what is warned about
+readonly DOCKERHUB_DESCRIPTION_MINIMUM_HEADROOM=500
+
+# The sections the page is worth publishing only while it still holds them,
+# named once here and asserted by two cases : the one that checks they are on
+# the page, and the one that checks the page is not about to lose one
+readonly DOCKERHUB_DESCRIPTION_REQUIRED_SECTIONS=("Requirements" "Supported architectures" "Usage" "Parameters")
+
 readonly DOCKERHUB_DESCRIPTION_GENERATOR=".github/generate_dockerhub_description.sh"
 readonly DOCKERHUB_DESCRIPTION_WORKFLOW=".github/workflows/dockerhub_description.yml"
 
@@ -56,6 +75,59 @@ function test_the_dockerhub_description_fits_the_page_docker_hub_allows() {
     pass
   else
     fail "the rendered page is $SIZE characters long, Docker Hub keeps the first $DOCKERHUB_DESCRIPTION_SIZE_LIMIT and drops the rest"
+  fi
+}
+
+function test_the_dockerhub_description_is_not_about_to_lose_a_section_it_needs() {
+  # The case above holds the page under Docker Hub's limit, and the renderer
+  # guarantees that on its own by dropping sections. What neither of them says
+  # is which section goes next, and how much prose is left before it does.
+  #
+  # That distance is what nobody can see : a documentation change three sections
+  # away is what spends it, the page it breaks is published by a workflow no
+  # pull request runs, and the failure lands on whoever wrote the paragraph
+  # rather than on whoever chose what the page carries
+  if ! dockerhub_description_can_be_rendered; then
+    skip_test "no .github and README next to the scripts"
+    return 0
+  fi
+
+  local DESCRIPTION
+  DESCRIPTION="$(rendered_dockerhub_description)"
+
+  local SIZE
+  SIZE="$(printf '%s' "$DESCRIPTION" | wc -c)"
+  SIZE="${SIZE//[[:space:]]/}"
+  local -r HEADROOM=$(( DOCKERHUB_DESCRIPTION_SIZE_LIMIT - SIZE ))
+
+  # The section that goes next is the last one still on the page : the renderer
+  # drops them from the end
+  local SECTION_AT_RISK
+  SECTION_AT_RISK="$(printf '%s' "$DESCRIPTION" | grep '^## ' | tail -1)"
+  SECTION_AT_RISK="${SECTION_AT_RISK#\#\# }"
+
+  local SECTION
+  local IS_AT_RISK_SECTION_REQUIRED=false
+  for SECTION in "${DOCKERHUB_DESCRIPTION_REQUIRED_SECTIONS[@]}"; do
+    if [ "$SECTION_AT_RISK" == "$SECTION" ]; then
+      IS_AT_RISK_SECTION_REQUIRED=true
+    fi
+  done
+
+  # A page whose next casualty is a section it can do without has nothing to
+  # warn about : losing it costs a footer link, which is what the footer is for
+  if ! $IS_AT_RISK_SECTION_REQUIRED; then
+    pass
+    return 0
+  fi
+
+  if [ "$HEADROOM" -ge "$DOCKERHUB_DESCRIPTION_MINIMUM_HEADROOM" ]; then
+    pass
+  else
+    fail "the Docker Hub page is $HEADROOM characters from dropping \"$SECTION_AT_RISK\", which it cannot do without" \
+      "rendered: $SIZE of $DOCKERHUB_DESCRIPTION_SIZE_LIMIT characters" \
+      "the next section the renderer drops is \"$SECTION_AT_RISK\", and this suite requires it" \
+      "free room on the page rather than shrink the paragraph that tripped this : the sections are dropped from the end, so what the page carries is the thing to decide"
   fi
 }
 
@@ -128,7 +200,7 @@ function test_the_dockerhub_description_keeps_what_the_reader_came_for() {
   DESCRIPTION="$(rendered_dockerhub_description)"
 
   local SECTION
-  for SECTION in "Requirements" "Supported architectures" "Usage" "Parameters"; do
+  for SECTION in "${DOCKERHUB_DESCRIPTION_REQUIRED_SECTIONS[@]}"; do
     assert_contains "$DESCRIPTION" "## $SECTION" \
       "the Docker Hub page has to keep its \"$SECTION\" section"
   done


### PR DESCRIPTION
Closes #358.

One test case. The Docker Hub page renders at **24 155** of 25 000 characters, the last section on it is **`Parameters`**, and `Parameters` is one of the four this file requires to survive. So the page is **845 characters** from a red suite — and the last twelve commits that touched `README.md` added a median of about 1 500.

This measures that distance and fails while it is still a distance.

## Why it is not the existing case

`test_the_dockerhub_description_fits_the_page_docker_hub_allows` cannot catch this, and not by oversight : the renderer never overflows. It drops whole sections from the end until what is left fits, so the size assertion is true on both sides of the accident. What changes is *which sections are on the page*, and the case that checks those only speaks once one has already gone.

Between the two sits the thing nobody can see : how much prose is left before the next one goes. Three things keep it hidden —

- the page still looks whole after a section leaves it ;
- `dockerhub_description.yml` runs on pushes to `master` and on no pull request, so the real page is rendered after the merge ;
- the section that disappears is not the one that was edited. Adding a `Troubleshooting` entry — a section that is not even on the page — is enough to remove `Parameters` from it.

## What it asserts

The room is only demanded when the section next in line is one the page cannot do without. The renderer drops from the end, so the section at risk is the last one still rendered ; losing a droppable one costs a footer link, which is what the footer is for, and `Stopping the container` already went that way in #350.

**500 characters**, set against what documentation changes here actually weigh rather than against the limit, and deliberately less than one ordinary paragraph : past that point the next edit is what removes the section rather than what gets warned about.

## Verified by growing the README

In a scratch copy, characters added to `Requirements` :

| README grows by | Rendered | Room left | Last section | Suite |
|---|---|---|---|---|
| — | 24 155 | 845 | `Parameters` | green |
| +200 | 24 357 | 643 | `Parameters` | green |
| +700 | 24 857 | 143 | `Parameters` | **this case fails**, while `Parameters` is still on the page |
| +1200 | 10 109 | — | `Usage` | `Parameters` has gone ; `test_the_dockerhub_description_keeps_what_the_reader_came_for` fails instead |

That is the whole point of the case : the failure moves from *after* the damage to *before* it.

## What it does not do

It frees no room. The room has to come from what the page carries — #358 lays out the four ways and I have no view worth imposing on which. **This will go off on the next documentation change of ordinary size**, which is the intent, and #358 is written to be read when it does.

Also moves the list of required sections into a constant, since two cases now read it.

## Verification

- Suite green : **411 cases, 2136 assertions** (410 before).
- `shellcheck -x` exits 0 on the eight scripts the workflow now lints, including the three under `.github/` added by #352.
- The new case is not vacuous : it fails at +700 characters of README, where every other case in the file still passes.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DeUE63BGiummXRm2R7Rg11

---
_Generated by [Claude Code](https://claude.ai/code/session_01DeUE63BGiummXRm2R7Rg11)_