### PR TITLE
Give the workflows the licence header every other program here carries

### DIFF
--- a/.github/workflows/auto_update_pull_request_branches.yml
+++ b/.github/workflows/auto_update_pull_request_branches.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2020-2026 Tigerblue77 and the Dell iDRAC fan controller Docker image contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+
 name: Auto-update pull request branches
 
 # "Require branches to be up to date before merging" leaves every other open

--- a/.github/workflows/base_image_refresh.yml
+++ b/.github/workflows/base_image_refresh.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2020-2026 Tigerblue77 and the Dell iDRAC fan controller Docker image contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+
 name: Base image refresh
 
 # Ubuntu keeps publishing security fixes into ubuntu:latest, but nothing

--- a/.github/workflows/build_and_publish_docker_image.yml
+++ b/.github/workflows/build_and_publish_docker_image.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2020-2026 Tigerblue77 and the Dell iDRAC fan controller Docker image contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+
 name: Docker image CI
 
 on:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2020-2026 Tigerblue77 and the Dell iDRAC fan controller Docker image contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+
 name: Dependabot auto-merge
 
 on: pull_request

--- a/.github/workflows/dockerhub_description.yml
+++ b/.github/workflows/dockerhub_description.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2020-2026 Tigerblue77 and the Dell iDRAC fan controller Docker image contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+
 name: Docker Hub description
 
 # Docker Hub keeps an image's page on its own side, and nothing in this

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2020-2026 Tigerblue77 and the Dell iDRAC fan controller Docker image contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+
 name: Shellcheck
 
 # Scoped to the scripts nothing else would catch a mistake in, which is two groups and not one.

--- a/.github/workflows/test-results.yml
+++ b/.github/workflows/test-results.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2020-2026 Tigerblue77 and the Dell iDRAC fan controller Docker image contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+
 name: Test results
 
 # Publishes the test results of a pull request opened from a fork.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2020-2026 Tigerblue77 and the Dell iDRAC fan controller Docker image contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+
 name: Tests
 
 on:

--- a/tests/cases/12_github_workflows.sh
+++ b/tests/cases/12_github_workflows.sh
@@ -110,3 +110,38 @@ function test_no_docker_action_list_entry_ends_with_a_comment() {
     fi
   done
 }
+
+function test_every_workflow_carries_the_licence_header() {
+  # NOTICE names the SPDX headers as part of what discharges AGPL 5(a) and 7(b) :
+  # "Keeping this file, the LICENSE file and the SPDX headers in the source files
+  # intact is what satisfies them". That was true of every script and the
+  # Dockerfile, and of none of these files, which are the only programs here that
+  # carried no licence statement at all -- and there is no REUSE.toml or
+  # .reuse/dep5 covering them by fallback either (issue #367).
+  #
+  # Asserted over the directory rather than a list, so that a workflow added
+  # later fails here instead of quietly reopening the gap. That is the shape of
+  # test_the_shellcheck_workflow_lints_every_script_it_is_scoped_to, and for the
+  # same reason : a list somebody has to remember to extend is one that falls
+  # behind
+  local -r WORKFLOW_DIRECTORY="$REPO_ROOT/.github/workflows"
+  if [ ! -d "$WORKFLOW_DIRECTORY" ]; then
+    skip_test "no .github/workflows next to the scripts"
+    return 0
+  fi
+
+  local WORKFLOW
+  local UNCOVERED=""
+  for WORKFLOW in "$WORKFLOW_DIRECTORY"/*.yml "$WORKFLOW_DIRECTORY"/*.yaml; do
+    [ -f "$WORKFLOW" ] || continue
+    # Read from the head of the file : a header is only a header where a reader
+    # and a scanner both find it, and one buried below the job it belongs to
+    # discharges nothing
+    if ! head -5 "$WORKFLOW" | grep -q '^# SPDX-License-Identifier: AGPL-3.0-only$'; then
+      UNCOVERED="$UNCOVERED ${WORKFLOW#"$REPO_ROOT"/}"
+    fi
+  done
+
+  assert_empty "$UNCOVERED" \
+    "every workflow has to open with the two SPDX lines the scripts and the Dockerfile carry"
+}


### PR DESCRIPTION
Closes #367.

The last gap left by the relicensing (#304 / #305), found by auditing what that work claimed against what is on `master`.

## What was wrong

`NOTICE` names the headers as part of what discharges the licence:

> Keeping this file, the LICENSE file and the SPDX headers in the source files intact is what satisfies them.

That was true of the five runtime scripts, the three under `.github/`, the runner, the five library files, the three mocks, all twenty-six test cases and the `Dockerfile` — and of none of the eight workflow files. No `REUSE.toml`, no `.reuse/dep5`, so nothing covered them by fallback either. They were the only programs in the repository with no licence statement at all.

Not trivia: `build_and_publish_docker_image.yml` and `base_image_refresh.yml` carry a few hundred lines of shell between them, including the `latest` reconciliation and the release-note logic that #337, #343 and #356 were spent getting right. A fork lifting one of them got no notice of what it was taking.

## What this does

The same two lines the `Dockerfile` carries, above `name:` in each of the eight files, plus a case that keeps the directory covered.

The guard asserts over `.github/workflows/` rather than over a list, so a workflow added next year fails the suite instead of quietly reopening this — the shape of `test_the_shellcheck_workflow_lints_every_script_it_is_scoped_to`, and for the same reason: a list somebody has to remember to extend is one that falls behind.

## Deliberately untouched

`.dockerignore`, `.shellcheckrc`, `dependabot.yml` and `FUNDING.yml` are configuration rather than programs — `FUNDING.yml` is a list of sponsor handles — and `.devcontainer/devcontainer.json` is JSON, where a comment is a parser question rather than a licence one. A blanket rule over those buys nothing and is harder to state than one over the workflow directory.

## Verification

- **412 cases, 2128 assertions, passing.**
- The new guard checked in both directions: it passes as committed, and it fails naming the file when a header is removed from `tests.yml`.
- All eight files re-parsed as YAML after the edit, to confirm the prepended comment left them loadable.
- The header is read from the first five lines only — one buried below the job it belongs to discharges nothing.
- No behavioural change: comments in a workflow do not reach the runner, and nothing in the image changes.
- `Signed-off-by` present, per `CONTRIBUTING.md`.

> [!NOTE]
> `shellcheck` reports one pre-existing `SC2295` (info) at `tests/cases/12_github_workflows.sh:108`, in the case above the one added here. It is untouched and unrelated — the tests directory is outside the lint workflow's scope, which is why it has survived. Left for a separate change rather than folded in.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HysCBnMuZr87yHzVLHKuXM)_