### PR TITLE
Correct what the tree says about itself, and widen the guards that read past it (#403)

### DIFF
--- a/.github/release_note_already_exists.sh
+++ b/.github/release_note_already_exists.sh
@@ -16,8 +16,8 @@
 # it has just generated to that ("body = `${body}\n\n${releaseNotes.data.body}`",
 # in prepareReleaseMutation). First run, nothing is there, and one copy comes
 # out. Second run, the copy the first one wrote is what gets appended to. v1.71
-# was re-fired once and carries its changelog twice ; v1.75 did too and was
-# repaired by hand. The "append_body" input is not what does this, and setting it
+# and v1.75 were each re-fired once, came out carrying their changelog twice,
+# and were repaired by hand. The "append_body" input is not what does this, and setting it
 # to false changes nothing : it only ever applies to a body the step supplies
 # itself.
 #

--- a/.github/workflows/build_and_publish_docker_image.yml
+++ b/.github/workflows/build_and_publish_docker_image.yml
@@ -382,7 +382,8 @@ jobs:
       # action appends to it. Asked only to generate notes it is handed no body
       # of its own, so it re-sends the body already there and appends the notes
       # it generates to that, and every re-fire added one more copy of the
-      # changelog - v1.71 still carries two - which would eventually have
+      # changelog - v1.71 carried two until it was repaired by hand - which
+      # would eventually have
       # happened to the upgrade notes v1.72 and v1.75 carry above theirs
       # (issue #337).
       #

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ dependency graph.
 
 ```bash
 ./tests/run_tests.sh                 # the whole suite : no hardware, no iDRAC, no network
-./tests/run_tests.sh -f temperature  # only the cases whose name matches
+./tests/run_tests.sh -f temperature  # only the cases whose name, or whose case file, matches
 ./tests/run_tests.sh --list          # list them without running
 
 shellcheck -x Dell_iDRAC_fan_controller.sh functions.sh constants.sh \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,5 +74,5 @@ Do not add your own copyright line: the collective notice above already covers e
 
 - Run the test suite: `./tests/run_tests.sh`. It needs no Dell hardware, no iDRAC and no network.
 - Add a test case for what you changed. The suite covers every PowerEdge generation from the 9th to the 17th, and a behaviour with no test is a behaviour the next refactor is free to break.
-- Keep [`shellcheck`](https://www.shellcheck.net/) quiet — CI runs it on every push.
+- Keep [`shellcheck`](https://www.shellcheck.net/) quiet — CI runs it on every pull request.
 - Say which server model and iDRAC generation you tested on, if you tested on real hardware. That context is worth more than it looks in a project that talks to twenty years of firmware.

--- a/README.md
+++ b/README.md
@@ -224,11 +224,11 @@ services:
 <!-- PARAMETERS -->
 ## Parameters
 
-All parameters are optional as they have default values (including default iDRAC username and password).
+Every parameter has a default value except `IDRAC_USERNAME` and `IDRAC_PASSWORD`, which are credentials : the image ships none, and both have to be set whenever `IDRAC_HOST` is not `local`.
 
 - `IDRAC_HOST` parameter can be set to "local" or to your distant iDRAC's IP address. **Default** value is "local".
-- `IDRAC_USERNAME` parameter is only necessary if you're adressing a distant iDRAC. **Default** value is "root".
-- `IDRAC_PASSWORD` parameter is only necessary if you're adressing a distant iDRAC. **Default** value is "calvin".
+- `IDRAC_USERNAME` parameter is only necessary if you're adressing a distant iDRAC. It has **no default value** : the image ships none.
+- `IDRAC_PASSWORD` parameter is only necessary if you're adressing a distant iDRAC. It has **no default value** : the image ships none.
 - `FAN_SPEED` parameter is the duty cycle the fans are held at while your fan control profile is applied. It can be set as a decimal percentage (from 0 to 100%) or as the same value in hexadecimal (from 0x00 to 0x64). **Default** value is 5(%).
   - Anything outside that range stops the container at startup rather than being clamped or passed through to the fans, `200` having once reached `ipmitool` as `0xc8`.
   - :warning: **The `0x` prefix is the only thing that tells the two notations apart**, and both are accepted, so a value that lost its prefix is not refused — it just applies a different duty cycle than the one you meant. `0x64` is 100% while `64` is 64%; `0x30` is 48% while `30` is 30%. The startup log always states the one that was resolved:
@@ -283,7 +283,7 @@ All parameters are optional as they have default values (including default iDRAC
   - The minimum is **1**, `0` being refused: nothing can be concluded from fewer than one observed failure. Use an empty value, not `0`, to disable the escalation.
   - `1` is accepted but **warned about** at startup, since it means exiting on the very first unreachable reading — on any transient glitch. It is legitimate on a rock-solid LAN, which is why it is a warning rather than a refusal; the same warning fires when `MAXIMUM_IPMI_UNREACHABLE_DURATION` resolves to a single check.
 - `DISABLE_THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE` parameter is a boolean that allows to disable third-party PCIe card Dell default cooling response. **Default** value is false.
-  - **From the 14th generation this parameter has no effect, and the container now says so rather than reporting the server unable.** Dell moved the setting at that generation, from one IPMI command covering the whole server to one attribute per PCIe slot reachable only over Redfish, so the command this container sends is answered *"invalid command"*. When that happens and the iDRAC is reachable over the network, the container asks it whether the setting is nonetheless there, and the temperatures table says `Not over IPMI (this server has it over Redfish)` instead of `Not supported by this server` — which was true of the command and false of the machine. Setting it yourself takes a moment : *Configuration > System Settings > Hardware Settings*, under **Cooling Configuration** (named **Fans Configuration** on older iDRAC 9 firmware), then in the *PCIe Airflow Settings* table set **LFM Mode** to `Disabled` on the slot holding the card. The question of whether the container should drive that itself is [#360](https://github.com/tigerblue77/Dell_iDRAC_fan_controller_Docker/issues/360).
+  - **From the 14th generation the IPMI command this parameter used is gone.** Dell moved the setting at that generation, from one command covering the whole server to one attribute per PCIe slot reachable only over Redfish, so the command this container sends is answered *"invalid command"*. Setting it yourself by hand takes a moment, should you ever want to : *Configuration > System Settings > Hardware Settings*, under **Cooling Configuration** (named **Fans Configuration** on older iDRAC 9 firmware), then in the *PCIe Airflow Settings* table set **LFM Mode** to `Disabled` on the slot holding the card.
   - **On those servers the container now applies it over Redfish**, so the parameter works again. Only the slots actually holding a third-party card are written to — a slot with a Dell card or no card at all is left alone, its airflow being something Dell has real data for — and every slot goes in a single request, because a Redfish write creates a configuration job on the iDRAC. It is written once rather than on every cycle for the same reason, and a slot already in the wanted state is not written at all.
   - `KEEP_THIRD_PARTY_PCIE_CARD_COOLING_RESPONSE_STATE_ON_EXIT` keeps its meaning on this transport : `false` puts **Dell's default** back on the way out, not whatever value was there before the container started, which is exactly what it has always done over IPMI.
   - Reaching the setting at all is retried up to three times, one `CHECK_INTERVAL` apart, when what stopped it describes a moment the iDRAC was having — busy, its configuration job queue full, or a request that never completed. An answer about the request, the resource or the credentials is concluded on the first one instead, none of those changing while the container runs. Either way the log says which, and how long it went on. This is not tunable, and does not need to be.
@@ -483,6 +483,7 @@ export IDRAC_USERNAME=<iDRAC username>
 export IDRAC_PASSWORD=<iDRAC password>
 export FAN_SPEED=<fan speed in %, from 0 to 100, or hexadecimal from 0x00 to 0x64>
 export CPU_TEMPERATURE_THRESHOLD=<decimal temperature threshold in °C, from 20 to 125, or auto>
+export CPU_TEMPERATURE_SOURCE=<auto, ipmi or lm-sensors>
 export CHECK_INTERVAL=<seconds between each check, or a suffixed duration like 5m, up to 15 minutes>
 export MAXIMUM_IPMI_UNREACHABLE_DURATION=<how long the iDRAC may stay unreachable before exiting, in seconds or suffixed like 5m, or empty>
 export MAXIMUM_CONSECUTIVE_IPMI_FAILURES=<the same threshold in cycles instead, 1 or more, or empty>
@@ -501,7 +502,7 @@ The repository ships an automated test suite that runs the controller against a 
 ```bash
 ./tests/run_tests.sh                 # run everything
 ./tests/run_tests.sh --list          # list the test cases without running them
-./tests/run_tests.sh -f temperature  # only run the test cases whose name matches
+./tests/run_tests.sh -f temperature  # only run the cases whose name, or whose case file, matches
 ./tests/run_tests.sh --tap           # emit TAP output for a CI parser
 ```
 
@@ -509,7 +510,7 @@ It covers every PowerEdge generation from the 9th (2006) to the 17th (2024) — 
 
 Blades and modular servers are covered too : the M1000e and VRTX blades, the FX2 and MX7000 sleds and the nodes of a C-series chassis. They carry no fan of their own — the enclosure does, driven by its CMC — so this container cannot cool them, and the suite pins what it does instead : identify the server, report that the fan control commands were rejected, and keep monitoring.
 
-The suite also runs on every push and pull request through the [`Tests`](.github/workflows/tests.yml) workflow, both directly and inside the built Docker image. Each run publishes a report on the pull request : the test count compared against the base commit, and, behind the check run, every test case that ran with what a failing one expected and what it obtained. See [`tests/README.md`](./tests/README.md) for the layout and for how to add a test case.
+The suite also runs on every pull request, and on every push to `master`, through the [`Tests`](.github/workflows/tests.yml) workflow, both directly and inside the built Docker image. Each run publishes a report on the pull request : the test count compared against the base commit, and, behind the check run, every test case that ran with what a failing one expected and what it obtained. See [`tests/README.md`](./tests/README.md) for the layout and for how to add a test case.
 
 <p align="right">(<a href="#top">back to top</a>)</p>
 

--- a/constants.sh
+++ b/constants.sh
@@ -39,8 +39,9 @@ readonly MAXIMUM_FAN_SPEED_PERCENTAGE=100
 # How far the per-fan identifier probe goes before it stops, on a server that refuses the broadcast fan
 # selector 0xff and has to be addressed one fan at a time (issue #378).
 #
-# The probe walks upwards from 0x00 and stops at the first identifier the server refuses, so this is only
-# the backstop for a BMC that would accept every one of them and leave the walk running forever. It is
+# The probe tries every identifier from 0x00 up to this bound, keeping the ones the server accepts and
+# carrying on past the ones it refuses, so this is the end of the address space a discovery searches --
+# and the number of commands it costs -- rather than a guard against a walk that would never stop. It is
 # deliberately far above any real fan count -- the R510 this was reported from accepts 0x00 to 0x07 and
 # refuses 0x08 onwards, and no PowerEdge exposes anything close to 32 fans -- because being too low would
 # silently stop the walk on a server that has more, leaving the fans past the cut running at whatever

--- a/tests/README.md
+++ b/tests/README.md
@@ -8,7 +8,7 @@ enough.
 ```bash
 ./tests/run_tests.sh                 # run everything
 ./tests/run_tests.sh --list          # list the test cases without running them
-./tests/run_tests.sh -f temperature  # only run the test cases whose name matches
+./tests/run_tests.sh -f temperature  # only run the cases whose name, or whose case file, matches
 ./tests/run_tests.sh --tap           # emit TAP version 13 output for a CI parser
 ./tests/run_tests.sh --junit FILE    # write a JUnit XML report
 ./tests/run_tests.sh --summary FILE  # append a Markdown report
@@ -21,12 +21,12 @@ It exits `0` when every test case passed, `1` otherwise.
 
 | File | What it checks |
 | --- | --- |
-| `cases/10_shell_scripts.sh` | Syntax of every script and the licence header each one carries, files shipped in the Docker image, drift between the code and what documents it — the lint list, `CLAUDE.md`'s layout table, paths, figures, dependency graph and worked example, and the packages its Environment section promises — healthcheck |
+| `cases/10_shell_scripts.sh` | Syntax of every script, the licence header each one and the `Dockerfile` carry, files shipped in the Docker image, drift between the code and what documents it — the lint list, `CLAUDE.md`'s layout table, paths, figures, dependency graph and worked example, and the packages its Environment section promises — healthcheck |
 | `cases/11_claude_code_settings.sh` | The settings a Claude Code session starts from, which no server ever reads : that the file still parses, that the rules letting any session run a command without asking are the ones argued for — in the shape they were argued in, still runnable, only those, and all of them still there — and that the `SessionStart` hook is still wired to a script that exists, under a budget outlasting what that script allows itself. Skipped where `jq` is missing, the list being read out of JSON |
 | `cases/12_github_workflows.sh` | The two publishing workflows no pull request ever runs : the release build and the base image refresh. Also that every workflow carries the licence header, which is the whole directory rather than those two |
 | `cases/13_dockerhub_description.sh` | The page Docker Hub shows on the image's repository, built by a workflow no pull request fires either : that it stays a pointer at the documentation rather than a copy of it, and that no change to `README.md` can alter it |
 | `cases/14_latest_tag_reconciliation.sh` | Which version `latest` ends up on after a release, against a stubbed registry. Skipped where `jq` is missing, the one thing the script needs that the suite does not |
-| `cases/15_test_runner.sh` | The runner itself : the ways it used to stay green while nothing had been verified |
+| `cases/15_test_runner.sh` | The runner itself : the ways it used to stay green while nothing had been verified, and what `--filter` is allowed to match |
 | `cases/16_release_note_publication.sh` | Whether a version tag still needs its GitHub release note written, against a stubbed GitHub : the decision that keeps a re-fired release from appending a second copy of its changelog to the one it already carries |
 | `cases/17_reports.sh` | The JUnit XML and Markdown reports, whose consumer is a parser rather than a reader |
 | `cases/18_sign_off.sh` | The gate that keeps an unsigned commit off `master`, on the pull request it arrives on : that a branch is refused for one missing trailer and every offender named in a single run, that the merge a contributor made to resolve their conflict is not asked to certify anything, and that a range it cannot read fails closed rather than green. Against a repository built for each case rather than a stubbed `git`, so skipped where `git` is missing |

--- a/tests/cases/10_shell_scripts.sh
+++ b/tests/cases/10_shell_scripts.sh
@@ -297,12 +297,11 @@ function test_the_usage_examples_offer_every_parameter_the_image_declares() {
     return 0
   fi
 
-  # The configuration examples are the fenced blocks of the "Usage" section that
-  # set IDRAC_HOST : the two "docker run" ones and the two docker-compose ones.
-  # Found by what they contain rather than by their position, so that reordering
-  # them, or adding a fifth, needs no change here
-  local -r USAGE_SECTION=$(awk '/^## Usage$/ {inside = 1; next} /^## / {inside = 0} inside' "$REPO_ROOT/README.md")
-
+  # Every fenced block of the README that sets IDRAC_HOST : the two "docker run"
+  # ones, the two docker-compose ones, and the "export" block further down for
+  # running it from a plain checkout. Found by what they contain rather than by
+  # their position -- and read from the whole file rather than from the "Usage"
+  # section, because the export block sits outside it and was the one that drifted
   local -a USAGE_EXAMPLES=()
   local BLOCK="" IS_INSIDE_BLOCK=false LINE
   while IFS= read -r LINE; do
@@ -315,11 +314,11 @@ function test_the_usage_examples_offer_every_parameter_the_image_declares() {
       continue
     fi
     $IS_INSIDE_BLOCK && BLOCK+="$LINE"$'\n'
-  done < <(printf '%s\n' "$USAGE_SECTION")
+  done < "$REPO_ROOT/README.md"
 
   # Without this the loop below would pass by having nothing to iterate over,
   # which is the failure mode these guards exist to prevent in the first place
-  if (( ${#USAGE_EXAMPLES[@]} < 4 )); then
+  if (( ${#USAGE_EXAMPLES[@]} < 5 )); then
     fail "only ${#USAGE_EXAMPLES[@]} usage examples were found in the README, expected at least 4"
     return 1
   fi
@@ -1211,6 +1210,12 @@ function test_the_packages_claude_md_says_the_hook_installs_are_the_ones_it_inst
 }
 
 function test_every_shell_script_carries_the_licence_header() {
+  # The Dockerfile joins the walk : CONTRIBUTING.md calls the two SPDX lines how
+  # AGPL-3.0 section 5(a) is satisfied file by file, and the file that builds the
+  # image is not less of a file for not being a script. And .claude/ at any depth
+  # rather than .claude/hooks/ alone, naming one directory being the mistake the
+  # Shellcheck guard had to correct
+  shopt -s globstar
   # CLAUDE.md states it as a convention and CONTRIBUTING.md as a rule, "test cases,
   # mocks and helpers included", and NOTICE ties these headers to what discharges
   # AGPL 5(a) and 7(b) : this is licence compliance rather than style. The suite
@@ -1220,9 +1225,9 @@ function test_every_shell_script_carries_the_licence_header() {
   # Read from the first five lines, the same window the workflow case uses, so that
   # it sits where a human and a scanner both find it
   local SCRIPT
-  for SCRIPT in "$REPO_ROOT"/*.sh "$REPO_ROOT"/.github/*.sh "$REPO_ROOT"/.claude/hooks/*.sh \
+  for SCRIPT in "$REPO_ROOT"/*.sh "$REPO_ROOT"/.github/*.sh "$REPO_ROOT"/.claude/**/*.sh \
     "$TESTS_DIRECTORY"/*.sh "$TESTS_DIRECTORY"/lib/*.sh "$TESTS_DIRECTORY"/cases/*.sh \
-    "$TESTS_DIRECTORY"/mocks/*; do
+    "$TESTS_DIRECTORY"/mocks/* "$REPO_ROOT"/Dockerfile; do
     [ -f "$SCRIPT" ] || continue
 
     if head -5 "$SCRIPT" | grep -q '^# SPDX-License-Identifier: AGPL-3.0-only$'; then

--- a/tests/cases/11_claude_code_settings.sh
+++ b/tests/cases/11_claude_code_settings.sh
@@ -132,6 +132,17 @@ function test_every_pre_approved_rule_is_one_that_was_argued() {
           "git and docker build were deliberately left out ; a new entry has to be argued the same way, here and in the settings" ;;
     esac
   done < <(printf '%s\n' "$PERMISSION_RULES")
+
+  # The same list read the other way round. The loop above refuses a rule nobody
+  # argued for ; it has nothing to say about one that quietly left, and CLAUDE.md
+  # counts three of them and names all three. A grant that disappears costs no
+  # security and breaks no test -- it just puts the prompts back while the
+  # documentation says they are gone, which is the drift this file exists for
+  local VETTED_RULE
+  for VETTED_RULE in 'Bash(./tests/run_tests.sh)' 'Bash(shellcheck:*)' 'Bash(bash -n:*)'; do
+    assert_contains "$PERMISSION_RULES" "$VETTED_RULE" \
+      "[$VETTED_RULE] is one of the three rules #382 argued for and CLAUDE.md still names, and the settings no longer carry it"
+  done
 }
 
 function test_every_pre_approved_command_is_one_the_repository_still_runs() {

--- a/tests/cases/15_test_runner.sh
+++ b/tests/cases/15_test_runner.sh
@@ -19,6 +19,7 @@ readonly PROBE_PREFIX="test"
 # controller, and never joins the suite that is currently running
 function run_the_runner_on_a_probe_case_file() {
   local -r PROBE_CONTENT="$1"
+  shift
 
   local -r PROBE_REPOSITORY="$TEST_TEMPORARY_DIRECTORY/runner_probe"
   rm -rf "$PROBE_REPOSITORY"
@@ -33,8 +34,40 @@ function run_the_runner_on_a_probe_case_file() {
   cp -r "$TESTS_DIRECTORY/lib" "$TESTS_DIRECTORY/mocks" "$PROBE_REPOSITORY/tests/"
   printf '%s\n' "$PROBE_CONTENT" > "$PROBE_REPOSITORY/tests/cases/50_probe.sh"
 
-  PROBE_OUTPUT=$(bash "$PROBE_REPOSITORY/tests/run_tests.sh" --no-color 2>&1)
+  # Anything after the probe content is handed to the runner, which is how a case
+  # exercises an option rather than only the discovery
+  PROBE_OUTPUT=$(bash "$PROBE_REPOSITORY/tests/run_tests.sh" --no-color "$@" 2>&1)
   PROBE_EXIT_CODE=$?
+}
+
+function test_a_filter_matches_a_case_file_by_name_and_never_by_the_path_it_sits_at() {
+  # The runner matches a filter against the case name or the case FILE. Which of the
+  # two the file contributes decides whether the directory somebody cloned into is
+  # part of the question : while it was the absolute path, "-f fan" selected every
+  # case in this repository, the clone being named Dell_iDRAC_fan_controller_Docker,
+  # and the documented "-f temperature" selected four files' worth of cases beyond
+  # the ones whose name carries the word. Nothing said the filter had been widened --
+  # the count was the only clue.
+  #
+  # The probe repository sits under a directory called "runner_probe", a string that
+  # appears in neither the case file's name nor the case's own name, so filtering on
+  # it selects nothing unless the path is being matched
+  run_the_runner_on_a_probe_case_file \
+    "function ${PROBE_PREFIX}_is_selected_by_its_own_name() { pass ; }" \
+    --filter runner_probe
+
+  assert_equals 1 "$PROBE_EXIT_CODE" "a filter matching only the path a repository was cloned into should select nothing"
+  assert_contains "$PROBE_OUTPUT" "No test case matched" \
+    "and the runner should say so, rather than silently run every case"
+
+  # The other half of the same decision : a filter naming the case file is the way to
+  # run one file, and that has to keep working
+  run_the_runner_on_a_probe_case_file \
+    "function ${PROBE_PREFIX}_is_selected_by_its_own_name() { pass ; }" \
+    --filter 50_probe
+
+  assert_equals 0 "$PROBE_EXIT_CODE" "a filter naming the case file should still select what is in it"
+  assert_contains "$PROBE_OUTPUT" "1 test cases passed" "and select exactly that"
 }
 
 function test_a_test_case_that_asserts_nothing_is_reported_as_a_failure() {

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -11,7 +11,7 @@
 #
 #   ./tests/run_tests.sh                 # run everything
 #   ./tests/run_tests.sh --list          # list the test cases without running them
-#   ./tests/run_tests.sh -f temperature  # run the test cases whose name matches
+#   ./tests/run_tests.sh -f temperature  # run the cases whose name, or whose case file, matches
 #   ./tests/run_tests.sh --tap           # emit TAP output for a CI parser
 #   ./tests/run_tests.sh --junit FILE    # write a JUnit XML report
 #   ./tests/run_tests.sh --summary FILE  # write a Markdown report
@@ -34,7 +34,7 @@ function print_usage() {
   cat << 'EOF'
 Usage: tests/run_tests.sh [option ...]
 
-  -f, --filter PATTERN  only run the test cases whose name matches PATTERN
+  -f, --filter PATTERN  only run the test cases whose name, or whose case file, matches PATTERN
   -l, --list            list the test cases without running them
       --tap             emit TAP version 13 output
       --junit FILE      write a JUnit XML report, for a CI that publishes one
@@ -162,7 +162,12 @@ for TEST_FILE in "${TEST_FILES[@]}"; do
   while IFS= read -r TEST_CASE_NAME; do
     [ -n "$TEST_CASE_NAME" ] || continue
     DISCOVERED_TEST_CASES+=("$TEST_CASE_NAME")
-    if [ -n "$FILTER" ] && [[ ! "$TEST_CASE_NAME" =~ $FILTER ]] && [[ ! "$TEST_FILE" =~ $FILTER ]]; then
+    # Matched against the case file's NAME, never its path : TEST_FILE is absolute, so
+    # matching it let the directory the repository was cloned into decide what a filter
+    # selects. Under the name "git clone" gives this project, "-f fan" matched every case
+    # file's path and ran all of them, and the documented "-f temperature" selected four
+    # files' worth of cases beyond the ones whose name carries the word
+    if [ -n "$FILTER" ] && [[ ! "$TEST_CASE_NAME" =~ $FILTER ]] && [[ ! "${TEST_FILE##*/}" =~ $FILTER ]]; then
       continue
     fi
     SELECTED_TEST_CASES+=("$TEST_FILE"$'\t'"$TEST_CASE_NAME")


### PR DESCRIPTION
Closes #403.

What the sweep confirmed, **minus everything master repaired while it ran** — #394, #399 and #404 each took one of its findings, and master had already grown the licence-header walk and widened `bash -n` to `.claude/`. **11 files, +87 −30, no controller code touched.**

## 1. `-f fan` ran the whole suite

`tests/run_tests.sh` matched the pattern against the case name **or the case file's absolute path** — and the path carries the directory the repository was cloned into, which `git clone` names `Dell_iDRAC_fan_controller_Docker`.

| Command, before | Selected |
| --- | --- |
| `-f fan` / `-f Dell` / `-f iDRAC` / `-f Docker` / `-f controller` | **every case** |
| `-f temperature` (the documented example) | 128, where **29** case names carry the word |

Nothing in the output said the filter had been widened; the count was the only clue, and a contributor narrowing a run to bisect got the interference back without being told.

It matches the case file's **name** now — `-f 70_fan_control` still runs one file — and the five places describing the option say so. `cases/15` pins it from both sides.

## 2. Six statements that were not true

| Where | Was | Is |
| --- | --- | --- |
| `README.md` | `IDRAC_USERNAME` defaults to `root`, `IDRAC_PASSWORD` to `calvin`, *"all parameters are optional"* | the `Dockerfile` ships **neither** — following the README, the container refuses to start |
| `README.md` | the third-party PCIe bullet opens on *"this parameter has no effect"* and names a status `functions.sh` never produces | #375 made it work over Redfish |
| `README.md` | the plain-checkout export block | omitted `CPU_TEMPERATURE_SOURCE` |
| `CONTRIBUTING.md`, `README.md` | CI runs *"on every push"* | both workflows restrict `push` to `master` |
| `constants.sh` | `MAXIMUM_FAN_IDENTIFIER_PROBES` guards a walk that would never stop | it bounds the search |
| the release workflow + its script | v1.71 *carries* two changelogs | repaired by hand, carries one |

The seventh — the fan walk described as stopping at the first refusal — **master fixed while this was rebasing**, and its wording is kept.

## 3. Three guards that read past what they name

- **The licence-header walk** covered every script and **not the `Dockerfile`**, though `CONTRIBUTING.md` calls those two SPDX lines how AGPL-3.0 §5(a) is satisfied file by file — and the file that builds the image is not less of a file for not being a script. It also named `.claude/hooks/` where its sibling walks `.claude/` at any depth, which is the mistake that sibling had to correct.
- **The allow list** was read one way only : `cases/11` refused a rule nobody argued for, and had nothing to say about one that quietly left while `CLAUDE.md` still counts three.
- **The usage-example guard** read the `## Usage` section alone, so the export block below it — the one that had drifted — was outside its reach. It reads the whole README now ; floor raised from four blocks to five.

## How to test

```bash
./tests/run_tests.sh                    # 510 cases, 2551 assertions
./tests/run_tests.sh -f temperature     # 29 now, 128 before
./tests/run_tests.sh -f fan             # far fewer than the whole suite
./tests/run_tests.sh -f 70_fan_control  # selecting a whole file still works
```

Each guard was run against a deliberately broken tree, and each fails naming what is wrong :

| Break | Goes red |
| --- | --- |
| restore the old path-matching filter | `a filter matches a case file by name and never by the path it sits at` |
| delete the `Dockerfile`'s SPDX lines | `every shell script carries the licence header` |
| delete `Bash(shellcheck:*)` from `.claude/settings.json` | `every pre approved rule is one that was argued` |
| drop `export CPU_TEMPERATURE_SOURCE` from the README block | `the usage examples offer every parameter the image declares` |

## Deliberately not here

- `CLAUDE.md` saying `--summary` truncates — **repaired by #394** ;
- the worked example guarded in one document only, the hook path unchecked — **fixed by #399** ;
- `bash -n` not covering `.claude/`, and the licence header missing from the scripts — **master grew both** while the sweep ran ;
- #387's option guard reading the `--help` text rather than the parser, and the bash in workflow `run:` blocks that nothing lints — **recorded in #403**, both larger than a documentation pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AQ1MmPC3pGPywBgr9DVr9g