### PR TITLE
Pre-approve the repository's routine commands so a session stops asking (#382)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,5 +10,12 @@
         ]
       }
     ]
+  },
+  "permissions": {
+    "allow": [
+      "Bash(./tests/run_tests.sh:*)",
+      "Bash(shellcheck:*)",
+      "Bash(bash -n:*)"
+    ]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,7 +13,7 @@
   },
   "permissions": {
     "allow": [
-      "Bash(./tests/run_tests.sh:*)",
+      "Bash(./tests/run_tests.sh)",
       "Bash(shellcheck:*)",
       "Bash(bash -n:*)"
     ]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,10 +115,12 @@ controller cannot cool them, and the suite pins what it does instead.
 it is otherwise missing while CI still gates on it. `ipmitool`, `lm-sensors` and `perl`
 are not needed to run the suite — it mocks them.
 
-`.claude/settings.json` also pre-approves the three commands of the working loop —
-`./tests/run_tests.sh`, `shellcheck` and `bash -n` — so a session runs them without
-stopping to ask. They are the ones that execute nothing they read and write nothing
-outside the tree ; `git` and `docker build` were deliberately left out (issue #382).
-That list is a standing grant to every session opened here, so adding to it is a
-decision to argue, not a line to append : `tests/cases/11_claude_code_settings.sh`
-holds it.
+`.claude/settings.json` also pre-approves three commands, so a session runs them without
+stopping to ask : `./tests/run_tests.sh` **exactly**, then `shellcheck` and `bash -n`
+with any arguments. The suite's rule carries no `:*` on purpose — a prefix rule
+pre-approves every argument list, and `--junit FILE` / `--summary FILE` create
+directories and truncate files wherever they are pointed ; `shellcheck` and `bash -n`
+have no option that names a file to write. `git` and `docker build` were deliberately
+left out (issue #382). That list is a standing grant to every session opened here, so
+adding to it is a decision to argue, not a line to append :
+`tests/cases/11_claude_code_settings.sh` holds it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,3 +114,11 @@ controller cannot cool them, and the suite pins what it does instead.
 `.claude/hooks/session-start.sh` installs `shellcheck` in Claude Code on the web, where
 it is otherwise missing while CI still gates on it. `ipmitool`, `lm-sensors` and `perl`
 are not needed to run the suite — it mocks them.
+
+`.claude/settings.json` also pre-approves the three commands of the working loop —
+`./tests/run_tests.sh`, `shellcheck` and `bash -n` — so a session runs them without
+stopping to ask. They are the ones that execute nothing they read and write nothing
+outside the tree ; `git` and `docker build` were deliberately left out (issue #382).
+That list is a standing grant to every session opened here, so adding to it is a
+decision to argue, not a line to append : `tests/cases/11_claude_code_settings.sh`
+holds it.

--- a/tests/README.md
+++ b/tests/README.md
@@ -21,7 +21,7 @@ It exits `0` when every test case passed, `1` otherwise.
 | File | What it checks |
 | --- | --- |
 | `cases/10_shell_scripts.sh` | Syntax of every script, files shipped in the Docker image, drift between the code and what documents it, healthcheck |
-| `cases/11_claude_code_settings.sh` | The settings a Claude Code session starts from, which no server ever reads : that the file still parses, and that the commands it lets any session run without asking are the read-only ones argued for, still runnable, and only those |
+| `cases/11_claude_code_settings.sh` | The settings a Claude Code session starts from, which no server ever reads : that the file still parses, and that the rules letting any session run a command without asking are the ones argued for — in the shape they were argued in, still runnable, and only those. Skipped where `jq` is missing, the list being read out of JSON |
 | `cases/12_github_workflows.sh` | The two publishing workflows no pull request ever runs : the release build and the base image refresh. Also that every workflow carries the licence header, which is the whole directory rather than those two |
 | `cases/13_dockerhub_description.sh` | The page Docker Hub shows on the image's repository, built by a workflow no pull request fires either : that it stays a pointer at the documentation rather than a copy of it, and that no change to `README.md` can alter it |
 | `cases/14_latest_tag_reconciliation.sh` | Which version `latest` ends up on after a release, against a stubbed registry. Skipped where `jq` is missing, the one thing the script needs that the suite does not |

--- a/tests/README.md
+++ b/tests/README.md
@@ -21,6 +21,7 @@ It exits `0` when every test case passed, `1` otherwise.
 | File | What it checks |
 | --- | --- |
 | `cases/10_shell_scripts.sh` | Syntax of every script, files shipped in the Docker image, drift between the code and what documents it, healthcheck |
+| `cases/11_claude_code_settings.sh` | The settings a Claude Code session starts from, which no server ever reads : that the file still parses, and that the commands it lets any session run without asking are the read-only ones argued for, still runnable, and only those |
 | `cases/12_github_workflows.sh` | The two publishing workflows no pull request ever runs : the release build and the base image refresh. Also that every workflow carries the licence header, which is the whole directory rather than those two |
 | `cases/13_dockerhub_description.sh` | The page Docker Hub shows on the image's repository, built by a workflow no pull request fires either : that it stays a pointer at the documentation rather than a copy of it, and that no change to `README.md` can alter it |
 | `cases/14_latest_tag_reconciliation.sh` | Which version `latest` ends up on after a release, against a stubbed registry. Skipped where `jq` is missing, the one thing the script needs that the suite does not |

--- a/tests/cases/11_claude_code_settings.sh
+++ b/tests/cases/11_claude_code_settings.sh
@@ -23,11 +23,17 @@ readonly CLAUDE_CODE_SETTINGS_FILE=".claude/settings.json"
 #
 # jq is the second condition. The list is read out of a JSON file, and reading JSON
 # with sed is how the first version of this guard came to stop at the first "]" of a
-# rule and report green over everything that followed it. The suite's own
-# dependencies stop at bash, coreutils, grep and awk, so a machine without jq skips
-# these rather than turning the promise in tests/README.md into a lie -- the same
-# trade cases/14 makes, and every runner, the devcontainer and the SessionStart hook
-# provide it
+# rule and report green over everything that followed it. Two rewrites that kept to
+# grep and awk were tried and measured against jq : both mis-read a rule holding an
+# escaped quote, "Bash(grep -E \"[0-9]\":*)", and one of them stopped there and never
+# saw the two entries after it. A rule can contain any character JSON can carry, so
+# what reads it has to be a JSON parser.
+#
+# The suite's own dependencies stop at bash, coreutils, grep and awk, so a machine
+# without jq skips these rather than turning the promise in tests/README.md into a
+# lie -- the same trade cases/14 makes. The skip is reported rather than silent, the
+# runner counts it, and every runner, the devcontainer and the SessionStart hook
+# provide jq : what gates a pull request runs these for real
 # Usage : if ! claude_code_settings_can_be_read; then skip_test "..."; return 0; fi
 function claude_code_settings_can_be_read() {
   [ -f "$REPO_ROOT/$CLAUDE_CODE_SETTINGS_FILE" ] && command -v jq > /dev/null 2>&1

--- a/tests/cases/11_claude_code_settings.sh
+++ b/tests/cases/11_claude_code_settings.sh
@@ -18,22 +18,31 @@
 
 readonly CLAUDE_CODE_SETTINGS_FILE=".claude/settings.json"
 
-# The permission rules the settings pre-approve, one per line, exactly as written.
+# The suite also runs inside the built image, which carries the shipped scripts and
+# none of the files a contributor works with : no .github, no .claude.
 #
-# jq is not a dependency of this suite -- tests/README.md promises it runs on bash,
-# coreutils, grep and awk alone -- and this file is small, hand-written and ours, so
-# the array is isolated by its key and then read one quoted string at a time
-function pre_approved_permission_rules() {
-  local -r SETTINGS_ON_ONE_LINE=$(tr '\n' ' ' < "$REPO_ROOT/$CLAUDE_CODE_SETTINGS_FILE")
-  local -r ALLOW_LIST=$(printf '%s' "$SETTINGS_ON_ONE_LINE" | sed -n 's/.*"allow"[[:space:]]*:[[:space:]]*\[\([^]]*\)\].*/\1/p')
-
-  printf '%s' "$ALLOW_LIST" | grep -oE '"[^"]*"' | tr -d '"'
+# jq is the second condition. The list is read out of a JSON file, and reading JSON
+# with sed is how the first version of this guard came to stop at the first "]" of a
+# rule and report green over everything that followed it. The suite's own
+# dependencies stop at bash, coreutils, grep and awk, so a machine without jq skips
+# these rather than turning the promise in tests/README.md into a lie -- the same
+# trade cases/14 makes, and every runner, the devcontainer and the SessionStart hook
+# provide it
+# Usage : if ! claude_code_settings_can_be_read; then skip_test "..."; return 0; fi
+function claude_code_settings_can_be_read() {
+  [ -f "$REPO_ROOT/$CLAUDE_CODE_SETTINGS_FILE" ] && command -v jq > /dev/null 2>&1
 }
 
-# The command a permission rule pre-approves, stripped of the "Bash(...)" wrapper
-# and of the ":*" that makes the rule match a prefix : "Bash(shellcheck:*)" reads
-# back as "shellcheck". A rule of any other shape is returned untouched, which is
-# what makes it fail the guard below rather than pass it under a wrong name
+# The permission rules the settings pre-approve, one per line, exactly as written
+function pre_approved_permission_rules() {
+  jq -r '.permissions.allow[]?' "$REPO_ROOT/$CLAUDE_CODE_SETTINGS_FILE" 2> /dev/null
+}
+
+# The command a permission rule pre-approves, stripped of the "Bash(...)" wrapper and
+# of the ":*" that makes a rule match a prefix rather than one exact command line :
+# "Bash(shellcheck:*)" reads back as "shellcheck". A rule of any other shape is
+# returned untouched, which is what makes it fail the guard below rather than pass it
+# under a wrong name
 # Usage : pre_approved_command "Bash(shellcheck:*)" -> "shellcheck"
 function pre_approved_command() {
   local RULE="$1"
@@ -53,19 +62,8 @@ function test_the_claude_code_settings_are_valid_json() {
   # installing shellcheck, the permission list stops pre-approving anything, and
   # the only symptom is a session that asks about everything again -- which reads
   # as "the grant was refused" rather than as "the JSON has a trailing comma"
-  if [ ! -f "$REPO_ROOT/$CLAUDE_CODE_SETTINGS_FILE" ]; then
-    # The suite is running inside the built image, which carries the shipped
-    # scripts and none of the files a contributor works with
-    skip_test "no .claude next to the scripts"
-    return 0
-  fi
-
-  if ! command -v jq > /dev/null 2>&1; then
-    # Same reasoning as cases/14 : the suite's own dependencies stop at bash,
-    # coreutils, grep and awk, so a machine without jq skips this rather than
-    # turning the promise in tests/README.md into a lie. Every runner, the
-    # devcontainer and the SessionStart hook provide it
-    skip_test "jq is missing"
+  if ! claude_code_settings_can_be_read; then
+    skip_test "no .claude next to the scripts, or no jq to read it with"
     return 0
   fi
 
@@ -73,16 +71,22 @@ function test_the_claude_code_settings_are_valid_json() {
     jq empty "$REPO_ROOT/$CLAUDE_CODE_SETTINGS_FILE"
 }
 
-function test_every_pre_approved_command_is_read_only_or_sandboxed() {
-  # The three rules #382 settled on share one property : none of them can change
-  # anything outside the tree, whoever asked for them to run.
+function test_every_pre_approved_rule_is_one_that_was_argued() {
+  # The rules #382 settled on, and the shape each of them is written in. Both halves
+  # matter, which is why this compares whole rules rather than the commands inside
+  # them : ":*" is not decoration, it pre-approves every argument list there is, and
+  # an argument list is where a harmless command stops being one.
   #
-  # - ./tests/run_tests.sh mocks ipmitool, lm-sensors and sleep, needs no iDRAC and
-  #   no network, and writes only under its own temporary directory
-  # - shellcheck reads the scripts, analyses them, and executes none of them
-  # - bash -n parses a script without running a single statement of it
-  # (the dashes are not decoration : a comment line beginning with the linter's own
-  # name is read by it as a directive, and refuses to parse)
+  # - Bash(./tests/run_tests.sh) is EXACT, deliberately. Run with no arguments the
+  #   suite mocks ipmitool, lm-sensors and sleep, needs no iDRAC and no network, and
+  #   writes only inside the throwaway directory it makes with mktemp -d. Run as
+  #   "--junit FILE" or "--summary FILE" it creates directories and truncates files
+  #   wherever the caller points it (tests/lib/reports.sh), which a prefix rule would
+  #   hand to every session without a prompt. Filtered runs are one prompt each ;
+  #   that is the price of the entry staying what it claims to be.
+  # - Bash(shellcheck:*) and Bash(bash -n:*) are prefixes, which is safe here for the
+  #   reason the first one is not : neither has an option that names a file to write.
+  #   They read, they analyse, and bash -n parses without running a statement of it.
   #
   # Two commands were argued out and are meant to stay out. "git" : "git diff" is
   # harmless, but the prefix matching that would allow it is easy to widen by
@@ -93,8 +97,8 @@ function test_every_pre_approved_command_is_read_only_or_sandboxed() {
   # Nothing in Claude Code will ever refuse a fourth entry, so this is the only
   # place that can : a rule outside the vetted set fails here, and widening the
   # grant means coming back to this comment and arguing the new one the same way
-  if [ ! -f "$REPO_ROOT/$CLAUDE_CODE_SETTINGS_FILE" ]; then
-    skip_test "no .claude next to the scripts"
+  if ! claude_code_settings_can_be_read; then
+    skip_test "no .claude next to the scripts, or no jq to read it with"
     return 0
   fi
 
@@ -106,16 +110,18 @@ function test_every_pre_approved_command_is_read_only_or_sandboxed() {
     "$CLAUDE_CODE_SETTINGS_FILE should pre-approve the repository's routine commands, or this guard watches nothing" ||
     return 1
 
-  local RULE COMMAND
+  local RULE
   while IFS= read -r RULE; do
-    COMMAND=$(pre_approved_command "$RULE")
-
-    case "$COMMAND" in
-      './tests/run_tests.sh' | 'shellcheck' | 'bash -n')
+    case "$RULE" in
+      'Bash(./tests/run_tests.sh)' | 'Bash(shellcheck:*)' | 'Bash(bash -n:*)')
         pass ;;
+      'Bash(./tests/run_tests.sh:*)')
+        fail "[$RULE] grants the suite by prefix, which pre-approves every argument list it takes" \
+          "--junit FILE and --summary FILE create directories and truncate files wherever the caller points them" \
+          "the rule that was argued is the exact one : Bash(./tests/run_tests.sh)" ;;
       *)
-        fail "[$RULE] is pre-approved for every session opened on this repository, and it is not one of the commands #382 argued for" \
-          "the vetted ones are : ./tests/run_tests.sh (mocked and self-contained), shellcheck and bash -n (analysers that run nothing)" \
+        fail "[$RULE] is pre-approved for every session opened on this repository, and it is not one of the rules #382 argued for" \
+          "the vetted ones are : Bash(./tests/run_tests.sh), Bash(shellcheck:*), Bash(bash -n:*)" \
           "git and docker build were deliberately left out ; a new entry has to be argued the same way, here and in the settings" ;;
     esac
   done < <(printf '%s\n' "$PERMISSION_RULES")
@@ -129,8 +135,8 @@ function test_every_pre_approved_command_is_one_the_repository_still_runs() {
   #
   # Each command is held to the thing in the tree that proves the repository still
   # runs it, rather than to a second copy of the list
-  if [ ! -f "$REPO_ROOT/$CLAUDE_CODE_SETTINGS_FILE" ]; then
-    skip_test "no .claude next to the scripts"
+  if ! claude_code_settings_can_be_read; then
+    skip_test "no .claude next to the scripts, or no jq to read it with"
     return 0
   fi
 
@@ -156,16 +162,19 @@ function test_every_pre_approved_command_is_one_the_repository_still_runs() {
           fail "shellcheck is pre-approved but no workflow gates a pull request on it any more"
         fi ;;
       'bash -n')
-        # The syntax check cases/10 runs over every script of the repository. This
-        # file is the one place the search leaves out : it names the command in
-        # every second comment, and would answer the question with itself
+        # The syntax check in cases/10, which is the only thing in the suite that
+        # runs it. A comment does not count : cases/10 names the command in one of
+        # its own comments, so a plain search for the string stayed green with the
+        # function that runs it deleted -- and this file names it more often still.
+        # Comments are skipped the way cases/10 skips them for the same reason, and
+        # this file is left out of the search altogether
         local THIS_CASE_FILE
         THIS_CASE_FILE=$(basename "${BASH_SOURCE[0]}")
 
-        if grep -rqF --exclude="$THIS_CASE_FILE" -- 'bash -n' "$TESTS_DIRECTORY/cases"; then
+        if grep -rqE --exclude="$THIS_CASE_FILE" -- '^[^#]*bash -n' "$TESTS_DIRECTORY/cases"; then
           pass
         else
-          fail "bash -n is pre-approved but the suite does not run it any more"
+          fail "bash -n is pre-approved but nothing in the suite runs it any more"
         fi ;;
       *)
         fail "nothing in the tree proves this repository still runs [$COMMAND]" \

--- a/tests/cases/11_claude_code_settings.sh
+++ b/tests/cases/11_claude_code_settings.sh
@@ -1,0 +1,175 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: 2020-2026 Tigerblue77 and the Dell iDRAC fan controller Docker image contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+
+# The settings a Claude Code session starts from, under .claude/.
+#
+# Nothing in there reaches a server : the file holds the SessionStart hook that
+# installs the linter CI gates on, and the list of commands a session may run
+# without stopping to ask for a human's approval first.
+#
+# That list is a standing grant. It is not given to the person who wrote it, it is
+# given to every session ever opened on this repository, including one acting on a
+# prompt that came from a pull request body, an issue comment or a fetched page. So
+# what belongs in it was argued rather than assumed (issue #382), and this file is
+# where that argument is held against the settings : one guard for what the list may
+# contain, one for whether the repository still runs what it names.
+
+readonly CLAUDE_CODE_SETTINGS_FILE=".claude/settings.json"
+
+# The permission rules the settings pre-approve, one per line, exactly as written.
+#
+# jq is not a dependency of this suite -- tests/README.md promises it runs on bash,
+# coreutils, grep and awk alone -- and this file is small, hand-written and ours, so
+# the array is isolated by its key and then read one quoted string at a time
+function pre_approved_permission_rules() {
+  local -r SETTINGS_ON_ONE_LINE=$(tr '\n' ' ' < "$REPO_ROOT/$CLAUDE_CODE_SETTINGS_FILE")
+  local -r ALLOW_LIST=$(printf '%s' "$SETTINGS_ON_ONE_LINE" | sed -n 's/.*"allow"[[:space:]]*:[[:space:]]*\[\([^]]*\)\].*/\1/p')
+
+  printf '%s' "$ALLOW_LIST" | grep -oE '"[^"]*"' | tr -d '"'
+}
+
+# The command a permission rule pre-approves, stripped of the "Bash(...)" wrapper
+# and of the ":*" that makes the rule match a prefix : "Bash(shellcheck:*)" reads
+# back as "shellcheck". A rule of any other shape is returned untouched, which is
+# what makes it fail the guard below rather than pass it under a wrong name
+# Usage : pre_approved_command "Bash(shellcheck:*)" -> "shellcheck"
+function pre_approved_command() {
+  local RULE="$1"
+
+  if [[ "$RULE" == Bash\(*\) ]]; then
+    RULE="${RULE#Bash(}"
+    RULE="${RULE%)}"
+    RULE="${RULE%':*'}"
+  fi
+
+  printf '%s' "$RULE"
+}
+
+function test_the_claude_code_settings_are_valid_json() {
+  # A settings file that does not parse is not a settings file with one broken
+  # entry : the whole of it is dropped, silently. The SessionStart hook stops
+  # installing shellcheck, the permission list stops pre-approving anything, and
+  # the only symptom is a session that asks about everything again -- which reads
+  # as "the grant was refused" rather than as "the JSON has a trailing comma"
+  if [ ! -f "$REPO_ROOT/$CLAUDE_CODE_SETTINGS_FILE" ]; then
+    # The suite is running inside the built image, which carries the shipped
+    # scripts and none of the files a contributor works with
+    skip_test "no .claude next to the scripts"
+    return 0
+  fi
+
+  if ! command -v jq > /dev/null 2>&1; then
+    # Same reasoning as cases/14 : the suite's own dependencies stop at bash,
+    # coreutils, grep and awk, so a machine without jq skips this rather than
+    # turning the promise in tests/README.md into a lie. Every runner, the
+    # devcontainer and the SessionStart hook provide it
+    skip_test "jq is missing"
+    return 0
+  fi
+
+  assert_command_succeeds "$CLAUDE_CODE_SETTINGS_FILE should parse, a settings file that does not is ignored whole" \
+    jq empty "$REPO_ROOT/$CLAUDE_CODE_SETTINGS_FILE"
+}
+
+function test_every_pre_approved_command_is_read_only_or_sandboxed() {
+  # The three rules #382 settled on share one property : none of them can change
+  # anything outside the tree, whoever asked for them to run.
+  #
+  # - ./tests/run_tests.sh mocks ipmitool, lm-sensors and sleep, needs no iDRAC and
+  #   no network, and writes only under its own temporary directory
+  # - shellcheck reads the scripts, analyses them, and executes none of them
+  # - bash -n parses a script without running a single statement of it
+  # (the dashes are not decoration : a comment line beginning with the linter's own
+  # name is read by it as a directive, and refuses to parse)
+  #
+  # Two commands were argued out and are meant to stay out. "git" : "git diff" is
+  # harmless, but the prefix matching that would allow it is easy to widen by
+  # accident and the blast radius of getting it wrong once is the branch.
+  # "docker build" : it runs apt-get against the network as root inside the build,
+  # which is not something to grant standing approval to for the sake of one prompt.
+  #
+  # Nothing in Claude Code will ever refuse a fourth entry, so this is the only
+  # place that can : a rule outside the vetted set fails here, and widening the
+  # grant means coming back to this comment and arguing the new one the same way
+  if [ ! -f "$REPO_ROOT/$CLAUDE_CODE_SETTINGS_FILE" ]; then
+    skip_test "no .claude next to the scripts"
+    return 0
+  fi
+
+  local -r PERMISSION_RULES=$(pre_approved_permission_rules)
+
+  # Without this the loop below would report green by having nothing to iterate
+  # over, which is the failure mode these guards exist to prevent in the first place
+  assert_not_empty "$PERMISSION_RULES" \
+    "$CLAUDE_CODE_SETTINGS_FILE should pre-approve the repository's routine commands, or this guard watches nothing" ||
+    return 1
+
+  local RULE COMMAND
+  while IFS= read -r RULE; do
+    COMMAND=$(pre_approved_command "$RULE")
+
+    case "$COMMAND" in
+      './tests/run_tests.sh' | 'shellcheck' | 'bash -n')
+        pass ;;
+      *)
+        fail "[$RULE] is pre-approved for every session opened on this repository, and it is not one of the commands #382 argued for" \
+          "the vetted ones are : ./tests/run_tests.sh (mocked and self-contained), shellcheck and bash -n (analysers that run nothing)" \
+          "git and docker build were deliberately left out ; a new entry has to be argued the same way, here and in the settings" ;;
+    esac
+  done < <(printf '%s\n' "$PERMISSION_RULES")
+}
+
+function test_every_pre_approved_command_is_one_the_repository_still_runs() {
+  # The other end of the same list. A grant that outlives the command it was given
+  # for is a grant nobody reads again : the session goes back to asking about
+  # everything, the entry stays in the file looking deliberate, and the next
+  # person to widen the list starts from a list already half wrong.
+  #
+  # Each command is held to the thing in the tree that proves the repository still
+  # runs it, rather than to a second copy of the list
+  if [ ! -f "$REPO_ROOT/$CLAUDE_CODE_SETTINGS_FILE" ]; then
+    skip_test "no .claude next to the scripts"
+    return 0
+  fi
+
+  local RULE COMMAND
+  while IFS= read -r RULE; do
+    COMMAND=$(pre_approved_command "$RULE")
+
+    case "$COMMAND" in
+      './'*)
+        # A path is pre-approved relative to the project directory, which is where
+        # a session runs : it has to exist there, and be runnable that way
+        if [ -x "$REPO_ROOT/${COMMAND#./}" ]; then
+          pass
+        else
+          fail "$COMMAND is pre-approved but is not an executable file of this repository" \
+            "a rule naming a path that moved pre-approves nothing at all"
+        fi ;;
+      'shellcheck')
+        # What makes the grant worth having is that a pull request is gated on it
+        if [ -f "$REPO_ROOT/.github/workflows/shellcheck.yml" ]; then
+          pass
+        else
+          fail "shellcheck is pre-approved but no workflow gates a pull request on it any more"
+        fi ;;
+      'bash -n')
+        # The syntax check cases/10 runs over every script of the repository. This
+        # file is the one place the search leaves out : it names the command in
+        # every second comment, and would answer the question with itself
+        local THIS_CASE_FILE
+        THIS_CASE_FILE=$(basename "${BASH_SOURCE[0]}")
+
+        if grep -rqF --exclude="$THIS_CASE_FILE" -- 'bash -n' "$TESTS_DIRECTORY/cases"; then
+          pass
+        else
+          fail "bash -n is pre-approved but the suite does not run it any more"
+        fi ;;
+      *)
+        fail "nothing in the tree proves this repository still runs [$COMMAND]" \
+          "a pre-approved command needs a reason to stay pre-approved" ;;
+    esac
+  done < <(pre_approved_permission_rules)
+}


### PR DESCRIPTION
Closes #382.

The working loop here is short and always the same : edit a script, run `./tests/run_tests.sh`, run `shellcheck`, read a diff. Under the default permission mode each of those stops the session and waits for a human, and on a task that runs the suite five times the prompts cost more wall-clock than the work does.

`.claude/settings.json` has held the `SessionStart` hook since #380 and takes a `permissions.allow` list in the same file, so that is where the three entries go :

```json
"permissions": {
  "allow": [
    "Bash(./tests/run_tests.sh)",
    "Bash(shellcheck:*)",
    "Bash(bash -n:*)"
  ]
}
```

## The trade-off

The one the issue states, with one correction the issue could not have known about.

`shellcheck` and `bash -n` are granted **by prefix** : neither has an option that names a file to write, so pre-approving every argument list they take costs nothing. They read, they analyse, and `bash -n` parses without running a statement of it.

`./tests/run_tests.sh` is granted **exactly**, with no `:*`. Run bare it mocks `ipmitool`, `lm-sensors` and `sleep`, needs no iDRAC and no network, and writes only inside the throwaway directory it makes with `mktemp -d`. Run as `--junit FILE` or `--summary FILE` it is a different program : `tests/lib/reports.sh` does `mkdir -p` on the directory it is pointed at and then truncates the file. A prefix rule pre-approves every argument list, so `Bash(./tests/run_tests.sh:*)` — which is what the first commit of this branch granted — hands an unprompted arbitrary-file-write primitive to every session opened on this repository, including one acting on a prompt that came from a pull request body. That is the threat this change names, so the entry is narrowed rather than the claim softened. The cost is one prompt per filtered run.

`git` is deliberately absent — `git diff` is harmless, but the prefix matching that would allow it is easy to widen by accident and the blast radius of getting it wrong once is the branch. `docker build` is deliberately absent too : it runs `apt-get` against the network as root inside the build, which is not something to grant standing approval to for the sake of one prompt.

## What is tested

The grant is not given to whoever wrote it. It applies to every session ever opened on this repository, and nothing in Claude Code will ever refuse a fourth entry. So `tests/cases/11_claude_code_settings.sh` refuses one instead. Each of these was verified by mutating the tree and watching the right case go red :

- **a rule outside the vetted set fails.** The comparison is on whole rules, not on the commands inside them : `:*` is part of the decision, and relaxing the suite's rule back to a prefix fails with the option that makes it unsafe named in the diagnostic ;
- **an empty list fails** rather than passing by having nothing to iterate over ;
- **JSON that does not parse fails** — a settings file that does not parse is not one broken entry, it is the whole file dropped silently, hook included ;
- **a grant that outlived its command fails** : each entry is held to the thing in the tree that proves the repository still runs it — the executable file the rule names, the workflow that gates a pull request on `shellcheck`, and, for `bash -n`, an invocation in the suite rather than a mention of it, comments being skipped the way `cases/10` skips them at its own boolean-dispatch guard.

The list is read with `jq`, and the cases skip where `jq` is missing — the trade `cases/14` already makes. Reading JSON with `sed` is how the first commit's guard came to stop at the first `]` of a rule and report green over everything that followed it.

## The second commit

The first commit of this branch was reviewed adversarially before a human saw it, and three defects were found in it, reproduced, and fixed in `fb8dcc0` :

1. the suite granted by prefix, i.e. the arbitrary write above — the argument the whole change rests on was false as written ;
2. the allow list read with `sed`, which stopped at the first `]` inside a rule : a list holding `"Bash(sed -n '1,5p]':*)"` was read as one entry and the `"Bash(curl:*)"` after it was granted with all three cases green ;
3. the `bash -n` staleness proof satisfied by a comment : deleting the function in `cases/10` that actually runs it left the guard green.

The prose was corrected with them. "Writes nothing outside the tree" was false twice over — the reports, and the suite's own `mktemp -d` under `/tmp` — and "execute nothing they read" is not true of a suite whose whole job is to run the controller.

## Checks

- `./tests/run_tests.sh` — 445 test cases, 2260 assertions, green
- inside the built image the three new cases skip (no `.claude/` there), which the CI run of the first commit confirmed : 42 skipped, +3
- `shellcheck -x` on the files CI lints, on the `SessionStart` hook and on the new case file — clean
- `.claude/` is not in the image : no shipped file changed, nothing to rebuild

Note that a slower loop remains a legitimate answer : nothing else in the tree depends on this list, and dropping the three entries plus `tests/cases/11_claude_code_settings.sh` reverts the whole change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AQ1MmPC3pGPywBgr9DVr9g