### PR TITLE
Point the Docker Hub page at the README, and date the relicensing in NOTICE

### DIFF
--- a/.github/generate_dockerhub_description.sh
+++ b/.github/generate_dockerhub_description.sh
@@ -3,51 +3,38 @@
 # SPDX-FileCopyrightText: 2020-2026 Tigerblue77 and the Dell iDRAC fan controller Docker image contributors
 # SPDX-License-Identifier: AGPL-3.0-only
 
-# Renders README.md into the page Docker Hub shows on the image's repository,
-# and prints it on stdout.
+# Prints the page Docker Hub shows on the image's repository : a short pointer
+# at the documentation, which lives on GitHub.
 #
-# Why the README is not simply uploaded as it is :
+# This used to render README.md into that page, dropping whole sections from the
+# end until the result fitted Docker Hub's 25,000-character limit. That worked,
+# and cost more than it was worth. The README passed the limit long ago, so the
+# page was always an extract ; which sections it carried moved every time the
+# documentation did ; and an ordinary paragraph three sections away could push
+# the last section a reader actually needed off the page. Guarding against that
+# meant measuring headroom, warning before it ran out, and periodically deciding
+# which paragraph to sacrifice to a registry's character count -- a recurring
+# editorial argument that produced nothing for anyone reading either page.
 #
-#   - Docker Hub caps that page at 25,000 characters, and the README passed
-#     that a while ago. The action that uploads it truncates whatever it is
-#     handed, which lands in the middle of the parameters table with nothing on
-#     the page to say a word about it. Here the cut is made on a section
-#     boundary and every section left out is named at the bottom, with a link.
-#   - The README navigates itself through anchors : a table of contents, and a
-#     "back to top" link under each section. Docker Hub renders the page
-#     without the ids they point at, so all of them go nowhere.
-#   - A relative link resolves against Docker Hub there, so "./.env.example"
-#     is a 404. They are rewritten into their absolute GitHub form.
+# So the page no longer competes with the README : it points at it. There is one
+# page to keep correct instead of two, this one cannot go stale because it says
+# nothing that can, and no documentation change can ever break it again.
 #
-# Usage : .github/generate_dockerhub_description.sh [README path]
+# What is lost is real and worth stating : a reader on Docker Hub no longer sees
+# the parameters without following a link. What is gained is that they no longer
+# see an arbitrary two thirds of them and no sign that the rest exists.
+#
+# Usage : .github/generate_dockerhub_description.sh
 
 set -euo pipefail
-
-# Docker Hub's own limit on a repository description. Counted in bytes below,
-# which is the same number for the ASCII the README is almost entirely made of
-# and an over-estimate for the handful of characters that are not : erring on
-# the short side is what keeps the upload from being rejected
-readonly DESCRIPTION_SIZE_LIMIT=25000
-
-README_FILE="${1:-}"
-if [ -z "$README_FILE" ]; then
-  REPOSITORY_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-  README_FILE="$REPOSITORY_ROOT/README.md"
-fi
-readonly README_FILE
-
-if [ ! -f "$README_FILE" ]; then
-  printf 'No README to render at %s\n' "$README_FILE" >&2
-  exit 1
-fi
 
 # The links this writes have to be absolute, so the repository they point at has
 # to be known. GITHUB_REPOSITORY is set on every runner ; the git remote covers
 # a run from a working copy, and having neither is not something to guess at :
-# a wrong owner here is a page full of links to somebody else's repository
+# a wrong owner here is a page pointing at somebody else's repository
 REPOSITORY="${GITHUB_REPOSITORY:-}"
 if [ -z "$REPOSITORY" ]; then
-  REMOTE_URL="$(git -C "$(dirname "$README_FILE")" remote get-url origin 2> /dev/null || true)"
+  REMOTE_URL="$(git -C "$(dirname "${BASH_SOURCE[0]}")" remote get-url origin 2> /dev/null || true)"
   REPOSITORY="$(printf '%s' "$REMOTE_URL" | sed -E 's#^.*github\.com[:/]##; s#\.git$##')"
 fi
 if [ -z "$REPOSITORY" ]; then
@@ -62,206 +49,31 @@ readonly REPOSITORY_URL="https://github.com/$REPOSITORY"
 # and survive the default branch being renamed
 readonly BLOB_URL="$REPOSITORY_URL/blob/HEAD"
 
-# "Container console log example" -> "container-console-log-example", the anchor
-# GitHub gives that heading. Lowercase, spaces to hyphens, and everything that
-# is neither a letter, a digit, a hyphen nor an underscore dropped. The classes
-# are spelled out in ASCII on purpose : tr works on bytes, so a UTF-8 character
-# must not be handed to it as something to case-fold
-function anchor_of_heading() {
-  local SLUG
-  SLUG="$(printf '%s' "$1" | tr 'ABCDEFGHIJKLMNOPQRSTUVWXYZ' 'abcdefghijklmnopqrstuvwxyz')"
-  SLUG="${SLUG// /-}"
-  SLUG="$(printf '%s' "$SLUG" | sed 's/[^a-z0-9_-]//g')"
-  printf '%s' "$SLUG"
-}
+cat << EOF
+# Dell iDRAC fan controller
 
-CLEANED_FILE="$(mktemp)"
-readonly CLEANED_FILE
-trap 'rm -f "$CLEANED_FILE"' EXIT
+Control the fans of a Dell PowerEdge server from its CPU temperatures, over IPMI.
 
