### PR TITLE
Test the lm-sensors fallback on the shape real hardware has (#256)

### DIFF
--- a/tests/cases/23_cpu_temperature_source.sh
+++ b/tests/cases/23_cpu_temperature_source.sh
@@ -71,6 +71,15 @@ function simulate_iDRAC_reporting_no_CPU() {
   MOCK_IPMITOOL_SDR_OUTPUT=$(make_sdr_output --cpus 0 --inlet 23 --exhaust 34)
 }
 
+# The same server as reported hardware actually presents it : the processor entities ARE there, they
+# simply carry no reading. Issue #256 asked which of the two shapes the affected servers have, and the
+# R510 of #378 answered -- it is this one, not the one above
+# Usage : simulate_iDRAC_reporting_every_CPU_as_disabled
+function simulate_iDRAC_reporting_every_CPU_as_disabled() {
+  export MOCK_IPMITOOL_SDR_OUTPUT
+  MOCK_IPMITOOL_SDR_OUTPUT=$(make_sdr_output --cpus 2 --every-cpu-disabled --inlet 29 --no-exhaust)
+}
+
 # --- The parameter itself -----------------------------------------------------
 
 function test_the_three_sources_are_recognized() {
@@ -744,4 +753,73 @@ function test_a_package_read_column_says_nothing_extra() {
 
   assert_not_contains "$(format_detected_CPU_temperature_sensors)" "hottest core" \
     "nothing is standing in for anything on a chip that has its package"
+}
+
+# --- The shape reported hardware actually has (issues #256, #378) --------------
+
+function test_processor_entities_that_carry_no_reading_are_not_counted_as_CPUs() {
+  # An iDRAC6 on an 11G server lists its processor entities and reports "Disabled" where a temperature
+  # would be. "Disabled" is not a malformed reading to be parsed more cleverly -- it is the absence of
+  # one -- so the entity must not become a column whose value nothing can produce
+  local -r SDR_DATA=$(make_sdr_output --cpus 2 --every-cpu-disabled --inlet 29 --no-exhaust)
+
+  detect_CPU_temperature_sensors "$SDR_DATA"
+
+  assert_equals "0" "${#DETECTED_CPU_ENTITY_IDS[@]}" \
+    "entities 3.1 and 3.2 are listed, but neither carries a temperature"
+}
+
+function test_a_disabled_entity_is_told_apart_from_an_absent_one_only_by_its_reading() {
+  # The two shapes must reach the same verdict, because the container's answer to both is the same :
+  # ask another source. Pinning it here is what stops a looser reading check from making one of them
+  # look like a CPU -- the entity row is present in this one, and only the reading column says no
+  local -r NO_ENTITY_AT_ALL=$(make_sdr_output --cpus 0 --inlet 29)
+  local -r EVERY_ENTITY_DISABLED=$(make_sdr_output --cpus 2 --every-cpu-disabled --inlet 29)
+
+  assert_not_contains "$NO_ENTITY_AT_ALL" "3.1" "this shape emits no processor row"
+  assert_contains "$EVERY_ENTITY_DISABLED" "3.1" "this one does, which is the whole difference"
+
+  detect_CPU_temperature_sensors "$NO_ENTITY_AT_ALL"
+  local -r WITHOUT_ENTITIES=${#DETECTED_CPU_ENTITY_IDS[@]}
+  detect_CPU_temperature_sensors "$EVERY_ENTITY_DISABLED"
+  local -r WITH_DISABLED_ENTITIES=${#DETECTED_CPU_ENTITY_IDS[@]}
+
+  assert_equals "$WITHOUT_ENTITIES" "$WITH_DISABLED_ENTITIES" \
+    "both are a server with no readable CPU, however differently the iDRAC words it"
+}
+
+function test_the_controller_supervises_a_server_whose_cpu_entities_are_all_disabled() {
+  # The end to end path #216 built and #256 asked to confirm, on the shape real hardware has rather
+  # than on the one it was first tested with. Before the fallback this container could do nothing but
+  # hand the fans back to Dell forever
+  provide_local_ipmi_device
+
+  export IDRAC_HOST="local"
+  export CPU_TEMPERATURE_SOURCE="auto"
+  simulate_iDRAC_reporting_every_CPU_as_disabled
+  simulate_readable_CPUs_in_lm_sensors 45.000 47.000
+
+  local -r OUTPUT=$(run_controller)
+
+  assert_contains "$OUTPUT" "reading the CPUs from lm-sensors instead" \
+    "the fallback must engage on this shape too"
+  assert_contains "$OUTPUT" "45°C" "the first CPU should be supervised"
+  assert_contains "$OUTPUT" "47°C" "the second CPU should be supervised"
+  assert_contains "$OUTPUT" "User static fan control profile" \
+    "the fans must finally be driven, which is what this container exists for"
+}
+
+function test_such_a_server_still_reports_the_one_temperature_its_idrac_can_read() {
+  # The R510 of #378 publishes exactly one readable temperature, its intake. Losing it while rescuing
+  # the CPU columns would trade one blind spot for another
+  provide_local_ipmi_device
+
+  export IDRAC_HOST="local"
+  export CPU_TEMPERATURE_SOURCE="auto"
+  simulate_iDRAC_reporting_every_CPU_as_disabled
+  simulate_readable_CPUs_in_lm_sensors 45.000 47.000
+
+  local -r OUTPUT=$(run_controller)
+
+  assert_contains "$OUTPUT" "29°C" "the intake reading must survive the switch of CPU source"
 }

--- a/tests/lib/fixtures.sh
+++ b/tests/lib/fixtures.sh
@@ -218,6 +218,14 @@ function make_sdr_line() {
 #   --exhaust N / --no-exhaust exhaust sensor reading, or no exhaust sensor at all
 #   --cpu2-disabled            CPU 2 is listed but has no reading ("ns | Disabled"),
 #                              like a second socket left empty
+#   --every-cpu-disabled       EVERY processor entity is listed and none carries a
+#                              reading. This is not an empty socket : it is what an
+#                              iDRAC6 reports on an 11G server whose CPUs it cannot
+#                              measure at all (issue #378, an R510 on firmware 2.92),
+#                              and it is the shape the lm-sensors fallback of #216
+#                              exists to rescue. Distinct from "--cpus 0", which emits
+#                              no processor row at all -- a shape no reported hardware
+#                              produces, and the one the fallback used to be tested on
 #   --with-extra-sensors       add the non-CPU, non-inlet, non-exhaust temperature
 #                              sensors bigger servers report (board, PCIe risers)
 #   --eleventh-generation-sensor-names
@@ -235,6 +243,7 @@ function make_sdr_output() {
   local WITH_INLET=true
   local WITH_EXHAUST=true
   local CPU2_DISABLED=false
+  local EVERY_CPU_DISABLED=false
   local WITH_EXTRA_SENSORS=false
   local ELEVENTH_GENERATION_SENSOR_NAMES=false
 
@@ -248,6 +257,7 @@ function make_sdr_output() {
       --no-inlet) WITH_INLET=false; shift ;;
       --no-exhaust) WITH_EXHAUST=false; shift ;;
       --cpu2-disabled) CPU2_DISABLED=true; shift ;;
+      --every-cpu-disabled) EVERY_CPU_DISABLED=true; shift ;;
       --with-extra-sensors) WITH_EXTRA_SENSORS=true; shift ;;
       --eleventh-generation-sensor-names) ELEVENTH_GENERATION_SENSOR_NAMES=true; shift ;;
       *) printf 'make_sdr_output: unknown option "%s"\n' "$1" >&2; return 1 ;;
