### PR TITLE
Hand back fans that were taken but whose speed was refused (#389)

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -61,12 +61,16 @@ function apply_user_fan_control_profile() {
   # fan control away from Dell's own dynamic profile, the second sets the speed. Failing the first and
   # succeeding the second is not a partial success but the worst case -- the fans are still Dell's to
   # drive -- so either failure means the profile was not applied
+  WERE_THE_FANS_HANDED_BACK_THIS_CYCLE=false
   local ipmitool_stderr
   local IS_PROFILE_APPLIED=true
   # What the server answered to the command that takes the fans, kept until both commands have run so
   # that the verdict below is drawn after everything this cycle had to say, rather than between two
   # error lines it would then look like it did not cover
   local MANUAL_FAN_CONTROL_STDERR=""
+  # Whether the server DECIDED not to run the speed command, as opposed to being unable to answer it
+  # this once. Only a decision is worth acting on : see the hand-back below
+  local WAS_THE_SPEED_DEFINITIVELY_REFUSED=false
 
   ipmitool_stderr=$(ipmitool -I $IDRAC_LOGIN_STRING raw 0x30 0x30 0x01 0x00 2>&1 >/dev/null)
   # shellcheck disable=SC2181  # $? here is the command substitution above, already run; there is no direct command left to negate
@@ -106,6 +110,16 @@ function apply_user_fan_control_profile() {
           # Explained once, rather than as a raw ipmitool line on every cycle. It settles nothing and
           # stops nothing being sent
           note_that_the_server_rejects_the_broadcast_fan_selector "$ipmitool_stderr"
+          # The server answered with a completion code that is a decision rather than a moment : it
+          # rejected the selector byte and then rejected every fan it was offered one at a time, or it
+          # answered that it does not have the command at all, or that this account may not run it.
+          # A busy BMC, a dropped session or an answer nothing here recognizes is deliberately none of
+          # those, and is left to the next check rather than concluded from
+          if does_the_server_reject_this_data_field "$ipmitool_stderr" ||
+            does_the_server_lack_this_command "$ipmitool_stderr" ||
+            does_the_command_need_a_higher_privilege_level "$ipmitool_stderr"; then
+            WAS_THE_SPEED_DEFINITIVELY_REFUSED=true
+          fi
         fi
       fi
     fi
@@ -117,6 +131,34 @@ function apply_user_fan_control_profile() {
   # back fans it had already taken, which is the one outcome that leaves them pinned with nobody watching
   if [ -n "$MANUAL_FAN_CONTROL_STDERR" ]; then
     note_that_the_server_refuses_fan_control "$MANUAL_FAN_CONTROL_STDERR"
+  fi
+
+  # The fans were taken and the speed was refused, so they are on neither profile : Dell's own dynamic
+  # fan control no longer has them, and the speed meant to replace it never landed. They run at whatever
+  # this iDRAC does with manual control and no speed set, which nothing here can read back -- so the
+  # table could only ever name a profile that is not running, which is the one thing it must not do.
+  #
+  # Handing them back is the only state this container can both reach and describe. It is not what makes
+  # the server safe : is_any_CPU_overheating() already restores Dell's profile on a CPU above the
+  # threshold, on a reading it cannot parse, on an unusable threshold and on a server reporting no CPU
+  # at all, so the fans were never unwatched. What it removes is the window before any of those happen,
+  # in which a cool server sits at a duty nobody chose -- possibly higher than the user asked for, which
+  # is a noise complaint nothing in the table could have explained (issue #389).
+  #
+  # Only ever on a decision, and only if the fans were actually taken : an empty MANUAL_FAN_CONTROL_STDERR
+  # is the command that takes them having landed. Where it did not, the fans never left Dell and there is
+  # nothing to give back
+  if $WAS_THE_SPEED_DEFINITIVELY_REFUSED && [ -z "$MANUAL_FAN_CONTROL_STDERR" ]; then
+    WERE_THE_FANS_HANDED_BACK_THIS_CYCLE=true
+    if apply_Dell_default_fan_control_profile; then
+      CURRENT_FAN_CONTROL_PROFILE="Dell default dynamic fan control profile (speed refused)"
+    else
+      # The hand-back was refused too, so the fans are still on neither profile. apply_Dell_default_fan_control_profile()
+      # has already named that state ; saying the user's profile was applied over it would be the lie this
+      # whole branch exists to avoid
+      CURRENT_FAN_CONTROL_PROFILE="Fans left on no profile (speed refused, and Dell's own could not be restored)"
+    fi
+    return 1
   fi
 
   if ! $IS_PROFILE_APPLIED; then
@@ -2029,9 +2071,9 @@ function note_that_the_server_rejects_the_broadcast_fan_selector() {
   HAS_THE_BROADCAST_FAN_SELECTOR_REJECTION_BEEN_REPORTED=true
 
   print_warning "This server took the command that puts its fans under manual control, then refused the one that sets their speed, over one of its arguments rather than over the command itself (completion code 0xcc, \"invalid data field in request\").
- Its fans are consequently on neither profile : they have left Dell's own dynamic fan control profile, and the speed of $DECIMAL_FAN_SPEED% that was meant to replace it never reached them. They are running at whatever this iDRAC does with manual control and no speed set, which nothing here can read back.
+ Its fans have therefore been handed back to Dell's own dynamic fan control profile, which is the only state this container can both reach and describe : they had already left it when the command that takes them landed, and the speed of $DECIMAL_FAN_SPEED% meant to replace it never arrived, so they were running at a duty nothing here can read back (issue #389).
  Both ways of asking were refused. The speed is normally addressed to every fan at once with the selector 0xff, and an 11th generation iDRAC6 refuses that while accepting the very same command addressed to one fan at a time (issue #378) -- so the fans were then asked individually, walking upwards from 0x00, and this server refused that too. The selector is therefore not what stands in the way here.
- Set MONITORING_ONLY_MODE=true so the container never takes the fans from Dell's own dynamic fan control profile at all and only logs temperatures, or stop it : stopping hands them back to that profile on the way out.
+ This container cannot make this server quieter, and will keep saying so rather than appearing to. Setting MONITORING_ONLY_MODE=true stops it trying at all and keeps the temperatures logged, which is the same outcome with a quieter log.
  If your server answers this, the output of \"ipmitool -I lanplus -H <iDRAC IP address> -U <iDRAC username> -P <iDRAC password> sdr type fan\" on issue #378 would help work out what it wants instead"
 }
 
@@ -2442,6 +2484,18 @@ function fan_control_comment_clause() {
 
   if has_the_server_refused_fan_control; then
     echo "and this server refused fan control, so its fans stay Dell's own to drive"
+    return
+  fi
+
+  # The profile column names Dell's profile on the cycles where the speed was refused and the fans were
+  # handed back (issue #389), so the comment cannot name the user's : one row would then say the fans are
+  # on both. CLAUDE.md is explicit that the table never names a profile the fans are not running, and a
+  # comment is part of the table.
+  # Read from what this cycle did, not from a verdict about the server : a refused speed deliberately
+  # settles nothing, the fans being the controller's by then and only the command that takes them able
+  # to say whether this server hands them over at all
+  if "${WERE_THE_FANS_HANDED_BACK_THIS_CYCLE:-false}"; then
+    echo "and this server refused the speed command, so its fans were handed back to Dell's own profile"
     return
   fi
 

--- a/tests/cases/70_fan_control_profiles.sh
+++ b/tests/cases/70_fan_control_profiles.sh
@@ -276,19 +276,20 @@ function test_a_refused_profile_is_not_reported_as_applied() {
 }
 
 function test_a_refused_fan_speed_alone_is_enough_to_deny_the_profile() {
-  # Taking control away from Dell's profile and then failing to set a speed leaves
-  # the fans on the controller's watch at an unknown duty : the profile named in
-  # the table is not the one running either way
+  # Taking control away from Dell's profile and then failing to set a speed leaves the fans at an
+  # unknown duty, so the user's profile is not the one running. Since #389 the fans are handed back
+  # rather than left there, and the table names what they are actually on
   DECIMAL_FAN_SPEED=30
   HEXADECIMAL_FAN_SPEED="0x1e"
   export MOCK_IPMITOOL_RAW_FAIL_PATTERN="0x30 0x30 0x02"
   export MOCK_IPMITOOL_RAW_FAIL_STDERR="$REJECTED_BY_FIRMWARE_STDERR"
 
   apply_user_fan_control_profile 2>/dev/null
+  local -r EXIT_CODE=$?
 
-  assert_contains "$CURRENT_FAN_CONTROL_PROFILE" "not applied"
-  assert_contains "$CURRENT_FAN_CONTROL_PROFILE" "30%" \
-    "the speed that was asked for is still worth showing, it is what was refused"
+  assert_equals "1" "$EXIT_CODE" "the profile the user asked for is not the one running"
+  assert_not_contains "$CURRENT_FAN_CONTROL_PROFILE" "User static"     "and the table must not name it, however qualified"
+  assert_equals "Dell default dynamic fan control profile (speed refused)" "$CURRENT_FAN_CONTROL_PROFILE"
 }
 
 function test_a_refused_dell_default_profile_is_not_reported_as_applied() {
@@ -518,31 +519,31 @@ function test_a_rejected_fan_selector_never_makes_the_controller_give_up_on_fan_
 
 function test_a_rejected_fan_selector_is_explained_once_and_names_the_state_the_fans_are_in() {
   # The defect from the user's side : the log repeated one raw ipmitool line a minute, and nothing said
-  # that manual control had been taken while the speed had not, which is why the fans sat "too low".
-  # Only a server that refuses the speed BOTH ways reaches this now -- one that merely refuses the
-  # broadcast selector is handled rather than reported, which the fallback tests below cover
+  # what had become of the fans. It now says they were handed back (#389), names the completion code the
+  # verdict was read from, and says it once rather than on every cycle
   export MOCK_IPMITOOL_RAW_FAIL_PATTERN="0x30 0x30 0x02"
   export MOCK_IPMITOOL_RAW_FAIL_STDERR="$BROADCAST_FAN_SELECTOR_REJECTED_STDERR"
 
   capture_output apply_user_fan_control_profile
 
-  assert_contains "$CAPTURED_OUTPUT" "neither profile" \
-    "the fans are on neither Dell's profile nor the user's, and that is the part worth saying"
+  assert_contains "$CAPTURED_OUTPUT" "handed back" \
+    "what became of the fans is the part worth saying"
   assert_contains "$CAPTURED_OUTPUT" "0xcc" \
     "the completion code the verdict was read from must be quoted"
   assert_contains "$CAPTURED_OUTPUT" "MONITORING_ONLY_MODE" \
-    "the one setting that gets this server out of it must be named"
+    "the one setting that stops the container trying must be named"
 
   forget_recorded_ipmitool_calls
   capture_output apply_user_fan_control_profile
 
-  assert_not_contains "$CAPTURED_OUTPUT" "neither profile" \
+  assert_not_contains "$CAPTURED_OUTPUT" "handed back" \
     "explained the once, not on every cycle for the life of the container"
 }
 
 function test_a_rejected_fan_selector_still_denies_the_profile() {
   # Whatever is said about it, the table must not name a profile the fans are not running. A server that
-  # refuses the speed however it is addressed is running neither
+  # refuses the speed however it is addressed gets its fans back from the controller (#389), and that is
+  # what the table names
   export MOCK_IPMITOOL_RAW_FAIL_PATTERN="0x30 0x30 0x02"
   export MOCK_IPMITOOL_RAW_FAIL_STDERR="$BROADCAST_FAN_SELECTOR_REJECTED_STDERR"
 
@@ -550,7 +551,8 @@ function test_a_rejected_fan_selector_still_denies_the_profile() {
   local -r EXIT_CODE=$?
 
   assert_equals "1" "$EXIT_CODE"
-  assert_contains "$CURRENT_FAN_CONTROL_PROFILE" "not applied"
+  assert_not_contains "$CURRENT_FAN_CONTROL_PROFILE" "User static"
+  assert_equals "Dell default dynamic fan control profile (speed refused)" "$CURRENT_FAN_CONTROL_PROFILE"
 }
 
 # The identifiers an 11G iDRAC6 accepts, as swept on the R510 of issue #378 : 0x00 to 0x07 answer, 0x08
@@ -621,8 +623,9 @@ function test_the_fan_identifier_set_is_never_counted_from_the_sensor_list() {
 }
 
 function test_a_server_refusing_the_speed_every_way_is_reported_rather_than_probed_forever() {
-  # Nothing is accepted here, so the selector was never what stood in the way. The walk must stop at
-  # 0x00, the profile must not claim to be applied, and the user must be told
+  # Nothing is accepted here, so the selector was never what stood in the way. Nothing is remembered,
+  # the user is told once, and the refusal must still not be read as a server refusing fan control --
+  # which would stop the hand-back below from ever being sent
   export MOCK_IPMITOOL_RAW_FAIL_PATTERN="0x30 0x30 0x02"
   export MOCK_IPMITOOL_RAW_FAIL_STDERR="$BROADCAST_FAN_SELECTOR_REJECTED_STDERR"
 
@@ -630,7 +633,6 @@ function test_a_server_refusing_the_speed_every_way_is_reported_rather_than_prob
   local -r EXIT_CODE=$?
 
   assert_equals "1" "$EXIT_CODE"
-  assert_contains "$CURRENT_FAN_CONTROL_PROFILE" "not applied"
   assert_equals "0" "${#DISCOVERED_FAN_IDENTIFIERS[@]}" "nothing was accepted, so nothing is remembered"
   assert_contains "$CAPTURED_OUTPUT" "Both ways of asking were refused" \
     "the message must describe the server that refused both, not send the user probing again"
@@ -792,4 +794,103 @@ function test_an_interrupted_walk_never_claims_the_server_refused_the_speed_both
 
   assert_contains "$CAPTURED_OUTPUT" "Both ways of asking were refused" \
     "the one-off explanation must not have been spent by the interruption"
+}
+
+function test_fans_that_were_taken_are_handed_back_when_the_speed_is_refused_every_way() {
+  # The fans left Dell's profile and the speed never replaced it, so they run at a duty nothing here
+  # can read back. Handing them back is the only state this container can both reach and describe
+  # (issue #389)
+  export MOCK_IPMITOOL_RAW_FAIL_PATTERN="0x30 0x30 0x02"
+  export MOCK_IPMITOOL_RAW_FAIL_STDERR="$BROADCAST_FAN_SELECTOR_REJECTED_STDERR"
+  DECIMAL_FAN_SPEED=30
+  HEXADECIMAL_FAN_SPEED="0x1e"
+
+  capture_output apply_user_fan_control_profile
+  local -r EXIT_CODE=$?
+
+  assert_equals "1" "$EXIT_CODE" "the profile the user asked for is not the one running"
+  assert_equals "1" "$(count_ipmitool_calls_matching "$DELL_DEFAULT_FAN_CONTROL_COMMAND")" \
+    "the fans must be handed back to Dell's own dynamic fan control profile"
+  assert_equals "Dell default dynamic fan control profile (speed refused)" "$CURRENT_FAN_CONTROL_PROFILE" \
+    "and the table must name the profile the fans are actually running, and why it is that one"
+}
+
+function test_fans_that_were_never_taken_are_not_handed_back() {
+  # The command that takes the fans failed, so they never left Dell : there is nothing to give back,
+  # and sending the hand-back would be one more doomed command on a server that already refused this one
+  export MOCK_IPMITOOL_RAW_FAIL_PATTERN="0x30 0x30 0x01 0x00|0x30 0x30 0x02"
+  export MOCK_IPMITOOL_RAW_FAIL_STDERR="$BROADCAST_FAN_SELECTOR_REJECTED_STDERR"
+
+  capture_output apply_user_fan_control_profile
+
+  assert_equals "0" "$(count_ipmitool_calls_matching "$DELL_DEFAULT_FAN_CONTROL_COMMAND")" \
+    "nothing was taken, so nothing is handed back"
+}
+
+function test_an_interrupted_walk_does_not_hand_the_fans_back() {
+  # A walk cut short by a busy BMC is a moment, not a decision. Handing back on it would flip the fans
+  # to Dell's profile over a blip and take them again on the very next check
+  export MOCK_IPMITOOL_RAW_FAIL_PATTERN="0x30 0x30 0x02 (0xff|$REFUSED_FAN_IDENTIFIER_PATTERN)"
+  export MOCK_IPMITOOL_RAW_FAIL_STDERR="$BROADCAST_FAN_SELECTOR_REJECTED_STDERR"
+  export MOCK_IPMITOOL_RAW_TRANSIENT_PATTERN="0x30 0x30 0x02 0x03"
+
+  capture_output apply_user_fan_control_profile
+
+  assert_equals "0" "$(count_ipmitool_calls_matching "$DELL_DEFAULT_FAN_CONTROL_COMMAND")" \
+    "an interrupted walk settles nothing, so nothing is handed back over it"
+  assert_contains "$CURRENT_FAN_CONTROL_PROFILE" "not applied"
+}
+
+function test_a_server_that_takes_the_speed_is_never_handed_anything_back() {
+  # The hand-back must be invisible on healthy hardware
+  DECIMAL_FAN_SPEED=30
+  HEXADECIMAL_FAN_SPEED="0x1e"
+
+  apply_user_fan_control_profile
+
+  assert_equals "0" "$(count_ipmitool_calls_matching "$DELL_DEFAULT_FAN_CONTROL_COMMAND")"
+  assert_equals "User static fan control profile (30%)" "$CURRENT_FAN_CONTROL_PROFILE"
+}
+
+function test_a_refused_hand_back_is_not_reported_as_a_profile_that_is_running() {
+  # Both the speed and the hand-back refused : the fans are on neither profile, and the table must say
+  # so rather than name one of them
+  export MOCK_IPMITOOL_RAW_FAIL_PATTERN="0x30 0x30 0x02|0x30 0x30 0x01 0x01"
+  export MOCK_IPMITOOL_RAW_FAIL_STDERR="$BROADCAST_FAN_SELECTOR_REJECTED_STDERR"
+
+  capture_output apply_user_fan_control_profile
+  local -r EXIT_CODE=$?
+
+  assert_equals "1" "$EXIT_CODE"
+  assert_contains "$CURRENT_FAN_CONTROL_PROFILE" "no profile" \
+    "neither Dell's profile nor the user's is running, and the table must not claim either"
+}
+
+function test_the_row_comment_never_names_a_profile_the_fans_are_not_running() {
+  # The profile column names Dell's profile on a cycle where the fans were handed back, so the comment
+  # on that same row cannot name the user's : one row would say the fans are on both (#389)
+  export MOCK_IPMITOOL_RAW_FAIL_PATTERN="0x30 0x30 0x02"
+  export MOCK_IPMITOOL_RAW_FAIL_STDERR="$BROADCAST_FAN_SELECTOR_REJECTED_STDERR"
+
+  apply_user_fan_control_profile 2>/dev/null
+  local -r CLAUSE=$(fan_control_comment_clause "user's fan control profile applied")
+
+  assert_not_contains "$CLAUSE" "user's fan control profile applied" \
+    "the fans are on Dell's profile, so the comment must not say the user's was applied"
+  assert_contains "$CLAUSE" "handed back" "it says what actually happened to them instead"
+}
+
+function test_a_cycle_that_applied_the_user_profile_says_so_plainly() {
+  # The clause must stay untouched on the healthy path : a hand-back on one cycle must not colour the
+  # comment of a later one that worked
+  export MOCK_IPMITOOL_RAW_FAIL_PATTERN="0x30 0x30 0x02"
+  export MOCK_IPMITOOL_RAW_FAIL_STDERR="$BROADCAST_FAN_SELECTOR_REJECTED_STDERR"
+  apply_user_fan_control_profile 2>/dev/null
+
+  unset MOCK_IPMITOOL_RAW_FAIL_PATTERN
+  apply_user_fan_control_profile
+
+  assert_equals "user's fan control profile applied" \
+    "$(fan_control_comment_clause "user's fan control profile applied")" \
+    "the cycle that worked says so, whatever the previous one did"
 }

--- a/tests/lib/harness.sh
+++ b/tests/lib/harness.sh
@@ -41,6 +41,7 @@ function setup_test_context() {
   # Same, for the fan control commands : a test starts against a server that has refused nothing and
   # accepted nothing, which is what the controller starts from too
   IS_FAN_CONTROL_SUPPORTED=true
+  WERE_THE_FANS_HANDED_BACK_THIS_CYCLE=false
   HAS_FAN_CONTROL_EVER_BEEN_ACCEPTED=false
   # Same, for the one-off explanation of a rejected fan selector : a test starts against a server that
   # has not been told anything yet


### PR DESCRIPTION
Closes #389.

## What it does

The controller sends two commands: the first takes the fans away from Dell's own dynamic fan control profile, the second sets their speed. When the first lands and the second is refused **however it is addressed**, the fans are on neither profile — Dell no longer drives them, and the speed that was meant to replace it never arrived. They run at a duty nobody chose and nothing here can read back.

They now go back to Dell, and the table names that instead of naming the user's profile with a caveat.

## What it is not

**Not a safety fix.** `is_any_CPU_overheating()` already restores Dell's profile on a CPU above the threshold, on a reading it cannot parse, on an unusable threshold, and on a server reporting no CPU at all — so the fans were never unwatched. I said otherwise when I opened #389, and corrected the issue before writing this; a fix designed against that wording would have aimed at the wrong thing.

What this removes is the window before any of those fire, in which a cool server sits at an unknown duty — possibly *higher* than the user asked for, which is a noise complaint nothing in the table could have explained.

## Only on a decision, and only if there was something to give back

- The completion code has to be one that says the server **decided**: `0xcc` after every fan was also refused one at a time, `0xc1`, `0xd5`, or `0xd4`. A busy BMC, a dropped session, a walk abandoned mid-way, or an answer nothing here recognises are none of those, and are left to the next check.
- The command that takes the fans has to have landed. Where it did not, they never left Dell and there is nothing to hand back.

## The invariant this deliberately does not touch

A refused speed still **settles nothing** about the server, and every cycle tries again exactly as before. `test_a_refused_fan_speed_never_stops_the_controller_from_trying()` pins that, and it is right to: the speed command runs on fans the controller already holds, so concluding from it would stop the controller ever giving back fans it had taken.

I wrote a first version that made the refusal durable — skipping the take entirely on later cycles. It broke that test, and I dropped it rather than overturn a documented invariant on my own initiative. What it was trying to fix is now #397.

## The row comment

The profile column names Dell's profile on a cycle where the fans were handed back, so the comment on that same row can no longer say the user's profile was applied — one row would have said the fans were on both. `fan_control_comment_clause()` now reads what the cycle actually did, deliberately not a verdict about the server, for the same reason as above.

Without this, the first cycle on an affected server printed `Dell default dynamic fan control profile (speed refused)` in one column and *"user's fan control profile applied"* in the next.

## Testing

Seven new cases: the fans are handed back on a definitive refusal; fans that were never taken are not; an interrupted walk does not trigger it; a server that takes the speed never sees it; a refused hand-back is not reported as a profile that is running; the row comment cannot contradict the profile column; and a later cycle that works says so plainly.

Each was verified against the code with the hand-back neutered — four fail there, and the other three cover the comment and the negative cases.

Three existing cases are realigned rather than dropped: they asserted `(not applied)` where the table now names Dell's profile. Their intent — the table must not name a profile the fans are not running — is what the new string satisfies.

- Full suite: **483 test cases passed (2415 assertions)**, rebased onto `09f25ae`
- `shellcheck -x` over the CI-scoped scripts: clean

## Found while doing this, and NOT fixed here → #397

On a server that refuses the speed every way, `DISCOVERED_FAN_IDENTIFIERS` stays empty, so every cycle re-walks the whole identifier range. Measured on this branch: **35 IPMI commands per check, 34 of them known in advance to fail, and cycle 2 sends the same 35 as cycle 1**.

That arrived with #384 and is not caused by this PR, which adds one command to that cycle. Fixing it properly means letting a refused speed settle *something*, which is exactly the invariant above — so it is #397's decision, with a middle option there that does not touch it.