### PR TITLE
Tell a server that refused the fan selector what its fans are actually doing (#378)

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -81,6 +81,10 @@ function apply_user_fan_control_profile() {
   # shellcheck disable=SC2181  # $? here is the command substitution above, already run; there is no direct command left to negate
   if [ $? -ne 0 ]; then
     print_error "Failed to set fan speed to $DECIMAL_FAN_SPEED%. ipmitool said: $ipmitool_stderr"
+    # A server that answered "invalid data field" ran the command and refused an argument, which is a
+    # different situation from the refusals below and gets its own explanation -- once, rather than as
+    # a raw ipmitool line on every cycle. It settles nothing and stops nothing being sent
+    note_that_the_server_rejects_the_broadcast_fan_selector "$ipmitool_stderr"
     IS_PROFILE_APPLIED=false
   fi
 
@@ -1377,6 +1381,25 @@ function does_the_command_need_a_higher_privilege_level() {
   [[ "$IPMITOOL_STDERR" == *"rsp=0xd4"* ]]
 }
 
+# Whether the given ipmitool stderr says the BMC itself answered, ran far enough to read the command's
+# arguments, and rejected one of them.
+# Usage : does_the_server_reject_this_data_field "$IPMITOOL_STDERR"
+#
+# 0xcc is "invalid data field in request" : the command is there and the account may run it, so the BMC
+# got as far as reading its data bytes and refused one of them. That is the opposite verdict from the
+# two predicates above, and it is deliberately kept out of both : concluding "this server has no fan
+# control" from it would stop the controller sending a command the server does have, over an argument
+# it could have been sent differently.
+#
+# What it does NOT say is which byte. That has to come from the hardware, and on the one server it has
+# been reported from -- an R510 whose iDRAC6 answers 0xcc to the broadcast fan selector 0xff and takes
+# the very same command with a single fan's ID (issue #378) -- it is the selector
+function does_the_server_reject_this_data_field() {
+  local -r IPMITOOL_STDERR="$1"
+
+  [[ "$IPMITOOL_STDERR" == *"rsp=0xcc"* ]]
+}
+
 # Read one Redfish resource from the iDRAC and print what it answered.
 # Usage : redfish_get "<resource path>"
 # Prints : the HTTP status code on its own first line, then the response body
@@ -1783,6 +1806,53 @@ function note_that_the_server_refuses_fan_control() {
  Two things answer like this, and the completion code does not say which. Dell removed these commands from the 14th generation on -- an iDRAC 9 refuses them from firmware 3.34.34.34 onwards, and an iDRAC 10 has never had them -- and an iDRAC also refuses them to an account that is not an Administrator. This iDRAC reports firmware version ${IDRAC_FIRMWARE_VERSION:-unknown}.
  If your iDRAC is one that used to accept them, check the privilege level of IDRAC_USERNAME before concluding that the firmware is the reason. The README's \"iDRAC version\" section covers both.
  Nothing else changes : temperatures keep being read and logged every cycle, as MONITORING_ONLY_MODE would"
+}
+
+# Whether the server has already been told about the broadcast fan selector it rejects, so that it is
+# explained the once rather than on every cycle for the life of the container.
+# Only ever written by note_that_the_server_rejects_the_broadcast_fan_selector() below
+HAS_THE_BROADCAST_FAN_SELECTOR_REJECTION_BEEN_REPORTED=false
+
+# Read a refused fan speed command and, if the server refused it over its data bytes, explain the one
+# thing that answers like this and say it once.
+# Usage : note_that_the_server_rejects_the_broadcast_fan_selector "$IPMITOOL_STDERR"
+# Returns : 0 if this call is the one that explained it
+#
+# This deliberately reaches NO verdict and stops nothing being sent. It is the counterpart of
+# note_that_the_server_refuses_fan_control() for the other completion code, and the difference between
+# the two is the whole point : 0xc1, 0xd4 and 0xd5 are a server saying the command is not its to run,
+# while 0xcc is a server that has the command, ran it, and refused an argument. Giving up on the second
+# would stop the controller sending a command the server does have.
+#
+# What it says instead is the state the fans are actually in, which is the part a raw ipmitool line
+# repeated every 60 seconds does not. Only the second of the two commands failed here : the first one
+# has already taken the fans away from Dell's own dynamic fan control profile, and the speed that was
+# supposed to follow it never landed. The fans are therefore on neither profile -- not Dell's, and not
+# the user's -- which is exactly the shape of "too low with nobody raising them" reported in issue #378
+#
+# /!\ The per-fan fallback this points to is NOT implemented yet, and this message must not claim it is.
+# The one server that has reported this answers 0xcc to the broadcast selector 0xff and accepts the same
+# command with a single fan's ID, but one accepted ID says nothing about how many fans the server has
+# nor whether Dell numbers them from 0 or from 1, and addressing the wrong set would leave some fans
+# unset while reporting the profile applied
+function note_that_the_server_rejects_the_broadcast_fan_selector() {
+  local -r IPMITOOL_STDERR="$1"
+
+  if ! does_the_server_reject_this_data_field "$IPMITOOL_STDERR"; then
+    return 1
+  fi
+
+  if "$HAS_THE_BROADCAST_FAN_SELECTOR_REJECTION_BEEN_REPORTED"; then
+    return 1
+  fi
+
+  HAS_THE_BROADCAST_FAN_SELECTOR_REJECTION_BEEN_REPORTED=true
+
+  print_warning "This server took the command that puts its fans under manual control, then refused the one that sets their speed, over one of its arguments rather than over the command itself (completion code 0xcc, \"invalid data field in request\").
+ Its fans are consequently on neither profile : they have left Dell's own dynamic fan control profile, and the speed of $DECIMAL_FAN_SPEED% that was meant to replace it never reached them. They are running at whatever this iDRAC does with manual control and no speed set, which nothing here can read back.
+ The known cause is the fan selector : the speed is addressed to every fan at once with 0xff, and an 11th generation iDRAC6 has been reported to reject that and to accept the very same command addressed to one fan's ID at a time (issue #378). Sending it per fan instead is not implemented yet -- it needs to be known how many fans a server exposes and how this iDRAC numbers them, and guessing would silently leave some of them unset.
+ Until then, set MONITORING_ONLY_MODE=true so the container never takes the fans from Dell's own dynamic fan control profile at all and only logs temperatures, or stop it : stopping hands them back to that profile on the way out.
+ If your server answers this, the output of \"ipmitool -I lanplus -H <iDRAC IP address> -U <iDRAC username> -P <iDRAC password> sdr type fan\" on issue #378 is what is missing to implement it"
 }
 
 # Prepare traps in case of container exit

--- a/tests/cases/70_fan_control_profiles.sh
+++ b/tests/cases/70_fan_control_profiles.sh
@@ -468,3 +468,84 @@ function test_monitoring_only_mode_reaches_no_verdict_because_it_asks_nothing() 
   assert_contains "$CURRENT_FAN_CONTROL_PROFILE" "monitoring only, not applied"
   assert_equals "0" "$(count_ipmitool_calls_matching "raw 0x30 0x30")"
 }
+
+# What an 11th generation iDRAC6 answers to the fan speed command addressed to every fan at once, as
+# reported on an R510 in issue #378. The very same command with a single fan's ID is accepted there,
+# so this is the BMC refusing an argument, not the command
+readonly BROADCAST_FAN_SELECTOR_REJECTED_STDERR="Unable to send RAW command (channel=0x0 netfn=0x30 lun=0x0 cmd=0x30 rsp=0xcc): Invalid data field in request"
+
+function test_a_rejected_data_field_is_told_apart_from_a_command_the_server_does_not_have() {
+  # The distinction the whole change rests on. 0xcc is a server that HAS the fan control commands and
+  # refused an argument of one of them : reading it as "this server refuses fan control" would stop the
+  # controller sending commands an R510 does take, and would report fans left with Dell that are not
+  assert_command_succeeds "0xcc is the server refusing one of the command's data bytes" \
+    does_the_server_reject_this_data_field "$BROADCAST_FAN_SELECTOR_REJECTED_STDERR"
+  assert_command_fails "0xcc does not say the command is absent" \
+    does_the_server_lack_this_command "$BROADCAST_FAN_SELECTOR_REJECTED_STDERR"
+  assert_command_fails "0xcc does not say the account may not run it" \
+    does_the_command_need_a_higher_privilege_level "$BROADCAST_FAN_SELECTOR_REJECTED_STDERR"
+
+  local ANSWER
+  for ANSWER in "$REJECTED_BY_FIRMWARE_STDERR" "$FAN_CONTROL_REFUSED_FOR_PRIVILEGE_STDERR" \
+    "Unable to send RAW command (channel=0x0 netfn=0x30 lun=0x0 cmd=0x30 rsp=0xc0): Node busy" \
+    "Error: Unable to establish IPMI v2 / RMCP+ session" \
+    ""; do
+    assert_command_fails "\"$ANSWER\" is not a rejected data field" \
+      does_the_server_reject_this_data_field "$ANSWER"
+  done
+}
+
+function test_a_rejected_fan_selector_never_makes_the_controller_give_up_on_fan_control() {
+  # The regression this guards against : 0xcc reaching note_that_the_server_refuses_fan_control() would
+  # silence every later command on a server that accepts them, and graceful_exit would then skip the
+  # hand-back on the way out, leaving the fans under manual control for good
+  export MOCK_IPMITOOL_RAW_FAIL_PATTERN="0x30 0x30 0x02 0xff"
+  export MOCK_IPMITOOL_RAW_FAIL_STDERR="$BROADCAST_FAN_SELECTOR_REJECTED_STDERR"
+
+  capture_output apply_user_fan_control_profile
+
+  assert_command_fails "a rejected argument is not a server refusing fan control" \
+    has_the_server_refused_fan_control
+
+  forget_recorded_ipmitool_calls
+  capture_output apply_user_fan_control_profile
+
+  assert_equals "1" "$(count_ipmitool_calls_matching "$MANUAL_FAN_CONTROL_COMMAND")" \
+    "the commands must keep being sent to a server that has them"
+  assert_equals "1" "$(count_ipmitool_calls_matching "$FAN_SPEED_COMMAND")" \
+    "including the one that was refused, which a different selector could still land"
+}
+
+function test_a_rejected_fan_selector_is_explained_once_and_names_the_state_the_fans_are_in() {
+  # The defect from the user's side : the log repeated one raw ipmitool line a minute, and nothing said
+  # that manual control had been taken while the speed had not, which is why the fans sat "too low"
+  export MOCK_IPMITOOL_RAW_FAIL_PATTERN="0x30 0x30 0x02 0xff"
+  export MOCK_IPMITOOL_RAW_FAIL_STDERR="$BROADCAST_FAN_SELECTOR_REJECTED_STDERR"
+
+  capture_output apply_user_fan_control_profile
+
+  assert_contains "$CAPTURED_OUTPUT" "neither profile" \
+    "the fans are on neither Dell's profile nor the user's, and that is the part worth saying"
+  assert_contains "$CAPTURED_OUTPUT" "0xcc" \
+    "the completion code the verdict was read from must be quoted"
+  assert_contains "$CAPTURED_OUTPUT" "MONITORING_ONLY_MODE" \
+    "the one setting that gets this server out of it must be named"
+
+  forget_recorded_ipmitool_calls
+  capture_output apply_user_fan_control_profile
+
+  assert_not_contains "$CAPTURED_OUTPUT" "neither profile" \
+    "explained the once, not on every cycle for the life of the container"
+}
+
+function test_a_rejected_fan_selector_still_denies_the_profile() {
+  # Whatever is said about it, the table must not name a profile the fans are not running
+  export MOCK_IPMITOOL_RAW_FAIL_PATTERN="0x30 0x30 0x02 0xff"
+  export MOCK_IPMITOOL_RAW_FAIL_STDERR="$BROADCAST_FAN_SELECTOR_REJECTED_STDERR"
+
+  apply_user_fan_control_profile 2>/dev/null
+  local -r EXIT_CODE=$?
+
+  assert_equals "1" "$EXIT_CODE"
+  assert_contains "$CURRENT_FAN_CONTROL_PROFILE" "not applied"
+}

--- a/tests/lib/harness.sh
+++ b/tests/lib/harness.sh
@@ -42,6 +42,9 @@ function setup_test_context() {
   # accepted nothing, which is what the controller starts from too
   IS_FAN_CONTROL_SUPPORTED=true
   HAS_FAN_CONTROL_EVER_BEEN_ACCEPTED=false
+  # Same, for the one-off explanation of a rejected fan selector : a test starts against a server that
+  # has not been told anything yet
+  HAS_THE_BROADCAST_FAN_SELECTOR_REJECTION_BEEN_REPORTED=false
   # Settled once at startup by the controller, and read by build_header() and by every row it prints
   resolve_fan_control_profile_column_width
 


### PR DESCRIPTION
Groundwork for [#378](https://github.com/tigerblue77/Dell_iDRAC_fan_controller_Docker/issues/378). Diagnostic only — the per-fan fallback the issue points to is deliberately **not** in here, and the reason is below.

## What the issue actually contains

Two independent problems, and only the second is addressed here.

**(A) The blocker.** The container exits at startup on that R510 with `No CPU temperature sensor could be read`. That is what stopped it working, and nothing in this PR changes it — it needs the `ipmitool sdr type temperature` output, which has not been posted. [#110](https://github.com/tigerblue77/Dell_iDRAC_fan_controller_Docker/issues/110) (R610 + R310, iDRAC6 firmware 2.92, the same firmware) is the identical symptom and was closed `not_planned` for exactly that missing data. Asked for on the issue.

**(B) The fan selector.** `raw 0x30 0x30 0x02 0xff <speed>` is refused with `rsp=0xcc`, while the same command with a single fan's ID is accepted. This PR is about that.

## Not the regression it was read as

The reporter's diagnosis — that `0xff` was introduced three weeks ago — does not hold. `functions.sh` at tag `v1.12` already reads:

```bash
ipmitool -I $IDRAC_LOGIN_STRING raw 0x30 0x30 0x02 0xff $HEXADECIMAL_FAN_SPEED > /dev/null
```

Blame on `functions.sh:80` shows the last commit that *touched* the line (the stderr capture), not the one that introduced the byte. Their own v1.12 log carries `cmd=0x30 rsp=0xcc` too. The command has always failed on that hardware; older versions sent it to `/dev/null` and never checked the exit code. What changed is that failures are now detected — the reporting is the new part, not the bug.

## What this changes

`0xcc` is not the refusal the two existing predicates read. `0xc1`, `0xd4` and `0xd5` are a server saying the command is not its to run; `0xcc` is a server that **has** the command, ran it, and refused an argument. Reading the second as the first would stop the controller sending commands an R510 does take, and would have `graceful_exit()` report fans left with Dell that are not.

- `does_the_server_reject_this_data_field()` — the `0xcc` predicate, deliberately kept out of both existing ones.
- `note_that_the_server_rejects_the_broadcast_fan_selector()` — explains the situation **once** instead of repeating one raw ipmitool line every check interval. It reaches no verdict and stops nothing being sent: the command keeps going out, since a different selector could still land it.

The part the log never said is the safety-relevant one. Only the *second* of the two commands fails here — `raw 0x30 0x30 0x01 0x00` succeeds, so manual control has already been taken and the speed that was meant to follow never landed. The fans are on **neither** profile, running at whatever the iDRAC does with manual control and no speed set. That matches the reported "fans no longer running at the desired speeds (too low)", and `Dell_iDRAC_fan_controller.sh:519` ignores the return value, so it persists for the life of the container.

## What is deliberately absent

Sending the speed per fan. One accepted ID says nothing about how many fans the server exposes, nor whether Dell numbers them from 0 or from 1. Addressing the wrong set would leave some fans unset while the table reported the profile applied — a silent version of the current failure. `ipmitool sdr type fan` from the affected hardware is what that needs; it is requested on the issue and the fallback lands on a follow-up once it arrives.

The README's hardware table is left untouched for the same reason: the 11G `0xff` limitation gets documented in one go alongside the fallback, rather than half now and half later.

**Open question, out of scope here:** should the controller hand the fans back to Dell when it takes them but cannot set a speed? Today it keeps them, on an unknown duty, forever. That is a behaviour change with a loudness trade-off, so I left it alone.

## Testing

4 new cases in `tests/cases/70_fan_control_profiles.sh`, driven through the mock's existing `MOCK_IPMITOOL_RAW_FAIL_PATTERN`: the code is told apart from the other four answers a BMC can give; a rejected selector never makes the controller give up on fan control; it is explained once and names the state the fans are in; and the profile is still denied.

- Full suite: **442 test cases passed (2249 assertions)**, locally and on CI (including inside the Docker image)
- `shellcheck -x` over the CI-scoped scripts: clean
- Verified the new cases fail with the call removed, so they test the change rather than pass alongside it

Not verified against real R510/iDRAC6 hardware — everything runs against the mock, and the `rsp=0xcc` comes from the reporter's log rather than from a run on the machine.

Fixes nothing on its own for the reporter — (A) still exits first. Said plainly on the issue.