### PR TITLE
Tell a fresh session what this repository already knows about itself

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: 2020-2026 Tigerblue77 and the Dell iDRAC fan controller Docker image contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+
+# SessionStart hook for Claude Code on the web.
+#
+# The test suite needs nothing but bash, coreutils, GNU grep and awk, all of which the
+# remote image already has - it mocks ipmitool, lm-sensors and perl, so a session can run
+# ./tests/run_tests.sh the moment it starts.
+#
+# The gap is shellcheck. The Shellcheck workflow gates every pull request on it and the
+# remote image ships without it, so an agent working here has no way to run the check that
+# will decide its push. Installing it up front turns "push and find out" into a local run,
+# which is one CI round trip saved per finding.
+#
+# jq is the same story a size smaller : tests/cases/14_latest_tag_reconciliation.sh skips
+# itself where jq is missing, so a run without it is quietly a little less green than it
+# looks.
+#
+# Best-effort by design : the suite does not need either of them, so a package index that
+# cannot be reached costs the session its linter, not its start. It says so and exits 0.
+
+set -uo pipefail
+
+# Local checkouts are the developer's own machine, with their own package manager and
+# their own idea of what should be installed on it
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+MISSING_PACKAGES=()
+for PACKAGE in shellcheck jq; do
+  command -v "$PACKAGE" > /dev/null 2>&1 || MISSING_PACKAGES+=("$PACKAGE")
+done
+
+# Idempotent : the container state is cached once the hook has run, so the second session
+# onwards finds both already there and does nothing
+if [ ${#MISSING_PACKAGES[@]} -eq 0 ]; then
+  echo "session-start : shellcheck and jq are already installed"
+  exit 0
+fi
+
+echo "session-start : installing ${MISSING_PACKAGES[*]}"
+
+export DEBIAN_FRONTEND=noninteractive
+
+if ! apt-get update -qq > /dev/null 2>&1; then
+  echo "session-start : could not refresh the package index, carrying on without ${MISSING_PACKAGES[*]}" >&2
+fi
+
+if ! apt-get install -y --no-install-recommends "${MISSING_PACKAGES[@]}" > /dev/null 2>&1; then
+  echo "session-start : could not install ${MISSING_PACKAGES[*]}." >&2
+  echo "session-start : the test suite still runs (./tests/run_tests.sh) ; shellcheck findings will only surface in CI." >&2
+  exit 0
+fi
+
+for PACKAGE in "${MISSING_PACKAGES[@]}"; do
+  if command -v "$PACKAGE" > /dev/null 2>&1; then
+    echo "session-start : $PACKAGE $("$PACKAGE" --version 2>&1 | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?' | head -1) installed"
+  else
+    echo "session-start : $PACKAGE reported installed but is not on the PATH" >&2
+  fi
+done

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -3,15 +3,20 @@
 
 name: Shellcheck
 
-# Scoped to the scripts nothing else would catch a mistake in, which is two groups and not one.
+# Scoped to the scripts nothing else would catch a mistake in, which is three groups and not one.
 #
 # The 5 shipped in the Docker image, because a finding there affects runtime, on real hardware. And the 3
 # under .github/, because they decide what gets published - which version "latest" points at, whether a
 # release note is written, what the Docker Hub page says - and the first time any of them runs is on the
 # tag or the push that publishes it. Neither of the workflows carrying them fires on a pull request.
 #
-# The tests/ tree stays out for the reason those three do not have : the suite runs on every pull request,
-# so a mistake in it is found the moment it is pushed rather than at release time.
+# And the SessionStart hook under .claude/, for the same reason again : it runs when a Claude Code on the
+# web session opens, which is somewhere no workflow and no test ever looks. It earned its place here the
+# moment it was written - a comment line opening with the linter's own name parsed as a directive, which
+# only this job would have found.
+#
+# The tests/ tree stays out for the reason those do not have : the suite runs on every pull request, so a
+# mistake in it is found the moment it is pushed rather than at release time.
 #
 # -x resolves the "source functions.sh" / "source constants.sh" lines so shared declarations are understood
 # correctly instead of reported as unknown or unused when the sourcing file is linted on its own.
@@ -47,4 +52,5 @@ jobs:
             supervisor.sh \
             .github/generate_dockerhub_description.sh \
             .github/reconcile_latest_tag.sh \
-            .github/release_note_already_exists.sh
+            .github/release_note_already_exists.sh \
+            .claude/hooks/session-start.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,116 @@
+<!--
+SPDX-FileCopyrightText: 2020-2026 Tigerblue77 and the Dell iDRAC fan controller Docker image contributors
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
+# Working in this repository
+
+Bash, no build step, no package manager. A container reads the CPU temperatures of a
+Dell PowerEdge server over IPMI and drives its fans. It talks to twenty years of Dell
+firmware, so most of the difficulty here is in what a given generation accepts, not in
+the control logic.
+
+## Layout
+
+| File | What it holds |
+| --- | --- |
+| `supervisor.sh` | The image's entrypoint. Starts the controller and, if it dies without doing it itself, hands the fans back to Dell |
+| `Dell_iDRAC_fan_controller.sh` | Configuration validation, then the monitoring loop |
+| `functions.sh` | Every function (76, flat namespace, no modules) |
+| `constants.sh` | The raw IPMI commands and the tables they are read against |
+| `healthcheck.sh` | `HEALTHCHECK` for the image |
+| `tests/` | The suite. See `tests/README.md`, which is thorough — read it before touching a test |
+
+`Dell_iDRAC_fan_controller.sh`, `healthcheck.sh` and `supervisor.sh` each `source
+functions.sh` and `constants.sh`. That is the entire dependency graph.
+
+## Commands
+
+```bash
+./tests/run_tests.sh                 # the whole suite : no hardware, no iDRAC, no network
+./tests/run_tests.sh -f temperature  # only the cases whose name matches
+./tests/run_tests.sh --list          # list them without running
+
+shellcheck -x Dell_iDRAC_fan_controller.sh functions.sh constants.sh \
+              healthcheck.sh supervisor.sh .github/*.sh   # what CI lints
+
+docker build -t dell_idrac_fan_controller:dev .
+```
+
+Run both before pushing. CI runs the suite twice — on the runner and inside the built
+image — and shellcheck on every pull request.
+
+## Conventions
+
+- **Sign off every commit.** `git commit -s`. A commit without `Signed-off-by` is not
+  mergeable ; see `CONTRIBUTING.md` for what it certifies in a dual-licensed project.
+- **Every new shell script carries the two SPDX lines** right after the shebang, test
+  cases, mocks and helpers included. Copy them from any existing script.
+- **A new script under the repository root or `.github/` must be added by hand to
+  `.github/workflows/shellcheck.yml`.** That workflow names its files one by one
+  instead of globbing, and `tests/cases/10_shell_scripts.sh` guards the list —
+  a script missing from it is analysed by nothing at all.
+- **Add a test case for what you change.** A behaviour with no test is one the next
+  refactor is free to break, and this codebase's refactors span a hundred server models.
+
+## Invariants that are not obvious from the code
+
+These are settled decisions with a cost behind them. Do not "clean them up".
+
+- **One command substitution per statement.** Bash re-parses the text of every `$( )`
+  at expansion time and runs pending trap handlers from inside that same reader loop.
+  A `SIGTERM` landing there gets its handler parsed with the substitution still open,
+  `graceful_exit` never runs, and the container dies leaving the fans on the user's
+  static speed (issue #188). Measured : two substitutions in one expansion failed 61
+  to 182 times in 250 runs, one alone failed 2. Compute into a variable, then use the
+  variable. `tests/cases/10_shell_scripts.sh` enforces this.
+- **`IDRAC_LOGIN_STRING` is deliberately left unquoted** at every `ipmitool` call site.
+  It is a single space-separated string of arguments that has to split back into
+  separate argv entries ; quoting it passes `ipmitool` one argument instead of several
+  and breaks every call in network mode. This is why `SC2086` and `SC2206` are disabled
+  project-wide in `.shellcheckrc` — everywhere else, variables are quoted.
+- **Test case names must be unique across the whole suite.** Every file in
+  `tests/cases/` is sourced into one shell, so a duplicate name would silently replace
+  a definition. The runner refuses to start rather than allow it.
+- **Assertions do not stop a test case.** They record and carry on, so a loop over a
+  hundred server models reports every offending one in a single run. Use
+  `assert_... || return 1` when the rest of the case cannot run after a failure.
+- **The controller must keep trying after a rejected fan control command.** Recent
+  generations refuse Dell's IPMI raw commands outright ; the correct behaviour is to
+  say so once and keep monitoring, never to exit.
+
+## Writing a test case
+
+Add a `test_<what it checks>` function to the relevant `tests/cases/*.sh` file. The
+runner discovers it in declaration order and turns its name into the reported line —
+nothing to register.
+
+```bash
+function test_a_single_cpu_server_reports_one_cpu() {
+  export MOCK_IPMITOOL_SDR_OUTPUT
+  MOCK_IPMITOOL_SDR_OUTPUT=$(make_sdr_output --cpus 1 --cpu-temperatures "44")
+
+  retrieve_temperatures "$SDR_DATA"
+
+  assert_equals "1" "$NUMBER_OF_DETECTED_CPUS"
+}
+```
+
+Describe the server with `simulate_server` / `simulate_enclosure_housed_server`, build
+`ipmitool` output with `make_fru_output` and `make_sdr_output` (options in
+`tests/lib/fixtures.sh`), set what the server answers with the `MOCK_IPMITOOL_*`
+variables (`tests/mocks/ipmitool`), read back what was sent with
+`count_ipmitool_calls_matching`, and start the whole controller the way the image does
+with `run_controller`.
+
+Server models come from `tests/lib/dell_server_catalogue.sh` : a hundred-plus PowerEdge
+models from the 9th generation (2006) to the 17th (2024), each with its socket count,
+whether its firmware still accepts the raw fan control commands, and its enclosure.
+Blades and modular sleds carry no fan of their own — the enclosure's CMC does — so the
+controller cannot cool them, and the suite pins what it does instead.
+
+## Environment
+
+`.claude/hooks/session-start.sh` installs `shellcheck` in Claude Code on the web, where
+it is otherwise missing while CI still gates on it. `ipmitool`, `lm-sensors` and `perl`
+are not needed to run the suite — it mocks them.


### PR DESCRIPTION
Closes #380.

Three files, one of them a one-line change to an existing workflow.

## `CLAUDE.md`

The layout, the commands, the conventions, and — the part worth the file — the invariants that look like defects until you know why they are there. The unquoted `IDRAC_LOGIN_STRING`, one command substitution per statement (#188), test case names being unique across a suite sourced into one shell, assertions that record and carry on, and the rule that a rejected fan control command must never stop the controller.

Each of those is already explained in a comment somewhere in the tree. The point is not to restate them: it is that they are currently discoverable only by reading the file that happens to carry the explanation, which is exactly what a session does not do before editing.

It points at `tests/README.md` rather than paraphrasing it. That file is already thorough, and a second copy of it would be a drift risk, not a convenience — which is also why this branch adds no test-harness skill.

## `.claude/hooks/session-start.sh` + `.claude/settings.json`

`shellcheck` gates every pull request and is absent from the Claude Code on the web image. A session here could not run the check that would decide its push. The hook installs `shellcheck` and `jq`, and:

- **does nothing on a local checkout** — it returns early unless `CLAUDE_CODE_REMOTE=true`, because a developer's machine is their own business
- **is idempotent** — the container state is cached once it has run, so the second session onwards finds both present and exits
- **is best-effort** — the suite needs neither of them, so an unreachable package index costs the session its linter, not its start. It says so on stderr and exits 0.

Synchronous, so nothing races it. Measured cold cost below.

## `.github/workflows/shellcheck.yml`

The hook is a script that runs where no workflow and no test ever looks, which is the stated reason the other eight are in that job, so it joins them — with the scope comment updated from two groups to three.

It earned the place immediately: the first draft had a comment line opening with the linter's own name, which `shellcheck` parses as a directive (`SC1072`/`SC1073`). Nothing else in this repository would have found that.

`tests/cases/10_shell_scripts.sh` asserts that every root and `.github/` script appears in that list; it does not constrain the converse, so the extra entry passes as-is.

## Validation

Run in this environment, on this branch:

| Check | Result |
| --- | --- |
| `./tests/run_tests.sh` | **442 test cases passed, 2249 assertions** — identical to the count on `master` before the change |
| `shellcheck -x` on the full CI list plus the hook | **rc=0** |
| Hook, `CLAUDE_CODE_REMOTE` unset | no output, rc=0 |
| Hook, `CLAUDE_CODE_REMOTE=false` | no output, rc=0 |
| Hook, remote, `shellcheck` removed first | installed 0.9.0 in **12.6 s**, rc=0 |
| Hook, remote, run again | reported both already installed, rc=0 |

The install path was exercised for real — `shellcheck` was uninstalled and the hook re-run — rather than inferred from the idempotent branch.

## One thing to settle before merging

The commit is signed off as `Claude <noreply@anthropic.com>`, which is the configured git identity, not a person. `CONTRIBUTING.md` asks for a real name and a reachable address, and the DCO is an attestation only a human can make. Re-sign with your own identity before merging:

```bash
git commit --amend -s --author="Your Name <you@example.org>"
```

## Follow-ups, opened separately so they can be refused separately

- #381 — guard `CLAUDE.md` against drift with a test case, the way the shellcheck list is already guarded
- #382 — a short `permissions.allow` list, with the security trade-off argued rather than assumed

---
_Generated by [Claude Code](https://claude.ai/code/session_01FMfRqcqDSvp2r2Yw8HxQf6)_