### PR TITLE
Check what the repository tells a session about itself, rather than trusting it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,8 @@ functions.sh` and `constants.sh`. That is the entire dependency graph.
 ./tests/run_tests.sh --list          # list them without running
 
 shellcheck -x Dell_iDRAC_fan_controller.sh functions.sh constants.sh \
-              healthcheck.sh supervisor.sh .github/*.sh   # what CI lints
+              healthcheck.sh supervisor.sh .github/*.sh \
+              .claude/hooks/session-start.sh   # what CI lints
 
 docker build -t dell_idrac_fan_controller:dev .
 ```
@@ -46,9 +47,9 @@ image — and shellcheck on every pull request.
   mergeable ; see `CONTRIBUTING.md` for what it certifies in a dual-licensed project.
 - **Every new shell script carries the two SPDX lines** right after the shebang, test
   cases, mocks and helpers included. Copy them from any existing script.
-- **A new script under the repository root or `.github/` must be added by hand to
-  `.github/workflows/shellcheck.yml`.** That workflow names its files one by one
-  instead of globbing, and `tests/cases/10_shell_scripts.sh` guards the list —
+- **A new script under the repository root, `.github/` or `.claude/` must be added
+  by hand to `.github/workflows/shellcheck.yml`.** That workflow names its files one
+  by one instead of globbing, and `tests/cases/10_shell_scripts.sh` guards the list —
   a script missing from it is analysed by nothing at all.
 - **Add a test case for what you change.** A behaviour with no test is one the next
   refactor is free to break, and this codebase's refactors span a hundred server models.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,13 +16,14 @@ the control logic.
 | --- | --- |
 | `supervisor.sh` | The image's entrypoint. Starts the controller and, if it dies without doing it itself, hands the fans back to Dell |
 | `Dell_iDRAC_fan_controller.sh` | Configuration validation, then the monitoring loop |
-| `functions.sh` | Every function (76, flat namespace, no modules) |
-| `constants.sh` | The raw IPMI commands and the tables they are read against |
+| `functions.sh` | Every shared function (76, flat namespace, no modules). `supervisor.sh` keeps two of its own |
+| `constants.sh` | The fixed values everything else is measured against : bounds, thresholds, intervals, column widths, Redfish URIs. The raw IPMI commands are in `functions.sh` |
 | `healthcheck.sh` | `HEALTHCHECK` for the image |
 | `tests/` | The suite. See `tests/README.md`, which is thorough — read it before touching a test |
 
-`Dell_iDRAC_fan_controller.sh`, `healthcheck.sh` and `supervisor.sh` each `source
-functions.sh` and `constants.sh`. That is the entire dependency graph.
+`Dell_iDRAC_fan_controller.sh` and `supervisor.sh` each `source functions.sh` and
+`constants.sh` ; `healthcheck.sh` sources `functions.sh` alone. That is the entire
+dependency graph.
 
 ## Commands
 
@@ -87,13 +88,14 @@ runner discovers it in declaration order and turns its name into the reported li
 nothing to register.
 
 ```bash
-function test_a_single_cpu_server_reports_one_cpu() {
+function test_a_single_socket_server_reports_one_cpu() {
   export MOCK_IPMITOOL_SDR_OUTPUT
   MOCK_IPMITOOL_SDR_OUTPUT=$(make_sdr_output --cpus 1 --cpu-temperatures "44")
 
-  retrieve_temperatures "$SDR_DATA"
+  detect_CPU_temperature_sensors "$(retrieve_sdr_temperature_data)"
+  retrieve_temperatures
 
-  assert_equals "1" "$NUMBER_OF_DETECTED_CPUS"
+  assert_equals "1" "${#DETECTED_CPU_ENTITY_IDS[@]}"
 }
 ```
 
@@ -112,6 +114,7 @@ controller cannot cool them, and the suite pins what it does instead.
 
 ## Environment
 
