### PR TITLE
Read the sign-off as a trailer, and refuse a range that resolves to nothing (#388)

### DIFF
--- a/.github/check_sign_off.sh
+++ b/.github/check_sign_off.sh
@@ -44,7 +44,7 @@
 # authored.
 #
 # Exit 0 : every commit in the range carries a well-formed sign-off.
-# Exit 1 : at least one does not, or the range could not be read.
+# Exit 1 : at least one does not, or the range could not be read, or it is empty.
 # Exit 2 : called wrong.
 #
 # Which answer sits on which code is deliberate. Under "set -e" a script that
@@ -88,12 +88,16 @@ if ! COMMITS="$(git log --no-merges --format='%H' "$BASE..$HEAD" 2> /dev/null)";
   exit 1
 fi
 
-# A pull request that adds no commit of its own has nothing to certify. It is
-# not a state worth failing over -- reopening a merged branch reaches it -- and
-# saying so is worth more than a silent green
+# An empty range is refused rather than passed. A pull request that genuinely
+# adds no commit is a state nobody needs this job's opinion on ; a range that
+# resolves to nothing because the base or the head was computed wrong is the
+# shape of a false green, and it is indistinguishable from here. Both land on
+# the refusal, for the reason the exit codes are chosen on above : this exists
+# to keep an unsigned commit off master, so the cheap mistake is the red one
 if [ -z "$COMMITS" ]; then
-  printf 'No commit between %s and %s to check\n' "$BASE" "$HEAD"
-  exit 0
+  printf '::error::No commit between %s and %s. A range that resolves to nothing is refused rather than reported clean, since a base or head computed wrong looks exactly like this\n' \
+    "$BASE" "$HEAD" >&2
+  exit 1
 fi
 
 UNSIGNED_COUNT=0

--- a/.github/check_sign_off.sh
+++ b/.github/check_sign_off.sh
@@ -122,6 +122,13 @@ while IFS= read -r COMMIT; do
   # git's own trailer parser rather than the message body : a line quoting the rule
   # in a paragraph is not a trailer, and git is the authority on which is which
   SIGN_OFFS=""
+  # What this reading is and is not : STRICTLY STRONGER than searching the message
+  # body, and not complete. Every trailer git finds is also a well-formed line, so
+  # it refuses everything a body search refuses -- and one shape besides, a
+  # well-formed sign-off quoted in a paragraph that is not the last, which git
+  # reports no trailer for. A quotation placed AT THE END is parsed as a trailer
+  # and still passes ; that is measured, it is the bound of what is claimed here,
+  # and it is written down so the next reader who finds it knows it was known
   SIGN_OFFS="$(git log -1 --format='%(trailers:key=Signed-off-by,valueonly)' "$COMMIT")"
 
   # One well-formed value is enough : a commit may carry several, and a co-author's

--- a/.github/check_sign_off.sh
+++ b/.github/check_sign_off.sh
@@ -66,8 +66,17 @@ fi
 readonly BASE="$1"
 readonly HEAD="$2"
 
-# The trailer git itself writes with "commit -s", matched on its shape rather
-# than merely on its name : "Signed-off-by:" followed by nothing, or by a name
+# The trailer git itself writes with "commit -s", read as a TRAILER and matched on
+# its SHAPE. Both halves are needed, and each closes a hole the other leaves open :
+#
+# Searching the message body for the pattern passes a commit that merely QUOTES the
+# rule. The messages in this repository quote it routinely -- CONTRIBUTING.md's own
+# example, pasted into a commit explaining the sign-off, is a well-formed line that
+# certifies nobody -- and git itself reports no trailer on such a commit while a
+# grep over %B reports a match. Measured on one : the check answered "All 1 commits
+# carry a sign-off" over a commit git says has none.
+#
+# Reading the trailer without looking at its value passes the other shape : "Signed-off-by:" followed by nothing, or by a name
 # with no address, is what a broken git config produces, and it certifies
 # nobody. The address only has to look like one -- an "@" with something on
 # either side -- because deciding whether a mailbox is reachable is not this
@@ -76,7 +85,9 @@ readonly HEAD="$2"
 # Case-insensitive because a handful of tools write the trailer in their own
 # casing and the certification is the same either way ; git's own -s always
 # writes it exactly as CONTRIBUTING.md quotes it
-readonly SIGN_OFF_PATTERN='^[Ss]igned-off-by: .+ <[^[:space:]<>]+@[^[:space:]<>]+>[[:space:]]*$'
+# Matched against the trailer's VALUE, git having already consumed the key -- which
+# it matches case-insensitively itself, so nothing here has to
+readonly SIGN_OFF_VALUE_PATTERN='^.+ <[^[:space:]<>]+@[^[:space:]<>]+>[[:space:]]*$'
 
 # One command substitution per statement, for the reason CLAUDE.md gives : a
 # signal landing inside a second one in the same expansion gets its trap handler
@@ -108,10 +119,14 @@ while IFS= read -r COMMIT; do
 
   CHECKED_COUNT=$((CHECKED_COUNT + 1))
 
-  MESSAGE=""
-  MESSAGE="$(git log -1 --format='%B' "$COMMIT")"
+  # git's own trailer parser rather than the message body : a line quoting the rule
+  # in a paragraph is not a trailer, and git is the authority on which is which
+  SIGN_OFFS=""
+  SIGN_OFFS="$(git log -1 --format='%(trailers:key=Signed-off-by,valueonly)' "$COMMIT")"
 
-  if printf '%s\n' "$MESSAGE" | grep -qE "$SIGN_OFF_PATTERN"; then
+  # One well-formed value is enough : a commit may carry several, and a co-author's
+  # malformed line does not undo the author's certification
+  if printf '%s\n' "$SIGN_OFFS" | grep -qE "$SIGN_OFF_VALUE_PATTERN"; then
     continue
   fi
 

--- a/tests/cases/18_sign_off.sh
+++ b/tests/cases/18_sign_off.sh
@@ -169,6 +169,45 @@ function test_a_merge_commit_is_not_asked_for_a_sign_off() {
   teardown_sign_off_sandbox
 }
 
+function test_a_message_that_merely_quotes_the_rule_certifies_nothing() {
+  # The hole the shape check alone leaves open, and the one this repository walks
+  # into rather than a hypothetical : its commit messages quote the rule while
+  # explaining it, and CONTRIBUTING.md's own example is a well-formed sign-off
+  # line. Pasted into a paragraph it certifies nobody, git reports no trailer on
+  # such a commit -- and a search of the message body reports a match.
+  #
+  # Measured before this case existed : the check answered "All 1 commits carry a
+  # sign-off" over a commit git itself says has none. Reading git's trailer parser
+  # rather than the body is what tells the two apart
+  if ! sign_off_check_can_run; then
+    skip_test "no .github next to the scripts, or no git"
+    return 0
+  fi
+
+  setup_sign_off_sandbox || return 1
+
+  printf 'quoted\n' >> file.txt
+  git add file.txt
+  git commit --quiet --no-verify -m "Explain what the rule is" -m "CONTRIBUTING.md shows the shape :
+Signed-off-by: Random J Developer <random@developer.example.org>
+which this quotes without doing." -m "A paragraph after it, so the quotation is not the last one."
+
+  local OUTPUT STATUS
+  OUTPUT="$(run_sign_off_check "$BASE" HEAD)" && STATUS=0 || STATUS=$?
+
+  assert_equals "1" "$STATUS" "a body quoting the trailer is not a trailer, and the check must refuse it"
+
+  # The premise, asserted rather than assumed : git records no trailer here, while
+  # the string is plainly in the message. That gap is the whole case
+  local -r TRAILERS="$(git log -1 --format='%(trailers:key=Signed-off-by,valueonly)' HEAD)"
+  local -r MESSAGE="$(git log -1 --format='%B' HEAD)"
+  assert_empty "${TRAILERS//[[:space:]]/}" "git should record no trailer on this commit"
+  assert_contains "$MESSAGE" "Signed-off-by: Random J Developer" \
+    "while the message plainly carries the line, which is what a body search would have matched"
+
+  teardown_sign_off_sandbox
+}
+
 function test_a_sign_off_naming_nobody_is_refused() {
   if ! sign_off_check_can_run; then
     skip_test "no .github next to the scripts, or no git"
@@ -235,45 +274,6 @@ function test_a_range_holding_no_commit_is_refused_rather_than_reported_clean() 
 
   assert_equals "1" "$STATUS" "an empty range is what a miscomputed base looks like, and must not read as clean"
   assert_contains "$OUTPUT" "No commit" "and it should say which range it found empty"
-
-  teardown_sign_off_sandbox
-}
-
-function test_a_message_that_merely_quotes_the_rule_certifies_nothing() {
-  if ! sign_off_check_can_run; then
-    skip_test "no .github next to the scripts, or no git"
-    return 0
-  fi
-
-  setup_sign_off_sandbox || return 1
-
-  # Commit messages here quote the rule while explaining it -- the commit adding
-  # this case does -- so the string travels through the history in bodies that
-  # certify nothing. What keeps this refused is the anchoring : the pattern wants
-  # the trailer at the start of its own line, carrying a name and an address,
-  # rather than the words anywhere in the body.
-  #
-  # Reading it through "git ... %(trailers:)" instead would not be stronger. Git
-  # takes the last paragraph as the trailer block and finds a key:value line
-  # inside it wherever it sits, so a quotation placed at the end satisfies the
-  # trailer parser too -- measured, not assumed
-  printf 'quoting\n' >> file.txt
-  git add file.txt
-  git commit --quiet --no-verify -m "A change that talks about the rule
-
-CONTRIBUTING.md says a commit without Signed-off-by is not mergeable, which this quotes and does not do."
-
-  local OUTPUT STATUS
-  OUTPUT="$(run_sign_off_check "$BASE" HEAD)" && STATUS=0 || STATUS=$?
-
-  assert_equals "1" "$STATUS" "a body quoting the trailer is not a trailer" || return 1
-
-  # The premise, asserted rather than assumed : a plain search really would have
-  # been satisfied here, which is what makes the refusal worth pinning
-  local MESSAGE
-  MESSAGE="$(git log -1 --format='%B' HEAD)"
-  assert_contains "$MESSAGE" "Signed-off-by" \
-    "the message does carry the string, so a bare grep would have passed this commit"
 
   teardown_sign_off_sandbox
 }

--- a/tests/cases/18_sign_off.sh
+++ b/tests/cases/18_sign_off.sh
@@ -216,7 +216,7 @@ Signed-off-by: Random J Developer"
   teardown_sign_off_sandbox
 }
 