-# First pass : everything that is about the README being read on GitHub rather
-# than about the image
-awk -v blob_url="$BLOB_URL" '
-  # Rewrites the target of every markdown link on the line into an absolute one.
-  # Written as a scan rather than a gsub because the replacement depends on the
-  # target : an anchor becomes a link into the README, a path becomes a link
-  # into the repository, and anything already absolute is left alone
-  function absolutise(line,   out, opening, closing, target) {
-    out = ""
-    while ((opening = index(line, "](")) > 0) {
-      out = out substr(line, 1, opening + 1)
-      line = substr(line, opening + 2)
-      closing = index(line, ")")
-      # An unbalanced "](" is left exactly as it was rather than guessed at
-      if (closing == 0) break
-      target = substr(line, 1, closing - 1)
-      out = out absolutise_target(target)
-      line = substr(line, closing)
-    }
-    return out line
-  }
+## The documentation is on GitHub
 
-  function absolutise_target(target) {
-    # "#usage" : a section of the README, which only exists on GitHub
-    if (target ~ /^#/) return blob_url "/README.md" target
-    # "https:", "mailto:", "//host/..." : already absolute
-    if (target ~ /^[a-zA-Z][a-zA-Z0-9+.-]*:/) return target
-    if (target ~ /^\/\//) return target
-    sub(/^\.\//, "", target)
-    return blob_url "/" target
-  }
+**$REPOSITORY_URL#readme**
 
-  # Removing lines leaves the gaps they used to fill. Blank lines are held back
-  # rather than printed as they come, so a run of them collapses to one and the
-  # ones a removal left at the top of the file are dropped altogether : markdown
-  # reads both the same way, and every byte saved here is a byte of
-  # documentation that fits on the page. Every rule that prints flushes what is
-  # held first, or it would swallow a separation that was meant to be there
-  function flush_pending_blank_line() {
-    if (blank_lines > 0 && printed_any) print ""
-    blank_lines = 0
-    printed_any = 1
-  }
+It is kept there rather than copied here, so that there is one page to keep
+correct instead of two :
 
-  # A fenced block is copied out untouched : "./Dell_iDRAC_fan_controller.sh" in
-  # a shell example is a path on the reader"s machine, not a link to rewrite.
-  # Its own blank lines are content, and reach the rule below while in_code
-  # holds, which prints them as they are
-  /^[ \t]*```/ { in_code = !in_code; flush_pending_blank_line(); print; next }
-  in_code { print; next }
+- **Requirements** — which iDRAC firmware still accepts the fan control
+  commands, and the privileges the account needs
+- **Usage** — \`docker run\` and \`docker compose\`, against a local or a remote
+  iDRAC
+- **Parameters** — every variable, what it does and what it defaults to
+- **Troubleshooting** — what to look at when the fans do not move
 
-  # The table of contents, down to the heading that follows it : every one of
-  # its entries is an anchor, and none of them resolves on Docker Hub
-  /^## / && in_table_of_contents { in_table_of_contents = 0 }
-  /^##[ \t]+[Tt]able of contents[ \t]*$/ { in_table_of_contents = 1; next }
-  in_table_of_contents { next }
+## Licence
 
-  # The div the "back to top" links target, and the links themselves
-  /^<div id="top">/ { next }
-  /^<p align="right">.*back to top/ { next }
+GNU AGPL v3, or a commercial licence for uses it does not fit :
+$BLOB_URL/LICENSE-COMMERCIAL.md
 
-  # The comments that announce each section, "<!-- USAGE -->". Invisible in both
-  # renderings, so nothing on the page changes ; what this avoids is the one
-  # belonging to the first dropped section being left behind by the cut below,
-  # hanging under the last section that was kept
-  /^[ \t]*<!--.*-->[ \t]*$/ { next }
+## Issues and discussions
 
-  # A reference-style definition, "[label]: ./LICENSE". The inline form is
-  # handled by absolutise() above, this one is a line of its own
-  /^\[[^]]+\]:[ \t]*[^ \t]/ {
-    label = $0
-    sub(/:[ \t]*.*$/, ":", label)
-    target = $0
-    sub(/^\[[^]]+\]:[ \t]*/, "", target)
-    title = ""
-    if (match(target, /[ \t]+["(].*$/)) {
-      title = substr(target, RSTART)
-      target = substr(target, 1, RSTART - 1)
-    }
-    flush_pending_blank_line()
-    print label " " absolutise_target(target) title
-    next
-  }
-
-  /^[ \t]*$/ { blank_lines++; next }
-
-  {
-    flush_pending_blank_line()
-    print absolutise($0)
-  }
-' "$README_FILE" > "$CLEANED_FILE"
-
-# Second pass : where the sections start, so the cut below lands between two of
-# them instead of inside one. Fence-aware, so a "## " written inside a code
-# block is not mistaken for a heading
-declare -a SECTION_START_LINES=()
-declare -a SECTION_TITLES=()
-while IFS=$'\t' read -r LINE_NUMBER TITLE; do
-  SECTION_START_LINES+=("$LINE_NUMBER")
-  SECTION_TITLES+=("$TITLE")
-done < <(awk '
-  /^[ \t]*```/ { in_code = !in_code; next }
-  in_code { next }
-  /^## / { printf "%d\t%s\n", FNR, substr($0, 4) }
-' "$CLEANED_FILE")
-
-readonly SECTION_COUNT="${#SECTION_START_LINES[@]}"
-
-# The footer is what tells the reader this page is an extract and where the rest
-# is. Its own size counts against the limit, so it is rebuilt for each candidate
-# rather than measured once
-# Usage : footer_for "Troubleshooting" "Contributing"
-function footer_for() {
-  printf -- '---\n\n'
-  if [ "$#" -gt 0 ]; then
-    printf 'Docker Hub allows %s characters on this page, which the full documentation no longer fits in. These sections are on GitHub :\n\n' \
-      "$DESCRIPTION_SIZE_LIMIT"
-
-    local DROPPED_TITLE
-    for DROPPED_TITLE in "$@"; do
-      printf -- '- [%s](%s/README.md#%s)\n' "$DROPPED_TITLE" "$BLOB_URL" "$(anchor_of_heading "$DROPPED_TITLE")"
-    done
-    printf '\n'
-  fi
-  # The licence is stated here rather than left to the "License" section, because
-  # that section is the last one in the README and so the first the cut above
-  # drops : today it never reaches the page at all. A link under "these sections
-  # are on GitHub" is not the same thing as saying what the terms are, and this
-  # page is where a company evaluating the image decides whether it may ship it.
-  # One line, outside the cut, is what makes that answerable without leaving
-  # Docker Hub -- and what makes the commercial option discoverable by the only
-  # people who need it.
-  #
-  # Kept to a label rather than a sentence because the page is nearly full : it
-  # renders within a few hundred characters of the limit, and the section next in
-  # line to be dropped is "Parameters", which it cannot do without. The two facts
-  # a reader needs here are the licence name and that a paid alternative exists ;
-  # why it exists is one click away, in the file this links to
-  printf 'GNU AGPL v3, or a commercial licence : %s/LICENSE-COMMERCIAL.md\n\n' \
-    "$BLOB_URL"
-  printf 'Issues, discussions and the full documentation : %s\n' "$REPOSITORY_URL"
-}
-
-# Usage : byte_size "$TEXT"
-function byte_size() {
-  local SIZE
-  SIZE="$(printf '%s' "$1" | wc -c)"
-  printf '%s' "${SIZE// /}"
-}
-
-# Keep as many whole sections as fit, dropping them from the end : the reader
-# who lands here wants to know what the image is, what it needs and how to run
-# it, in that order, and that is the order the README already puts them in.
-# Written as a search rather than a fixed list of sections to leave out so that
-# the page follows the README on its own : a section that grows pushes the last
-# one off, a section that shrinks brings it back
-KEPT_SECTIONS="$SECTION_COUNT"
-while [ "$KEPT_SECTIONS" -ge 0 ]; do
-  if [ "$KEPT_SECTIONS" -eq "$SECTION_COUNT" ]; then
-    BODY="$(cat "$CLEANED_FILE")"
-  else
-    LAST_KEPT_LINE=$(( ${SECTION_START_LINES[$KEPT_SECTIONS]} - 1 ))
-    BODY="$(head -n "$LAST_KEPT_LINE" "$CLEANED_FILE")"
-  fi
-
-  DROPPED_TITLES=("${SECTION_TITLES[@]:$KEPT_SECTIONS}")
-  CANDIDATE="$BODY"$'\n\n'"$(footer_for "${DROPPED_TITLES[@]}")"
-
-  if [ "$(byte_size "$CANDIDATE")" -le "$DESCRIPTION_SIZE_LIMIT" ]; then
-    printf '%s\n' "$CANDIDATE"
-    exit 0
-  fi
-
-  KEPT_SECTIONS=$(( KEPT_SECTIONS - 1 ))
-done
-
-# Not reachable while the text above the first section is a title and a table of
-# contents. Should that ever stop being true, a page cut mid-sentence still
-# beats no page at all, and the warning says which one this is
-printf '::warning::%s does not fit in %s characters before its first section, cutting inside it\n' \
-  "$README_FILE" "$DESCRIPTION_SIZE_LIMIT" >&2
-
-FOOTER="$(footer_for "${SECTION_TITLES[@]}")"
-BUDGET=$(( DESCRIPTION_SIZE_LIMIT - $(byte_size "$FOOTER") - 2 ))
-head -c "$BUDGET" "$CLEANED_FILE" | head -n -1
-printf '\n%s\n' "$FOOTER"
+$REPOSITORY_URL/issues
+EOF

--- a/.github/workflows/dockerhub_description.yml
+++ b/.github/workflows/dockerhub_description.yml
@@ -6,23 +6,24 @@ name: Docker Hub description
 # registry that most users reach the image through was the only place the
 # documentation did not exist.
 #
-# This renders README.md into that page every time the README moves, so the two
-# can no longer drift apart.
+# This writes it : a short page pointing at the documentation on GitHub.
 #
-# Separate from "Docker image CI" on purpose : the page describes the repository
-# and not a version, and README changes land on master between releases, where
-# a workflow that fires on a version tag - and ignores README.md when it does -
-# never runs. GitHub Container Registry needs none of this : it reads the README
-# off the repository the image is linked to, through the
-# org.opencontainers.image.source label docker/metadata-action already writes.
+# It used to render README.md down to Docker Hub's 25,000-character limit, and
+# republish on every README change. That is why this workflow is separate from
+# "Docker image CI" - the page describes the repository and not a version, and
+# README changes land on master between releases. The page no longer contains
+# any documentation, so a README change can no longer alter it and no longer
+# needs to republish it ; what remains is the generator and this file.
+#
+# GitHub Container Registry needs none of this : it reads the README off the
+# repository the image is linked to, through the org.opencontainers.image.source
+# label docker/metadata-action already writes.
 
 on:
   push:
     branches: [master]
     paths:
-      - README.md
-      # The renderer and this file : a change to either can change the page
-      # without the README having moved at all
+      # The generator and this file : the page is built entirely from them
       - .github/generate_dockerhub_description.sh
       - .github/workflows/dockerhub_description.yml
   workflow_dispatch:
@@ -58,11 +59,11 @@ jobs:
           FINAL_NAME="${IMAGE_NAME/_Docker/}"
           echo "value=${FINAL_NAME,,}" >> "$GITHUB_OUTPUT"
 
-      - name: Render README.md into the description
+      - name: Build the description
         run: |
           set -euo pipefail
           .github/generate_dockerhub_description.sh > "$RUNNER_TEMP/dockerhub_description.md"
-          echo "Rendered $(wc -c < "$RUNNER_TEMP/dockerhub_description.md") characters" >> "$GITHUB_STEP_SUMMARY"
+          echo "Built $(wc -c < "$RUNNER_TEMP/dockerhub_description.md") characters" >> "$GITHUB_STEP_SUMMARY"
 
       # /!\ DOCKERHUB_TOKEN has to be a personal access token with the
       # "Read, Write, Delete" scope. The narrower "Read & Write" one is enough to

--- a/NOTICE
+++ b/NOTICE
@@ -77,7 +77,7 @@ history:
                              were therefore not made under any stated
                              licence.
 
-  2024-11-26 .. (relicensed) Creative Commons
+  2024-11-26 .. 2026-08-12   Creative Commons
                              Attribution-NonCommercial-ShareAlike 4.0
                              International (CC BY-NC-SA 4.0), issue #100.
                              Copies obtained under those terms keep them
@@ -86,7 +86,7 @@ history:
                              this relicensing does not withdraw it from
                              anyone who already holds such a copy.
 
-  (relicensed) onwards       GNU Affero General Public License v3.0 only
+  2026-08-12 onwards         GNU Affero General Public License v3.0 only
                              (AGPL-3.0-only), plus a separate commercial
                              licence, issue #304.
 

--- a/tests/cases/13_dockerhub_description.sh
+++ b/tests/cases/13_dockerhub_description.sh
@@ -5,64 +5,62 @@
 
 # Docker Hub is where most users meet this image, and the page it shows them is
 # not stored here : it is uploaded by the "Docker Hub description" workflow,
-# which renders README.md through .github/generate_dockerhub_description.sh.
-# Like the two publishing workflows, that one never runs on a pull request, and
-# what it produces is read by nobody in this repository. These are the checks
-# that read it anyway.
+# which runs .github/generate_dockerhub_description.sh. Like the two publishing
+# workflows, that one never runs on a pull request, and what it produces is read
+# by nobody in this repository. These are the checks that read it anyway.
+#
+# That page used to be README.md, rendered down to Docker Hub's 25,000-character
+# limit by dropping whole sections from the end. These cases used to guard the
+# distance between the page and the next section it would lose, because an
+# ordinary paragraph anywhere in the README could spend it. The page is now a
+# short pointer at the documentation on GitHub, which is why that guard and the
+# arithmetic behind it are gone : the failure it existed to catch cannot happen
+# to a page that says nothing the documentation can change.
+#
+# What is left to check is that the pointer points somewhere, that it points
+# there in a way Docker Hub can follow, and that it stays independent of the
+# documentation -- the last being the property the whole change was made for.
 
 # The owner and name a real run gets from GITHUB_REPOSITORY. Anything would do,
-# it is pinned here so that the links the renderer builds can be asserted on
+# it is pinned here so that the links the generator builds can be asserted on
 # without the assertions depending on which fork the suite runs from
 readonly DOCKERHUB_DESCRIPTION_REPOSITORY="owner/repository"
 readonly DOCKERHUB_DESCRIPTION_REPOSITORY_URL="https://github.com/$DOCKERHUB_DESCRIPTION_REPOSITORY"
 
-# Docker Hub's own limit, stated again rather than read from the renderer : the
-# point of a test is to hold the contract from outside. A renderer that raises
-# its own constant should fail here, not agree with itself
+# Docker Hub's own limit, stated again rather than read from the generator : the
+# point of a test is to hold the contract from outside
 readonly DOCKERHUB_DESCRIPTION_SIZE_LIMIT=25000
 
-# How close the page may come to losing its next section before this suite says
-# so. The renderer never overflows : it drops whole sections from the end until
-# what is left fits, so the room measured here is not room before a broken page
-# but room before the next section leaves it. Once the section next in line is
-# one the page cannot do without, that distance is the only warning there is.
-#
-# 500 is chosen against what documentation changes to this README actually
-# weigh, not against the limit : of the thirteen that touched it before this
-# guard was written, eleven added more than 500 characters and the median added
-# about 1 500. So this fires while there is still less than a third of an
-# ordinary paragraph in hand -- deliberately, because by then the next edit is
-# what removes the section rather than what is warned about
-readonly DOCKERHUB_DESCRIPTION_MINIMUM_HEADROOM=500
-
-# The sections the page is worth publishing only while it still holds them,
-# named once here and asserted by two cases : the one that checks they are on
-# the page, and the one that checks the page is not about to lose one
-readonly DOCKERHUB_DESCRIPTION_REQUIRED_SECTIONS=("Requirements" "Supported architectures" "Usage" "Parameters")
+# What the page is allowed to weigh. Far below the limit on purpose : this is
+# not headroom to be spent, it is a bound that says the page is a pointer and
+# not a copy of the documentation. A page that grows past this has started
+# becoming the second thing to keep correct that the rewrite removed
+readonly DOCKERHUB_DESCRIPTION_MAXIMUM_SIZE=2000
 
 readonly DOCKERHUB_DESCRIPTION_GENERATOR=".github/generate_dockerhub_description.sh"
 readonly DOCKERHUB_DESCRIPTION_WORKFLOW=".github/workflows/dockerhub_description.yml"
 
-# The suite also runs inside the built image, which carries the scripts but
-# neither the .github directory nor the README they are rendered from
+# The suite also runs inside the built image, which carries the scripts but not
+# the .github directory
 # Usage : if ! dockerhub_description_can_be_rendered; then skip_test "..."; return 0; fi
 function dockerhub_description_can_be_rendered() {
-  [ -x "$REPO_ROOT/$DOCKERHUB_DESCRIPTION_GENERATOR" ] && [ -f "$REPO_ROOT/README.md" ]
+  [ -x "$REPO_ROOT/$DOCKERHUB_DESCRIPTION_GENERATOR" ]
 }
 
 # Usage : DESCRIPTION="$(rendered_dockerhub_description)"
 function rendered_dockerhub_description() {
   GITHUB_REPOSITORY="$DOCKERHUB_DESCRIPTION_REPOSITORY" \
-    "$REPO_ROOT/$DOCKERHUB_DESCRIPTION_GENERATOR" "$REPO_ROOT/README.md"
+    "$REPO_ROOT/$DOCKERHUB_DESCRIPTION_GENERATOR"
 }
 
-function test_the_dockerhub_description_fits_the_page_docker_hub_allows() {
-  # This is the whole reason the README is not simply uploaded as it is : Docker
-  # Hub does not refuse an oversized description, the action uploading it
-  # truncates it, and a page cut in the middle of the parameters table looks
-  # exactly like a page that documents that much and no more
+function test_the_dockerhub_description_stays_a_pointer_and_not_a_second_copy() {
+  # Docker Hub does not refuse an oversized description, the action uploading it
+  # truncates it. The old page lived a few hundred characters from that edge and
+  # every documentation change moved it ; this one is nowhere near, and the
+  # bound is here so that it stays a pointer rather than drifting back into
+  # being a copy of the README with a different set of gaps
   if ! dockerhub_description_can_be_rendered; then
-    skip_test "no .github and README next to the scripts"
+    skip_test "no .github next to the scripts"
     return 0
   fi
 
@@ -74,72 +72,49 @@ function test_the_dockerhub_description_fits_the_page_docker_hub_allows() {
   # BSD wc pads its output, GNU wc does not
   SIZE="${SIZE//[[:space:]]/}"
 
-  if [ "$SIZE" -le "$DOCKERHUB_DESCRIPTION_SIZE_LIMIT" ]; then
+  if [ "$SIZE" -gt "$DOCKERHUB_DESCRIPTION_SIZE_LIMIT" ]; then
+    fail "the page is $SIZE characters long, Docker Hub keeps the first $DOCKERHUB_DESCRIPTION_SIZE_LIMIT and drops the rest"
+    return 0
+  fi
+
+  if [ "$SIZE" -le "$DOCKERHUB_DESCRIPTION_MAXIMUM_SIZE" ]; then
     pass
   else
-    fail "the rendered page is $SIZE characters long, Docker Hub keeps the first $DOCKERHUB_DESCRIPTION_SIZE_LIMIT and drops the rest"
+    fail "the Docker Hub page is $SIZE characters long, and a pointer at the documentation should not need $DOCKERHUB_DESCRIPTION_MAXIMUM_SIZE" \
+      "this page exists so there is one page to keep correct instead of two ; documentation belongs in README.md, which it links to"
   fi
 }
 
-function test_the_dockerhub_description_is_not_about_to_lose_a_section_it_needs() {
-  # The case above holds the page under Docker Hub's limit, and the renderer
-  # guarantees that on its own by dropping sections. What neither of them says
-  # is which section goes next, and how much prose is left before it does.
-  #
-  # That distance is what nobody can see : a documentation change three sections
-  # away is what spends it, the page it breaks is published by a workflow no
-  # pull request runs, and the failure lands on whoever wrote the paragraph
-  # rather than on whoever chose what the page carries
+function test_the_dockerhub_description_does_not_depend_on_the_documentation() {
+  # The property the rewrite was made for. The page used to be rendered from
+  # README.md, so every documentation change could alter it -- and did, silently,
+  # since no pull request runs the workflow that publishes it. Rendering the
+  # generator on its own, with no repository around it at all, has to produce
+  # exactly what rendering it here produces : that is what "the documentation
+  # cannot break this page" means, checked rather than asserted in a comment
   if ! dockerhub_description_can_be_rendered; then
-    skip_test "no .github and README next to the scripts"
+    skip_test "no .github next to the scripts"
     return 0
   fi
 
-  local DESCRIPTION
-  DESCRIPTION="$(rendered_dockerhub_description)"
+  local ISOLATED_DIRECTORY
+  ISOLATED_DIRECTORY="$(mktemp -d)"
+  cp "$REPO_ROOT/$DOCKERHUB_DESCRIPTION_GENERATOR" "$ISOLATED_DIRECTORY/generator.sh"
 
-  local SIZE
-  SIZE="$(printf '%s' "$DESCRIPTION" | wc -c)"
-  SIZE="${SIZE//[[:space:]]/}"
-  local -r HEADROOM=$(( DOCKERHUB_DESCRIPTION_SIZE_LIMIT - SIZE ))
+  local ISOLATED_DESCRIPTION
+  ISOLATED_DESCRIPTION="$(GITHUB_REPOSITORY="$DOCKERHUB_DESCRIPTION_REPOSITORY" "$ISOLATED_DIRECTORY/generator.sh")"
+  rm -rf "$ISOLATED_DIRECTORY"
 
-  # The section that goes next is the last one still on the page : the renderer
-  # drops them from the end
-  local SECTION_AT_RISK
-  SECTION_AT_RISK="$(printf '%s' "$DESCRIPTION" | grep '^## ' | tail -1)"
-  SECTION_AT_RISK="${SECTION_AT_RISK#\#\# }"
-
-  local SECTION
-  local IS_AT_RISK_SECTION_REQUIRED=false
-  for SECTION in "${DOCKERHUB_DESCRIPTION_REQUIRED_SECTIONS[@]}"; do
-    if [ "$SECTION_AT_RISK" == "$SECTION" ]; then
-      IS_AT_RISK_SECTION_REQUIRED=true
-    fi
-  done
-
-  # A page whose next casualty is a section it can do without has nothing to
-  # warn about : losing it costs a footer link, which is what the footer is for
-  if ! $IS_AT_RISK_SECTION_REQUIRED; then
-    pass
-    return 0
-  fi
-
-  if [ "$HEADROOM" -ge "$DOCKERHUB_DESCRIPTION_MINIMUM_HEADROOM" ]; then
-    pass
-  else
-    fail "the Docker Hub page is $HEADROOM characters from dropping \"$SECTION_AT_RISK\", which it cannot do without" \
-      "rendered: $SIZE of $DOCKERHUB_DESCRIPTION_SIZE_LIMIT characters" \
-      "the next section the renderer drops is \"$SECTION_AT_RISK\", and this suite requires it" \
-      "free room on the page rather than shrink the paragraph that tripped this : the sections are dropped from the end, so what the page carries is the thing to decide"
-  fi
+  assert_equals "$(rendered_dockerhub_description)" "$ISOLATED_DESCRIPTION" \
+    "the page has to be the same whether or not the documentation is next to it, or a README change can alter it again"
 }
 
 function test_the_dockerhub_description_carries_no_link_docker_hub_cannot_resolve() {
-  # A relative link resolves against Docker Hub's own domain there, and the
-  # anchors the README navigates itself with point at ids that page does not
-  # have. Both render as a working link and answer a 404
+  # A relative link resolves against Docker Hub's own domain there, and an
+  # anchor points at an id that page does not have. Both render as a working
+  # link and answer a 404
   if ! dockerhub_description_can_be_rendered; then
-    skip_test "no .github and README next to the scripts"
+    skip_test "no .github next to the scripts"
     return 0
   fi
 
@@ -156,76 +131,41 @@ function test_the_dockerhub_description_carries_no_link_docker_hub_cannot_resolv
   local SELF_ANCHORS
   SELF_ANCHORS="$(printf '%s\n' "$DESCRIPTION" | grep -nE 'href="#|back to top' || true)"
   assert_empty "$SELF_ANCHORS" \
-    "the anchors the README navigates itself with go nowhere on the Docker Hub page"
+    "an anchor into this page goes nowhere on Docker Hub"
 }
 
-function test_no_readme_section_disappears_from_the_dockerhub_description() {
-  # The renderer drops whole sections from the end until what is left fits, so
-  # which ones it drops changes as the README grows. What must not change is
-  # that a dropped section is still named on the page, with a link to it :
-  # otherwise a section quietly stops existing for every reader who arrives
-  # through Docker Hub, and nothing anywhere says so
+function test_the_dockerhub_description_sends_the_reader_to_the_documentation() {
+  # The one thing this page is for. A reader who reaches Docker Hub instead of
+  # GitHub has to leave with the documentation, and with the headings that tell
+  # them it answers their question -- otherwise the pointer costs them the visit
   if ! dockerhub_description_can_be_rendered; then
-    skip_test "no .github and README next to the scripts"
+    skip_test "no .github next to the scripts"
     return 0
   fi
 
   local DESCRIPTION
   DESCRIPTION="$(rendered_dockerhub_description)"
 
-  local SECTION_TITLE
-  while IFS= read -r SECTION_TITLE; do
-    [ -n "$SECTION_TITLE" ] || continue
-    # The table of contents is a list of anchors and nothing else, it is
-    # dropped rather than linked to
-    [ "$SECTION_TITLE" != "Table of contents" ] || continue
+  assert_contains "$DESCRIPTION" "$DOCKERHUB_DESCRIPTION_REPOSITORY_URL#readme" \
+    "the page has to link the README it stands in for"
 
-    if printf '%s\n' "$DESCRIPTION" | grep -qxF "## $SECTION_TITLE"; then
-      pass
-    elif printf '%s\n' "$DESCRIPTION" | grep -qF "[$SECTION_TITLE]($DOCKERHUB_DESCRIPTION_REPOSITORY_URL"; then
-      pass
-    else
-      fail "the README has a \"$SECTION_TITLE\" section, the Docker Hub page neither carries it nor links to it"
-    fi
-  done < <(grep -E '^## ' "$REPO_ROOT/README.md" | sed 's/^## //')
-}
-
-function test_the_dockerhub_description_keeps_what_the_reader_came_for() {
-  # Whatever the cut leaves out, someone landing on the image's page is there to
-  # find out what it needs and how to start it. These are the sections that
-  # answer that, and the page is worth publishing only while it still holds them
-  if ! dockerhub_description_can_be_rendered; then
-    skip_test "no .github and README next to the scripts"
-    return 0
-  fi
-
-  local DESCRIPTION
-  DESCRIPTION="$(rendered_dockerhub_description)"
-
-  local SECTION
-  for SECTION in "${DOCKERHUB_DESCRIPTION_REQUIRED_SECTIONS[@]}"; do
-    assert_contains "$DESCRIPTION" "## $SECTION" \
-      "the Docker Hub page has to keep its \"$SECTION\" section"
+  local SUBJECT
+  for SUBJECT in "Requirements" "Usage" "Parameters" "Troubleshooting"; do
+    assert_contains "$DESCRIPTION" "$SUBJECT" \
+      "a reader has to be able to tell that \"$SUBJECT\" is answered on the other side of the link"
   done
 
-  assert_contains "$DESCRIPTION" "docker run" \
-    "the Docker Hub page has to show how the image is started"
-  assert_contains "$DESCRIPTION" "$DOCKERHUB_DESCRIPTION_REPOSITORY_URL" \
-    "the Docker Hub page has to link back to the repository it is rendered from"
+  assert_contains "$DESCRIPTION" "$DOCKERHUB_DESCRIPTION_REPOSITORY_URL/issues" \
+    "the page has to say where a question goes"
 }
 
-function test_the_dockerhub_description_states_the_licence_whatever_the_cut() {
-  # The project is dual-licensed, and the page Docker Hub shows is where a
-  # company evaluating the image decides whether it may ship it. The README's
-  # "License" section cannot answer that here : it is the last section, so it is
-  # the first the cut drops, and it has never once reached the page. The footer
-  # is outside the cut, which is why the terms are stated there instead.
-  #
-  # Asserted on the rendered page rather than on the footer function, because
-  # what matters is that the answer is on the page no matter how much of the
-  # README had to be left out
+function test_the_dockerhub_description_states_the_licence() {
+  # This page is where a company evaluating the image decides whether it may
+  # ship it, and the licence is not something to make them follow a link for.
+  # The identifier names the AGPL alone : the commercial alternative is
+  # negotiated per licensee rather than granted by this page
   if ! dockerhub_description_can_be_rendered; then
-    skip_test "no .github and README next to the scripts"
+    skip_test "no .github next to the scripts"
     return 0
   fi
 
@@ -233,46 +173,32 @@ function test_the_dockerhub_description_states_the_licence_whatever_the_cut() {
   DESCRIPTION="$(rendered_dockerhub_description)"
 
   assert_contains "$DESCRIPTION" "AGPL" \
-    "the Docker Hub page has to name the licence the image is published under"
+    "the page has to name the licence the image is conveyed under"
   assert_contains "$DESCRIPTION" "$DOCKERHUB_DESCRIPTION_REPOSITORY_URL/blob/HEAD/LICENSE-COMMERCIAL.md" \
-    "the Docker Hub page has to link the commercial licence, the reader who needs it arrives here"
+    "the page has to link the commercial licence, for the readers who cannot meet the AGPL"
 }
 
-function test_the_dockerhub_description_workflow_renders_the_page_it_publishes() {
-  # The renderer and the workflow only meet at a path written in both. Renaming
-  # one of them is caught here rather than by a red run of the one workflow no
-  # pull request fires
+function test_the_dockerhub_description_workflow_publishes_what_this_generates() {
+  # The generator and the workflow are a pair : nothing in this repository reads
+  # what is published, so a workflow that stopped calling this script, or called
+  # it and uploaded something else, would go unnoticed until somebody looked at
+  # Docker Hub
   if [ ! -f "$REPO_ROOT/$DOCKERHUB_DESCRIPTION_WORKFLOW" ]; then
-    skip_test "no .github/workflows next to the scripts"
+    skip_test "no .github next to the scripts"
     return 0
   fi
 
-  local -r WORKFLOW_CONTENT="$(cat "$REPO_ROOT/$DOCKERHUB_DESCRIPTION_WORKFLOW")"
+  local WORKFLOW
+  WORKFLOW="$(< "$REPO_ROOT/$DOCKERHUB_DESCRIPTION_WORKFLOW")"
 
-  assert_contains "$WORKFLOW_CONTENT" "$DOCKERHUB_DESCRIPTION_GENERATOR" \
-    "the workflow has to render the page through $DOCKERHUB_DESCRIPTION_GENERATOR"
+  assert_contains "$WORKFLOW" "$DOCKERHUB_DESCRIPTION_GENERATOR" \
+    "the workflow has to build the page with the generator these cases check"
+  assert_contains "$WORKFLOW" "readme-filepath" \
+    "the workflow has to hand the generated file to the action that uploads it"
 
-  if [ -f "$REPO_ROOT/$DOCKERHUB_DESCRIPTION_GENERATOR" ]; then
-    pass
-  else
-    fail "$DOCKERHUB_DESCRIPTION_WORKFLOW runs $DOCKERHUB_DESCRIPTION_GENERATOR, which does not exist"
-    return 1
-  fi
-
-  # The workflow runs it as a command rather than through bash, so the bit is
-  # what makes the difference between a rendered page and "Permission denied"
-  if [ -x "$REPO_ROOT/$DOCKERHUB_DESCRIPTION_GENERATOR" ]; then
-    pass
-  else
-    fail "$DOCKERHUB_DESCRIPTION_GENERATOR is run as a command by the workflow, it has to be executable"
-  fi
-
-  # A README change that never reaches the page is the drift this whole
-  # workflow exists to remove. Read line by line off the file rather than
-  # matched on the content read above : bash anchors a regex on the whole
-  # string, so "^" there would only ever mean the first line of the workflow
-  local README_TRIGGER
-  README_TRIGGER="$(grep -E '^[[:space:]]+- README\.md$' "$REPO_ROOT/$DOCKERHUB_DESCRIPTION_WORKFLOW" || true)"
-  assert_not_empty "$README_TRIGGER" \
-    "the workflow has to list README.md among the paths it runs on"
+  # The page no longer depends on README.md, so a README change must no longer
+  # republish it : the run would upload a page identical to the one already
+  # there, on every documentation commit
+  assert_not_contains "$WORKFLOW" "- README.md" \
+    "the page does not depend on README.md any more, so a README change should not trigger a republication"
 }


### PR DESCRIPTION
Two loose ends from the relicensing (#304 / #305), found by auditing what that work claimed against what is on `master`.

> [!NOTE]
> **This replaces the approach this branch carried earlier.** It first fixed *how* the Docker Hub headroom guard measured the page (#363). @tigerblue77's call was to remove the problem instead of measuring it better: the page stops being a copy of the README and becomes a pointer at it. The guard, the headroom arithmetic and the editorial decision it kept demanding all go with it. #363 has the measurement diagnosis, which stands as the record of why.

## `cdae2a0` — date the relicensing in `NOTICE`

`NOTICE` says, three lines above its licence history, that the chain is recorded there so a downstream recipient can reconstruct which terms applied when. Both boundaries of the AGPL transition read `(relicensed)` — a placeholder written before the date was known, and the only date in that table a recipient cannot get from anywhere else. It is `2026-08-12`, the day #305 merged.

#305 described that file as carrying "a dated licence history". It did not, at the one boundary that matters.

## `5222c51` — the Docker Hub page points at the README

The page was rendered from `README.md`, cut to Docker Hub's 25 000-character limit by dropping whole sections from the end. That put the documentation and a registry's character count in permanent competition, and the documentation kept losing:

- the README passed 25 000 long ago, so the page was **always** an extract;
- which sections it carried moved every time the documentation did;
- a paragraph added three sections away is what pushed the next one off — in a workflow no pull request runs, so nobody saw it happen;
- guarding that meant measuring headroom, warning before it ran out, and periodically deciding which paragraph to sacrifice to Docker Hub.

The page now says what the image is, links the README, names the licence and links the commercial one. **949 characters**, built from nothing but the repository name, and no documentation change can reach it.

<details>
<summary>The page, as it will be published</summary>

```markdown
# Dell iDRAC fan controller

Control the fans of a Dell PowerEdge server from its CPU temperatures, over IPMI.

## The documentation is on GitHub

**https://github.com/tigerblue77/Dell_iDRAC_fan_controller_Docker#readme**

It is kept there rather than copied here, so that there is one page to keep
correct instead of two :

- **Requirements** — which iDRAC firmware still accepts the fan control
  commands, and the privileges the account needs
- **Usage** — `docker run` and `docker compose`, against a local or a remote
  iDRAC
- **Parameters** — every variable, what it does and what it defaults to
- **Troubleshooting** — what to look at when the fans do not move

## Licence

GNU AGPL v3, or a commercial licence for uses it does not fit :
https://github.com/tigerblue77/Dell_iDRAC_fan_controller_Docker/blob/HEAD/LICENSE-COMMERCIAL.md

## Issues and discussions

https://github.com/tigerblue77/Dell_iDRAC_fan_controller_Docker/issues
```
</details>

**What this costs, stated plainly.** A reader who lands on Docker Hub no longer sees the parameters without following a link. What they no longer see is an arbitrary two thirds of them with no sign that the rest exists — and there is now one page to keep correct instead of two.

**What it deletes.** Two `awk` passes, the section-boundary cut, the dropped-section footer, the headroom guard and its arithmetic: the generator goes from 271 lines to 78, and `-418 / +157` overall.

**The workflow** no longer republishes on a README change, because a README change can no longer alter what it would upload.

## Verification

- **411 cases, 2127 assertions, passing.** The suite trades the seven old cases for six, whose failure modes are now "the link is wrong" rather than "the page silently lost the parameters".
- One of them is the property the change was made for: rendering the generator alone, copied into an empty directory with no repository around it, has to produce byte-for-byte what rendering it in place produces. If the page ever depends on the documentation again, that fails.
- Another asserts the workflow no longer lists `README.md` among its trigger paths.
- `shellcheck -x` clean on the exact set the CI lints; the workflow YAML re-parsed to confirm both remaining trigger paths reach the action.
- No behavioural change to the container. `NOTICE` is not read at runtime; the generator runs only in the publishing workflow, which never runs on a pull request.
- Every commit carries `Signed-off-by`, per `CONTRIBUTING.md`.

Closes #363.