-`.claude/hooks/session-start.sh` installs `shellcheck` in Claude Code on the web, where
-it is otherwise missing while CI still gates on it. `ipmitool`, `lm-sensors` and `perl`
-are not needed to run the suite — it mocks them.
+`.claude/hooks/session-start.sh` installs `shellcheck` and `jq` in Claude Code on the
+web, where neither is there by default : CI gates every pull request on the first, and
+`tests/cases/14_latest_tag_reconciliation.sh` skips itself without the second. `ipmitool`,
+`lm-sensors` and `perl` are not needed to run the suite — it mocks them.

--- a/tests/README.md
+++ b/tests/README.md
@@ -99,13 +99,14 @@ the whole suite, every case file being sourced into the same shell : the runner
 refuses to run rather than let one definition silently replace another.
 
 ```bash
-function test_a_single_cpu_server_reports_one_cpu() {
+function test_a_single_socket_server_reports_one_cpu() {
   export MOCK_IPMITOOL_SDR_OUTPUT
   MOCK_IPMITOOL_SDR_OUTPUT=$(make_sdr_output --cpus 1 --cpu-temperatures "44")
 
-  retrieve_temperatures "$SDR_DATA"
+  detect_CPU_temperature_sensors "$(retrieve_sdr_temperature_data)"
+  retrieve_temperatures
 
-  assert_equals "1" "$NUMBER_OF_DETECTED_CPUS"
+  assert_equals "1" "${#DETECTED_CPU_ENTITY_IDS[@]}"
 }
 ```
 

--- a/tests/cases/10_shell_scripts.sh
+++ b/tests/cases/10_shell_scripts.sh
@@ -851,6 +851,62 @@ function test_the_function_count_claude_md_states_is_the_one_functions_sh_declar
     "CLAUDE.md counts the functions functions.sh holds, the count should be the number it declares"
 }
 