@@ -278,6 +288,11 @@ function make_sdr_output() {
   for ((CPU_INDEX = 1; CPU_INDEX <= CPU_COUNT; CPU_INDEX++)); do
     local SENSOR_ID
     SENSOR_ID=$(printf '%02Xh' "$((CPU_SENSOR_ID_BASE + CPU_INDEX - 1))")
+
+    if $EVERY_CPU_DISABLED; then
+      make_sdr_line "Temp" "$SENSOR_ID" "ns" "3.$CPU_INDEX" "Disabled"
+      continue
+    fi
 
     if $CPU2_DISABLED && [ "$CPU_INDEX" -eq 2 ]; then
       make_sdr_line "Temp" "$SENSOR_ID" "ns" "3.$CPU_INDEX" "Disabled"


### PR DESCRIPTION
Follows the hardware evidence posted on #256.

**Tests only — no production code changes.** The behaviour was already correct; nothing said so.

## The gap

#256 asked which of two shapes an iDRAC that reports no CPU temperature really has:

1. no processor entity at all;
2. one in a shape the parser rejects.

The R510 of #378 answered, and it is neither exactly. The entities **are** listed, and carry `Disabled` where a reading would be:

```
Temp | 01h | ns | 3.1 | Disabled
Temp | 02h | ns | 3.2 | Disabled
```

Every existing test of the fallback used `--cpus 0`, which emits **no processor row at all**. No reported hardware produces that. So the shape that actually reaches this code path was pinned by nothing: a change that started counting a `Disabled` entity as a CPU would have left the whole suite green while breaking the servers the fallback exists for.

## What this adds

`--every-cpu-disabled` on `make_sdr_output()`, and four cases:

- the entities are not counted as CPUs;
- the two shapes reach the same verdict — which is what stops a looser reading check from telling them apart;
- the fallback engages end to end on this shape;
- the one temperature such an iDRAC *can* read — its intake — survives the switch of CPU source.

## What each case is actually worth

Measured by mutation, not asserted:

| mutation | detection cases | end-to-end case | intake case | pre-existing `--cpus 0` case |
| --- | --- | --- | --- | --- |
| loosen the reading check in `detect_CPU_temperature_sensors()` | **fail** | pass | pass | pass |
| drop `grep degrees` from `retrieve_sdr_temperature_data()` | pass | pass | pass | pass |
| **both** | fail | **fail** | pass | pass |

Two things worth reading off that table.

**The gap is real.** The pre-existing case survives every mutation — it cannot catch a regression on this shape, because with `--cpus 0` there is no entity row to misclassify in the first place.

**The guards are redundant, which I did not know before measuring.** `retrieve_sdr_temperature_data()` strips `Disabled` rows with `grep degrees` before the detection ever sees them, and the detection checks again. Either alone is sufficient, which is why the end-to-end case only fails once both are gone. That is defence in depth and worth keeping — but it means the end-to-end case pins the *outcome*, not either guard.

The intake case fails on neither mutation. It guards something else: losing the one readable temperature while rescuing the CPU columns.

## Testing

- Full suite: **490 test cases passed (2432 assertions)**, rebased onto `55b56d5`
- `shellcheck -x` over the CI-scoped scripts: clean

## Does this close #256?

It closes the *question* — the shape is identified and now pinned. It does not close the *prerequisite*: nobody has yet run the fixed build on such a server. #378's reporter has been asked and `v1.91` carries the fixes. Whether to close #256 now or wait for that is yours to call; I have left it open.