-function test_a_branch_that_adds_no_commit_is_not_failed() {
+function test_a_range_holding_no_commit_is_refused_rather_than_reported_clean() {
   if ! sign_off_check_can_run; then
     skip_test "no .github next to the scripts, or no git"
     return 0
@@ -224,11 +224,56 @@ function test_a_branch_that_adds_no_commit_is_not_failed() {
 
   setup_sign_off_sandbox || return 1
 
+  # A pull request that genuinely adds nothing is a state nobody needs this
+  # job's opinion on. A range that resolves to nothing because the base or the
+  # head was computed wrong is the shape of a false green -- a shallow checkout,
+  # a branch compared against itself -- and from inside the script the two are
+  # indistinguishable. So both land on the refusal : this exists to keep an
+  # unsigned commit off master, which makes the red the cheap mistake
   local OUTPUT STATUS
   OUTPUT="$(run_sign_off_check "$BASE" HEAD)" && STATUS=0 || STATUS=$?
 
-  assert_equals "0" "$STATUS" "a range holding no commit has nothing to certify"
-  assert_contains "$OUTPUT" "No commit" "and it should say so rather than report a silent green"
+  assert_equals "1" "$STATUS" "an empty range is what a miscomputed base looks like, and must not read as clean"
+  assert_contains "$OUTPUT" "No commit" "and it should say which range it found empty"
+
+  teardown_sign_off_sandbox
+}
+
+function test_a_message_that_merely_quotes_the_rule_certifies_nothing() {
+  if ! sign_off_check_can_run; then
+    skip_test "no .github next to the scripts, or no git"
+    return 0
+  fi
+
+  setup_sign_off_sandbox || return 1
+
+  # Commit messages here quote the rule while explaining it -- the commit adding
+  # this case does -- so the string travels through the history in bodies that
+  # certify nothing. What keeps this refused is the anchoring : the pattern wants
+  # the trailer at the start of its own line, carrying a name and an address,
+  # rather than the words anywhere in the body.
+  #
+  # Reading it through "git ... %(trailers:)" instead would not be stronger. Git
+  # takes the last paragraph as the trailer block and finds a key:value line
+  # inside it wherever it sits, so a quotation placed at the end satisfies the
+  # trailer parser too -- measured, not assumed
+  printf 'quoting\n' >> file.txt
+  git add file.txt
+  git commit --quiet --no-verify -m "A change that talks about the rule
+
+CONTRIBUTING.md says a commit without Signed-off-by is not mergeable, which this quotes and does not do."
+
+  local OUTPUT STATUS
+  OUTPUT="$(run_sign_off_check "$BASE" HEAD)" && STATUS=0 || STATUS=$?
+
+  assert_equals "1" "$STATUS" "a body quoting the trailer is not a trailer" || return 1
+
+  # The premise, asserted rather than assumed : a plain search really would have
+  # been satisfied here, which is what makes the refusal worth pinning
+  local MESSAGE
+  MESSAGE="$(git log -1 --format='%B' HEAD)"
+  assert_contains "$MESSAGE" "Signed-off-by" \
+    "the message does carry the string, so a bare grep would have passed this commit"
 
   teardown_sign_off_sandbox
 }


### PR DESCRIPTION
**Converted.** This branch used to carry a second, parallel implementation of the #388 gate. #391 landed the other one, so the duplicate script and workflow are gone. What remains is the two things the comparison showed that implementation had and the merged one did not.

## 1. The sign-off is read as a trailer, not searched for in the message body

`master` matches an anchored pattern against the whole commit message. That is stronger than a bare `grep` — it wants the line to start with the trailer and to carry a name and an address — but a body is still not where a certification lives.

Commit messages in this repository quote the rule while explaining it, and `CONTRIBUTING.md`'s own example is a well-formed sign-off line. Measured against the merged script, on a message whose middle paragraph quotes it:

```
git log -1 --format='%(trailers:key=Signed-off-by,valueonly)'   ->  (nothing)
.github/check_sign_off.sh <base> <head>                          ->  rc=0, "All 1 commits carry a sign-off"
```

git says the commit has no trailer and the gate passed it. A false green, in the one place a false green is the entire risk.

The reading moves to git's own trailer parser, which is the authority on which line is a trailer and which is prose. The shape check stays, applied now to the trailer's **value**.

**One caveat, measured rather than assumed:** git takes the last paragraph as the trailer block and will find a `key: value` line anywhere inside it. A quotation placed at the very end of a message therefore satisfies the trailer parser too. This closes the mid-message shape, which is the one that occurs in practice; it does not make the check total.

## 2. A range that resolves to nothing is refused

It used to pass, on the reasoning that a pull request adding no commit has nothing to certify. That holds for the state it names and not for the one that produces it: a base or head computed wrong resolves to nothing too — a shallow checkout, a branch compared against itself — and from inside the script the two are indistinguishable.

This gate exists to keep an unsigned commit off `master`, so the red is the cheap mistake. The empty range now lands where *"the range could not be read"* already did.

## Validation

| Check | Result |
| --- | --- |
| `./tests/run_tests.sh` | **510 test cases passed, 2536 assertions** |
| `shellcheck -x` over the workflow's full list | **rc=0** |
| a quotation in a middle paragraph | refused, rc=1 |
| a real `git commit -s` | accepted, rc=0 |
| an empty range | refused, rc=1 |

## What was dropped

The parallel `.github/check_signed_off_by.sh` and `.github/workflows/dco.yml`. Two scripts doing one job is worse than either of them, and #391's is the one on `master`.