+
+function test_the_test_case_claude_md_documents_passes_when_it_is_run() {
+  if [ ! -f "$REPO_ROOT/CLAUDE.md" ]; then
+    skip_test "no CLAUDE.md next to the scripts"
+    return 0
+  fi
+
+  # The cases above settle what the document says about the repository. This one
+  # settles the single block it hands a session to copy, and copying is exactly
+  # how that block failed : it asserted on a variable only the controller sets,
+  # read the sdr output through one a case never has, and carried a name the
+  # suite had already taken. None of the cases above would have caught any of it
+  # -- a code block names no path, no option and no figure -- and the only
+  # reading that settles an example is to run it.
+  #
+  # Both failure modes are pinned, because they land at different moments : the
+  # name stops the runner before a single case runs, the body fails once one does
+  local -r DOCUMENTED_CASE=$(awk '
+    /^function test_/ { IS_THE_CASE = 1 }
+    IS_THE_CASE { print }
+    IS_THE_CASE && /^}/ { exit }' "$REPO_ROOT/CLAUDE.md")
+
+  assert_matches "$DOCUMENTED_CASE" '^function test_[A-Za-z0-9_]+[[:space:]]*\(\)' \
+    "CLAUDE.md should still show a test case under \"Writing a test case\"" || return 1
+
+  # Discovery reads the case files as text and the runner refuses to start on a
+  # name declared twice, so a name the suite already carries makes the example
+  # unusable as written whatever its body does. Matched with the runner's own
+  # expression rather than a tighter one, so that the two cannot disagree
+  local -r DOCUMENTED_CASE_NAME=$(printf '%s' "$DOCUMENTED_CASE" | sed -n '1s/^function \([A-Za-z0-9_]*\).*/\1/p')
+  local -r COLLIDING_FILES=$(grep -rlE "^[[:space:]]*(function[[:space:]]+)?$DOCUMENTED_CASE_NAME[[:space:]]*\(\)" "$TESTS_DIRECTORY/cases" || true)
+
+  if [ -z "$COLLIDING_FILES" ]; then
+    pass
+  else
+    fail "$DOCUMENTED_CASE_NAME is already declared in the suite, so pasting the example stops the runner" \
+      "declared in : $(printf '%s' "$COLLIDING_FILES" | tr '\n' ' ')"
+  fi
+
+  # Then run it the way a session would : the real runner, on a repository of its
+  # own holding that case and nothing else. The probe machinery belongs to
+  # tests/cases/15_test_runner.sh, which is sourced into this same shell along
+  # with every other case file, so it is reachable from here whatever the filter
+  if ! declare -F run_the_runner_on_a_probe_case_file > /dev/null; then
+    fail "the probe helper tests/cases/15_test_runner.sh declares is gone, so the example cannot be run"
+    return 1
+  fi
+
+  run_the_runner_on_a_probe_case_file "$DOCUMENTED_CASE"
+
+  if [ "$PROBE_EXIT_CODE" -eq 0 ]; then
+    pass
+  else
+    fail "the test case CLAUDE.md documents does not pass when it is run" "$PROBE_OUTPUT"
+  fi
+}
 function test_the_healthcheck_succeeds_when_the_sensors_can_be_read() {
   local OUTPUT
   OUTPUT=$(bash "$REPO_ROOT/healthcheck.sh" 2>&1)

--- a/tests/cases/10_shell_scripts.sh
+++ b/tests/cases/10_shell_scripts.sh
@@ -42,14 +42,19 @@ function test_the_shellcheck_workflow_lints_every_script_it_is_scoped_to() {
   # to .github/ afterwards stay out of it for months without a word. The list is
   # hand-maintained, so it is worth a guard : nothing else lints these files.
   # "bash -n" above is a syntax check and the suite invokes shellcheck nowhere,
-  # so a script missing from that list is analysed by nothing at all -- and the
-  # ones outside the Docker image are exactly the ones no test ever reaches :
-  # those under .github/ run first on the tag or the push that publishes, and the
-  # hook under .claude/ when a Claude Code on the web session opens
+  # so a script missing from that list is analysed by nothing at all. The ones
+  # under .github/ run first on the tag or the push that publishes -- the suite
+  # does execute all three, in cases 13, 14 and 16, but never on the path a
+  # release takes. The hook under .claude/ has neither : it runs when a Claude
+  # Code on the web session opens, where no workflow and no test ever looks.
+  #
+  # Walked over all of .claude/ rather than the one directory a script lives in
+  # today, because that is the scope the convention in CLAUDE.md states
   local -r LINTED_SCRIPTS="$(sed -n 's/^ *\([A-Za-z0-9_./-]*\.sh\) *\\\{0,1\}$/\1/p' "$SHELLCHECK_WORKFLOW")"
 
+  shopt -s globstar
   local SCRIPT RELATIVE_PATH
-  for SCRIPT in "$REPO_ROOT"/*.sh "$REPO_ROOT"/.github/*.sh "$REPO_ROOT"/.claude/hooks/*.sh; do
+  for SCRIPT in "$REPO_ROOT"/*.sh "$REPO_ROOT"/.github/*.sh "$REPO_ROOT"/.claude/**/*.sh; do
     [ -f "$SCRIPT" ] || continue
 
     RELATIVE_PATH="${SCRIPT#$REPO_ROOT/}"
@@ -60,6 +65,8 @@ function test_the_shellcheck_workflow_lints_every_script_it_is_scoped_to() {
         "it checks : $(printf '%s' "$LINTED_SCRIPTS" | tr '\n' ' ')"
     fi
   done
+
+  shopt -u globstar
 }
 
 function test_no_statement_expands_two_command_substitutions() {

--- a/tests/cases/10_shell_scripts.sh
+++ b/tests/cases/10_shell_scripts.sh
@@ -42,12 +42,14 @@ function test_the_shellcheck_workflow_lints_every_script_it_is_scoped_to() {
   # to .github/ afterwards stay out of it for months without a word. The list is
   # hand-maintained, so it is worth a guard : nothing else lints these files.
   # "bash -n" above is a syntax check and the suite invokes shellcheck nowhere,
-  # so a script missing from that list is analysed by nothing at all, and the
-  # ones under .github/ run first on the tag or the push that publishes
+  # so a script missing from that list is analysed by nothing at all -- and the
+  # ones outside the Docker image are exactly the ones no test ever reaches :
+  # those under .github/ run first on the tag or the push that publishes, and the
+  # hook under .claude/ when a Claude Code on the web session opens
   local -r LINTED_SCRIPTS="$(sed -n 's/^ *\([A-Za-z0-9_./-]*\.sh\) *\\\{0,1\}$/\1/p' "$SHELLCHECK_WORKFLOW")"
 
   local SCRIPT RELATIVE_PATH
-  for SCRIPT in "$REPO_ROOT"/*.sh "$REPO_ROOT"/.github/*.sh; do
+  for SCRIPT in "$REPO_ROOT"/*.sh "$REPO_ROOT"/.github/*.sh "$REPO_ROOT"/.claude/hooks/*.sh; do
     [ -f "$SCRIPT" ] || continue
 
     RELATIVE_PATH="${SCRIPT#$REPO_ROOT/}"
@@ -603,6 +605,243 @@ function test_the_suites_own_readme_lists_every_case_file() {
       fail "the README's coverage table lists $LISTED_FILE, which does not exist"
     fi
   done
+}
+
+# The cases below guard CLAUDE.md, the file a Claude Code session reads before it
+# touches anything here. Documentation that has fallen behind is a stale
+# paragraph everywhere else in this repository ; there it is an instruction, and
+# a session acts on it. A renamed script, or a lint command that no longer covers
+# what the pull request will be judged on, makes the session confidently wrong
+# and leaves the human to catch it in review (issue #381).
+#
+# What is pinned is what a machine can settle : the paths, the two lists that are
+# maintained in two places, the options, the one figure. The "Invariants" section
+# is prose about why a decision was taken and is deliberately left alone -- a test
+# over it would either be satisfied by a keyword or break on any rewording, and
+# neither would say anything about whether it is still true.
+
+function test_claude_md_carries_the_licence_header() {
+  # NOTICE names the SPDX headers as part of what discharges AGPL 5(a) and 7(b),
+  # and the workflows were brought under the same rule by #368. This file is
+  # prose rather than a program, so it carries them in an HTML comment : nothing
+  # shows where the document is rendered, and the two lines are still where a
+  # reader and a licence scanner look for them
+  if [ ! -f "$REPO_ROOT/CLAUDE.md" ]; then
+    # The suite is running inside the built image, which carries the scripts and
+    # not what documents them
+    skip_test "no CLAUDE.md next to the scripts"
+    return 0
+  fi
+
+  local -r HEADER=$(head -4 "$REPO_ROOT/CLAUDE.md")
+
+  assert_contains "$HEADER" "SPDX-FileCopyrightText: 2020-2026 Tigerblue77" \
+    "CLAUDE.md should open with the copyright line every other file here carries"
+  assert_contains "$HEADER" "SPDX-License-Identifier: AGPL-3.0-only" \
+    "CLAUDE.md should open with the licence line every other file here carries"
+}
+
+function test_the_lint_command_claude_md_documents_is_the_one_the_workflow_runs() {
+  local -r SHELLCHECK_WORKFLOW="$REPO_ROOT/.github/workflows/shellcheck.yml"
+
+  if [ ! -f "$REPO_ROOT/CLAUDE.md" ] || [ ! -f "$SHELLCHECK_WORKFLOW" ]; then
+    skip_test "no CLAUDE.md and no .github/workflows next to the scripts"
+    return 0
+  fi
+
+  # CLAUDE.md prints a shellcheck invocation under "Commands" and calls it what
+  # CI lints, so a session that runs it before pushing believes it has seen
+  # everything the pull request will be judged on. The workflow names its files
+  # one by one for the reasons the case above gives, which leaves the same list
+  # written down twice -- and the copy in CLAUDE.md is the one nothing runs.
+  #
+  # It is compared against the workflow rather than against the tree because
+  # being wrong about what CI checks is what makes a session push a file that
+  # nothing linted. The command is read the way a shell reads it : continuations
+  # joined, the trailing comment dropped, globs expanded from the repository
+  # root. What matters is the set of files it ends up handing shellcheck, not how
+  # it spells them
+  local -r DOCUMENTED_COMMAND=$(awk '
+    /^shellcheck -x/ { IS_THE_COMMAND = 1 }
+    IS_THE_COMMAND {
+      sub(/#.*$/, "")
+      CONTINUES = ($0 ~ /\\[[:space:]]*$/)
+      sub(/\\[[:space:]]*$/, "")
+      printf "%s ", $0
+      if (!CONTINUES) { exit }
+    }' "$REPO_ROOT/CLAUDE.md")
+
+  assert_not_empty "$DOCUMENTED_COMMAND" \
+    "CLAUDE.md should still print the shellcheck invocation it calls what CI lints" || return 1
+
+  # Each test case runs in its own subshell, so the working directory the globs
+  # are resolved from is this case's own
+  cd "$REPO_ROOT" || return 1
+  shopt -s nullglob
+  local -a DOCUMENTED_SCRIPTS=(${DOCUMENTED_COMMAND#shellcheck -x })
+  shopt -u nullglob
+
+  local -r LINTED_SCRIPTS=$(sed -n 's/^ *\([A-Za-z0-9_./-]*\.sh\) *\\\{0,1\}$/\1/p' "$SHELLCHECK_WORKFLOW")
+
+  local DOCUMENTED_SCRIPT
+  for DOCUMENTED_SCRIPT in "${DOCUMENTED_SCRIPTS[@]}"; do
+    if printf '%s\n' "$LINTED_SCRIPTS" | grep -qxF "$DOCUMENTED_SCRIPT"; then
+      pass
+    else
+      fail "CLAUDE.md has a session lint $DOCUMENTED_SCRIPT, which the Shellcheck workflow does not" \
+        "the workflow lints : $(printf '%s' "$LINTED_SCRIPTS" | tr '\n' ' ')"
+    fi
+  done
+
+  local LINTED_SCRIPT
+  while IFS= read -r LINTED_SCRIPT; do
+    [ -n "$LINTED_SCRIPT" ] || continue
+
+    if printf '%s\n' "${DOCUMENTED_SCRIPTS[@]}" | grep -qxF "$LINTED_SCRIPT"; then
+      pass
+    else
+      fail "the Shellcheck workflow lints $LINTED_SCRIPT, which the command in CLAUDE.md leaves out" \
+        "that command covers : ${DOCUMENTED_SCRIPTS[*]}"
+    fi
+  done <<< "$LINTED_SCRIPTS"
+}
+
+function test_the_claude_md_layout_table_names_every_script_at_the_repository_root() {
+  if [ ! -f "$REPO_ROOT/CLAUDE.md" ]; then
+    skip_test "no CLAUDE.md next to the scripts"
+    return 0
+  fi
+
+  # "Layout" is a table of one row per file, and it is where a session decides
+  # which file to open. A script it does not name is one the session does not
+  # know exists, so the table reads as the whole of the program while it is not
+  # -- the failure tests/README.md's own coverage table had, three files behind
+  # and still reading as complete.
+  #
+  # Read down the first column rather than over the section, because the section
+  # also holds the sentence naming the three scripts that source the other two :
+  # matched against the prose, this case stays green with the table emptied row
+  # by row. The other direction, a row naming a file that has been renamed away,
+  # is the case below, over the whole document rather than this table alone
+  local -r TABLE_FILE_COLUMN=$(awk -F '|' '
+    /^## Layout$/ { IS_THE_LAYOUT = 1; next }
+    /^## / { IS_THE_LAYOUT = 0 }
+    IS_THE_LAYOUT && /^\|/ { print $2 }' "$REPO_ROOT/CLAUDE.md")
+
+  assert_not_empty "$TABLE_FILE_COLUMN" "CLAUDE.md should still carry a \"Layout\" table" || return 1
+
+  local SCRIPT RELATIVE_PATH
+  for SCRIPT in "$REPO_ROOT"/*.sh; do
+    [ -f "$SCRIPT" ] || continue
+
+    RELATIVE_PATH="${SCRIPT#"$REPO_ROOT"/}"
+    assert_contains "$TABLE_FILE_COLUMN" "\`$RELATIVE_PATH\`" \
+      "$RELATIVE_PATH ships in the image, the Layout table should have a row saying what it holds"
+  done
+}
+
+function test_every_repository_path_claude_md_names_exists() {
+  if [ ! -f "$REPO_ROOT/CLAUDE.md" ]; then
+    skip_test "no CLAUDE.md next to the scripts"
+    return 0
+  fi
+
+  # Every path the document quotes, against the tree. A rename that leaves it
+  # behind is the realistic failure here, and the document is almost entirely
+  # made of them : the file table, the two case files named as the guards a
+  # contributor is told to respect, the fixtures and the mock a new test is told
+  # to build on, the catalogue the server models come from, the hook that
+  # installs shellcheck. Sent to a path that no longer exists, a session either
+  # invents a replacement or reports the repository as broken.
+  #
+  # Only the quoted tokens shaped like a path are kept -- a slash, one of the
+  # extensions used here, or a leading dot -- so that the function names, the
+  # variables and the environment variables quoted the same way stay out. Fenced
+  # blocks are dropped first : they are shell rather than prose, and the words in
+  # them are commands
+  local -r NAMED_PATHS=$(awk '/^```/ { IS_FENCED = !IS_FENCED; next } !IS_FENCED' "$REPO_ROOT/CLAUDE.md" |
+    grep -oE '`[^`]+`' | tr -d '`' |
+    grep -E '^[A-Za-z0-9_.*/-]+$' | grep -E '(/|\.sh$|\.md$|\.yml$|^\.)' | sort -u)
+
+  assert_not_empty "$NAMED_PATHS" "CLAUDE.md should still name the files it sends a session to" || return 1
+
+  cd "$REPO_ROOT" || return 1
+  shopt -s nullglob
+
+  local NAMED_PATH
+  local -a MATCHES
+  while IFS= read -r NAMED_PATH; do
+    [ -n "$NAMED_PATH" ] || continue
+
+    # A pattern where the document quotes one, a name where it quotes a name.
+    # Both are checked through the same expansion, and both halves are needed :
+    # nullglob drops a pattern nothing answers, and leaves a word carrying no
+    # pattern character at all exactly as it was written, existing or not
+    MATCHES=($NAMED_PATH)
+    if [ "${#MATCHES[@]}" -gt 0 ] && [ -e "${MATCHES[0]}" ]; then
+      pass
+    else
+      fail "CLAUDE.md sends a session to $NAMED_PATH, which is not in the repository"
+    fi
+  done <<< "$NAMED_PATHS"
+
+  shopt -u nullglob
+}
+
+function test_the_runner_options_claude_md_documents_are_ones_the_runner_accepts() {
+  if [ ! -f "$REPO_ROOT/CLAUDE.md" ]; then
+    skip_test "no CLAUDE.md next to the scripts"
+    return 0
+  fi
+
+  # The runner prints its options from a single cat block, so its help is the
+  # list of what it takes. An option CLAUDE.md documents and the runner no longer
+  # accepts sends the session into a usage error on the first command it was told
+  # to run, at the moment it is trying to find out whether the tree is sound
+  local -r RUNNER_HELP=$(bash "$TESTS_DIRECTORY/run_tests.sh" --help 2>&1)
+
+  assert_not_empty "$RUNNER_HELP" "the runner should still print what it takes" || return 1
+
+  local DOCUMENTED_OPTION
+  while IFS= read -r DOCUMENTED_OPTION; do
+    [ -n "$DOCUMENTED_OPTION" ] || continue
+
+    assert_matches "$RUNNER_HELP" "(^|[[:space:],])$DOCUMENTED_OPTION([[:space:],]|$)" \
+      "CLAUDE.md runs the suite with $DOCUMENTED_OPTION, the runner should still accept it"
+  done < <(grep -oE '(\./)?tests/run_tests\.sh[^#]*' "$REPO_ROOT/CLAUDE.md" |
+    grep -oE ' -{1,2}[A-Za-z][A-Za-z-]*' | tr -d ' ' | sort -u)
+}
+
+function test_the_function_count_claude_md_states_is_the_one_functions_sh_declares() {
+  if [ ! -f "$REPO_ROOT/CLAUDE.md" ]; then
+    skip_test "no CLAUDE.md next to the scripts"
+    return 0
+  fi
+
+  # The Layout table does not only name functions.sh, it counts what is in it,
+  # and that is the one figure in the document. The README's figures are pinned
+  # against the code above for the same reason -- the fan speed range, the check
+  # interval bounds, the supervisor's deadline -- since a number nobody checks is
+  # a number that stops being true without anybody noticing, and this one moves
+  # every time a function is added.
+  #
+  # The figure is read out of the row rather than matched word for word, so that
+  # rewording the cell does not fail here. Dropping the count is a legitimate way
+  # to answer a failure of this case : a claim that is not made cannot drift
+  local -r FUNCTIONS_ROW=$(grep -m 1 -F '| `functions.sh` |' "$REPO_ROOT/CLAUDE.md")
+
+  assert_not_empty "$FUNCTIONS_ROW" "the Layout table should still have a row for functions.sh" || return 1
+
+  local -r STATED_COUNT=$(printf '%s' "$FUNCTIONS_ROW" | grep -oE '[0-9]+' | head -1)
+  if [ -z "$STATED_COUNT" ]; then
+    pass
+    return 0
+  fi
+
+  local -r DECLARED_COUNT=$(grep -c '^function ' "$REPO_ROOT/functions.sh")
+
+  assert_equals "$DECLARED_COUNT" "$STATED_COUNT" \
+    "CLAUDE.md counts the functions functions.sh holds, the count should be the number it declares"
 }
 
 function test_the_healthcheck_succeeds_when_the_sensors_can_be_read() {


### PR DESCRIPTION
Closes #381.

`CLAUDE.md` is documentation an agent reads as instructions, so a paragraph that has fallen behind is not stale prose : a session acts on it, is confidently wrong, and the human catches it in review. This repository already treats that class of problem as testable — `tests/cases/10_shell_scripts.sh` guards the hand-maintained script list in `.github/workflows/shellcheck.yml`, and the coverage table in `tests/README.md`. The same file gains seven cases.

## 1. The guards

| Case | What it settles |
| --- | --- |
| `claude_md_carries_the_licence_header` | The two SPDX lines, in an HTML comment so nothing shows where the document is rendered. Same rule as #368 gave the workflows |
| `the_lint_command_claude_md_documents_is_the_one_the_workflow_runs` | The command against the workflow, read the way a shell reads it : continuations joined, trailing comment dropped, globs expanded. Both directions |
| `the_claude_md_layout_table_names_every_script_at_the_repository_root` | Every `*.sh` at the root has a row. Read down the table's first column, not over the section |
| `every_repository_path_claude_md_names_exists` | Every path the document quotes, against the tree — the file table, the case files named as guards, the fixtures and the mock, the catalogue, the hook |
| `the_runner_options_claude_md_documents_are_ones_the_runner_accepts` | The options in the `run_tests.sh` invocations, against the runner's own `--help` |
| `the_function_count_claude_md_states_is_the_one_functions_sh_declares` | The one figure in the document, against `grep -c '^function '` |
| `the_test_case_claude_md_documents_passes_when_it_is_run` | The worked example, **run** : its name against the suite's, then its body through the real runner on a repository of its own |

The *"Invariants"* section is deliberately left out, as the issue asked. It is prose about why a decision was taken, and a test over it would either be satisfied by a keyword match or break on any rewording — neither says whether it is still true.

**The first case failed on the tree as it stood.** The documented `shellcheck` invocation, labelled *"what CI lints"*, expanded to eight scripts where the workflow lints nine — `.claude/hooks/session-start.sh` was missing. The command now names it, the convention saying where a new script has to be registered names `.claude/` alongside the repository root and `.github/`, and `test_the_shellcheck_workflow_lints_every_script_it_is_scoped_to` walks `.claude/` at any depth so that convention holds wherever a linted script can live.

## 2. What reading the rest of the file turned up

Paths, lists, options and figures are settled by the cases above. The descriptions are not, and reading them against the tree by hand turned up five statements a session would act on and be wrong about :

- **`healthcheck.sh` sources `functions.sh` alone.** The sentence calling itself *"the entire dependency graph"* gave it `constants.sh` as well.
- **`functions.sh` does not hold every function** — `supervisor.sh` keeps two of its own.
- **`constants.sh` holds no raw IPMI command at all.** Those are in `functions.sh`. It holds the fixed values everything else is measured against.
- **The session-start hook installs `jq` as well as `shellcheck`**, and `jq` is not optional : `tests/cases/14_latest_tag_reconciliation.sh` skips without it.
- **The one worked example did not run.** The worst of the five, because it is the block a session pastes rather than reads.

### The worked example

Pasted verbatim, its name collided with the real case in `tests/cases/60_cpu_topologies.sh:22` and the runner refused to start :

```
These test case names are declared more than once, so only the last definition of each would run :
  test_a_single_cpu_server_reports_one_cpu
```

Renamed so the body could be judged, it asserted on `NUMBER_OF_DETECTED_CPUS` — which only `Dell_iDRAC_fan_controller.sh` sets, and the suite never sources it — and read the sdr output through `"$SDR_DATA"`, a variable a case never has, so the mocked output was discarded : `expected: [1] / actual: []`. Three defects in six lines, in the one place they are copied character for character, and nothing in the suite had an opinion.

`tests/README.md` carried the same block, three lines below its own sentence warning that a case name has to be unique across the whole suite. Both now detect the sensors before reading them, assert on `DETECTED_CPU_ENTITY_IDS`, and carry a name no case has taken — and the seventh case extracts that block and runs it, so it cannot drift back.

### Two of this branch's own changes

- the comment rewritten on the Shellcheck guard claimed the scripts outside the Docker image are the ones no test reaches. True of the `.claude/` hook, false of the three under `.github/`, which cases 13, 14 and 16 **execute** — breaking two of them fails eight test cases. What those three have is that a release runs them first, which is what the comment said before.
- the convention bullet was widened to `.claude/` while the guard walked `.claude/hooks/` only. The walk now covers `.claude/` at any depth, so a script at `.claude/skills/example/helper.sh` is caught.

### And one the merge of #386 turned up

#386 landed in all three files this branch touches. Its paragraph is kept verbatim; the Environment sentence above it keeps this branch's correction, since the hook really does install `jq`.

It also cost the option guard a false failure, which is the guard's fault rather than the sentence's. That sentence reads *"`./tests/run_tests.sh` **exactly**, then `shellcheck` and `bash -n`"*, and the guard read the whole line as an invocation : it demanded the runner accept `-n`. Options are now read out of the fenced blocks alone, where the document runs a command, rather than out of prose, where it quotes one.

## Verification

Every case was run against a deliberately broken tree before being kept, and **three did not fail on the first attempt** :

- the Layout-table case passed with a row deleted, because the section also holds the sentence naming three of the five root scripts — it matched the prose. It now reads the table's first column.
- the path case passed with `tests/lib/fixtures.sh` renamed away, because `nullglob` drops a pattern nothing answers but leaves a word carrying no pattern character exactly as written. It now checks the expansion *and* the first match's existence.
- the option case failed on prose it should never have read, as above.

With those fixed, every case fails on its own drift : header removed, row dropped, path renamed, glob answering nothing, an option the runner does not take, `76` changed to `91`, the hook dropped from the workflow, a script added anywhere under `.claude/`, the example's name taken by a real case, and the example's body put back in its broken state — that last one reporting the probe run's own diff.

```
452 test cases passed (2320 assertions)
```

Also run from a directory holding only what the `Dockerfile` copies into `/app`, since CI runs the suite inside the built image too : `403 passed, 49 skipped` — the cases needing `CLAUDE.md` or `.github/` skip rather than fail there. `shellcheck -x` is clean over the nine scripts, run both as the workflow spells them and as `CLAUDE.md` now does. Docker is not available in the environment this was written in, so the image itself was not built locally — CI covers that.