### PR TITLE
Install the four packages the image names, and nothing apt adds beside them (#400)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,16 +40,23 @@ LABEL org.opencontainers.image.licenses="AGPL-3.0-only"
 # The three commands are one RUN because the layer, not the filesystem, is what gets pulled : deleting
 # /var/lib/apt/lists from a later layer would hide the package lists without making this one any
 # smaller, and they would still be transferred. Merged, they are never committed in the first place.
-# apt-get install keeps its recommends on purpose - dropping them is a change to what is installed,
-# not to what is shipped, and is argued in its own right rather than smuggled in beside a size fix
 # lm-sensors is used to read the CPUs' own "high" temperature, which is the default CPU_TEMPERATURE_THRESHOLD
 # perl and libio-socket-ssl-perl are the HTTPS client : Redfish is HTTPS and the base image ships no client
-# at all - no curl, no wget, no openssl, no python3. perl and its core HTTP::Tiny already arrive here as a
-# recommends of lm-sensors, so only the TLS layer is really added, about 2 MB against curl's 13.5 MB and its
-# 24 packages of dependency surface. perl is named explicitly all the same rather than relied upon as
-# somebody else's recommends, so that a later --no-install-recommends cannot silently take it away
+# at all - no curl, no wget, no openssl, no python3, and the perl the base image does carry is perl-base,
+# which has no HTTP::Tiny in it. About 2 MB of TLS layer, against curl's 13.5 MB and its 24 packages
+# --no-install-recommends makes those four names the whole of what is asked for. Without it apt adds 13
+# packages and 3.3 MB that nothing in the image calls : ipmitool recommends openipmi, a daemon whose job is
+# loading the IPMI kernel modules on a host - which a container can neither do nor need, being handed a
+# /dev/ipmi0 the host already opened - and openipmi carries libsnmp, kmod, libpci and libpopt in behind it ;
+# libio-socket-ssl-perl recommends liburi-perl, which HTTP::Tiny does not use. Measured on ubuntu:latest :
+# 117 packages and 61.6 MB with the recommends, 104 and 58.3 MB without, and the two images answer
+# "ipmitool -h" with the same interface list, fail an absent /dev/ipmi0 with the same message, print the
+# same "sensors -u", and complete the same HTTPS round trip with Basic auth against a local TLS server.
+# That openipmi chain is where full perl came from before #374 named it - libsnmp depends on libperl - so
+# it is the one thing worth checking twice here : perl stays because libio-socket-ssl-perl depends on it
+# outright and because it is named, not because somebody's recommends still supplies it
 RUN apt-get update \
- && apt-get install ipmitool lm-sensors perl libio-socket-ssl-perl -y \
+ && apt-get install --no-install-recommends ipmitool lm-sensors perl libio-socket-ssl-perl -y \
  && rm -rf /var/lib/apt/lists/*
 
 # AGPL section 4 asks that the notices travel with every copy conveyed, and an image is a copy. They

--- a/tests/cases/10_shell_scripts.sh
+++ b/tests/cases/10_shell_scripts.sh
@@ -1003,9 +1003,50 @@ function test_the_notice_names_every_package_the_image_installs() {
 
   local PACKAGE
   for PACKAGE in $INSTALLED_PACKAGES; do
+    # apt-get's own options share the line with the package names. They are not
+    # software shipped in the image, so NOTICE has nothing to say about them
+    case "$PACKAGE" in -*) continue ;; esac
+
     assert_matches "$NOTICE_CONTENT" "(^|[^A-Za-z0-9_-])$PACKAGE([^A-Za-z0-9_-]|$)" \
       "the image installs $PACKAGE, NOTICE should name it among the software shipped with the image"
   done
+}
+
+function test_the_image_installs_the_packages_it_names_and_nothing_else() {
+  # Left to its recommends, apt puts 13 packages and 3.3 MB into the image that
+  # nothing in it ever calls : ipmitool recommends openipmi, a daemon whose job is
+  # loading the IPMI kernel modules on a host -- which a container can neither do
+  # nor need, being handed a /dev/ipmi0 the host already opened -- and openipmi
+  # brings libsnmp, kmod, libpci and libpopt with it ; libio-socket-ssl-perl
+  # recommends liburi-perl, which HTTP::Tiny does not use. Measured on
+  # ubuntu:latest : 117 packages and 61.6 MB with them, 104 and 58.3 MB without,
+  # the two images answering "ipmitool -h" with the same interface list, failing an
+  # absent /dev/ipmi0 with the same message, printing the same "sensors -u" and
+  # completing the same HTTPS round trip with Basic auth against a local TLS server
+  #
+  # The flag is also what makes the install line's four names the whole truth about
+  # what ships, which is the claim the NOTICE case above reads them as
+  if [ ! -f "$REPO_ROOT/Dockerfile" ]; then
+    # The suite is running inside the built image, which does not carry the
+    # Dockerfile that built it
+    skip_test "no Dockerfile next to the scripts"
+    return 0
+  fi
+
+  local -r DOCKERFILE_CONTENT=$(cat "$REPO_ROOT/Dockerfile")
+
+  assert_contains "$DOCKERFILE_CONTENT" "apt-get install --no-install-recommends " \
+    "the image should install what the Dockerfile names and nothing else" || return 1
+
+  # perl reached the image on its own before #374 named it, through the very chain
+  # this flag drops : ipmitool recommends openipmi, openipmi depends on libsnmp and
+  # libsnmp on libperl. It is named here, and libio-socket-ssl-perl depends on it
+  # outright, so the Redfish client does not rest on that coincidence any more --
+  # but the name is what says so, and dropping it would put the image back on it
+  local -r INSTALLED_PACKAGES=$(sed -n 's/.*apt-get install \(.*\) -y.*/\1/p' "$REPO_ROOT/Dockerfile")
+
+  assert_matches "$INSTALLED_PACKAGES" "(^| )perl( |$)" \
+    "perl is the Redfish client's interpreter, the Dockerfile should keep naming it explicitly"
 }
 
 function test_the_healthcheck_succeeds_when_the_sensors_can_be_read() {


### PR DESCRIPTION
Closes #400.

#365 deferred this on purpose — dropping the recommends changes what is installed rather than what is shipped, and that is an argument to make on its own rather than beside a size fix. This is that argument, made with both images built.

## What changes

`--no-install-recommends` on the install line, the comment above it replaced with what was measured, and both halves pinned in `tests/cases/10_shell_scripts.sh`.

## What it costs and what it saves

Built both ways on `ubuntu:latest`, from this repository's own `Dockerfile`:

| | packages | image size |
| --- | --- | --- |
| `master` | 117 | 61.74 MB |
| this branch | 104 | 58.42 MB |

The 13 that go — `openipmi`, `libopenipmi0t64`, `libsnmp40t64`, `libsnmp-base`, `kmod`, `libkmod2`, `libpci3`, `pci.ids`, `libpopt0`, `libwrap0`, `libncurses6`, `libgpm2`, `liburi-perl` — come from two chains, and nothing in this repository calls any of them:

- `ipmitool` recommends `openipmi`, the daemon whose job is loading the IPMI kernel modules on a host. A container can neither do that nor need it: the host loads them, and the README tells the user to hand the device in with `--device=/dev/ipmi0`. `openipmi` then depends on `libsnmp40t64`, which brings `libsnmp-base`, `libpci3`, `libwrap0` and `libpopt0` with it.
- `libio-socket-ssl-perl` recommends `liburi-perl`, which `HTTP::Tiny` does not use — it parses URLs itself.

## The comment was wrong about perl, and that is the part worth checking twice

It read:

> perl and its core HTTP::Tiny already arrive here as a recommends of lm-sensors

`lm-sensors` depends on `libc6` and `libsensors5` and recommends nothing; built alone it carries no `HTTP::Tiny`. `ipmitool` built alone does — through `openipmi` → `libsnmp40t64` → `libperl5.40`. So the chain the comment thanked for the Redfish interpreter is exactly the chain this flag drops.

It holds anyway: `libio-socket-ssl-perl` depends on `perl` outright, and #374 names it besides. The comment now says what was measured rather than what was assumed, and a test pins that `perl` stays named — the recommends that used to supply it will no longer be there to cover for its removal.

## Verification

Run, not argued. In both images:

- `ipmitool -h` prints the same interface list (`open`, `imb`, `lan`, `lanplus`, `free`, `serial-terminal`, `serial-basic`, `dummy`, `usb`);
- `ipmitool -I open sdr` fails an absent `/dev/ipmi0` with byte-identical output;
- `sensors -u` prints the same thing;
- `HTTP::Tiny` with `verify_SSL => 0` and a `Basic` header completes the same HTTPS round trip against a local `IO::Socket::SSL` server — 200, and the body back.

Suite: 477 cases / 2403 assertions pass on the runner, and 427 pass inside the image built from this branch (the 50 skips are the cases that need the `Dockerfile` beside the scripts, as on `master`). `shellcheck -x` clean on what CI lints.

## Test changes

- `test_the_image_installs_the_packages_it_names_and_nothing_else` — new: the flag, and that `perl` is still named.
- `test_the_notice_names_every_package_the_image_installs` — reads the install line word by word, so it now skips `apt`'s own options rather than asking `NOTICE` to attribute `--no-install-recommends`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LbwwtnuQyHu1tAuQiaRZ3f)_