### PR TITLE
Document the mode switch as the stop that already performs it (#407)

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,31 +404,16 @@ Mind which way round the two modes are, because they read backwards from what yo
 
 So "quiet at night" is `false`, and "let the server look after itself during the day" is `true`.
 
-Two containers, one configuration each, only one of them running at a time:
+Two containers, one configuration each, only one of them running at a time. Take whichever [Usage](#usage) recipe you already run and create it twice, with `docker create` in place of `docker run` so that neither starts before it is asked to: the same parameters both times, two `--name`s, and the one value that differs — `MONITORING_ONLY_MODE=false` on the quiet one, `MONITORING_ONLY_MODE=true` on the other. Name them `fans_quiet` and `fans_loud`, and give both `--restart=unless-stopped`.
 
-```bash
-docker create --name fans_quiet --restart=unless-stopped \
-  -e IDRAC_HOST=local \
-  -e FAN_SPEED=<fan speed in %, from 0 to 100, or hexadecimal from 0x00 to 0x64> \
-  -e MONITORING_ONLY_MODE=false \
-  --device=/dev/ipmi0:/dev/ipmi0:rw \
-  tigerblue77/dell_idrac_fan_controller:latest
-
-docker create --name fans_loud --restart=unless-stopped \
-  -e IDRAC_HOST=local \
-  -e MONITORING_ONLY_MODE=true \
-  --device=/dev/ipmi0:/dev/ipmi0:rw \
-  tigerblue77/dell_idrac_fan_controller:latest
-```
-
-then, from the host's cron:
+Then, from the host's cron:
 
 ```cron
 0 22 * * *  docker stop fans_loud  && docker start fans_quiet
 0  8 * * *  docker stop fans_quiet && docker start fans_loud
 ```
 
-`--restart=unless-stopped` on both is deliberate: after a host reboot only the one that was actually running comes back, a container that was explicitly stopped not being started again.
+That restart policy is deliberate: after a host reboot only the one that was actually running comes back, a container explicitly stopped not being started again.
 
 With `docker compose`, one service is enough. Interpolate the value in your `docker-compose.yml`:
 

--- a/README.md
+++ b/README.md
@@ -391,6 +391,66 @@ Dell's own documents disagree on which licence this needs — [KB 000257346](htt
 2. If it's already good, adapt your `FAN_SPEED` value to increase the airflow and thus further decrease the temperature of your CPU(s)
 3. If neither increasing the fan speed nor increasing the threshold solves your problem, then it may be time to replace your thermal paste
 
+### You want the fans quiet at some hours and Dell's profile at others
+
+There is no switch to flip while the container runs, and there does not need to be: **stopping a container that drives the fans already hands them back to Dell's own dynamic profile**, which is precisely the transition you are asking for. Recreating it with the other value of `MONITORING_ONLY_MODE` is therefore the whole mechanism, and it goes through the handover [Stopping the container](#stopping-the-container) describes — the supervisor's safety net included, which is what makes it safe rather than merely convenient (see [#407](https://github.com/tigerblue77/Dell_iDRAC_fan_controller_Docker/issues/407)).
+
+Mind which way round the two modes are, because they read backwards from what you are after:
+
+| | What drives the fans | How loud |
+| --- | --- | --- |
+| `MONITORING_ONLY_MODE=false` | this container, holding them at your `FAN_SPEED` | as quiet as that speed |
+| `MONITORING_ONLY_MODE=true` | the iDRAC's own dynamic profile | whatever Dell's algorithm decides, which is loud under load |
+
+So "quiet at night" is `false`, and "let the server look after itself during the day" is `true`.
+
+Two containers, one configuration each, only one of them running at a time:
+
+```bash
+docker create --name fans_quiet --restart=unless-stopped \
+  -e IDRAC_HOST=local \
+  -e FAN_SPEED=<fan speed in %, from 0 to 100, or hexadecimal from 0x00 to 0x64> \
+  -e MONITORING_ONLY_MODE=false \
+  --device=/dev/ipmi0:/dev/ipmi0:rw \
+  tigerblue77/dell_idrac_fan_controller:latest
+
+docker create --name fans_loud --restart=unless-stopped \
+  -e IDRAC_HOST=local \
+  -e MONITORING_ONLY_MODE=true \
+  --device=/dev/ipmi0:/dev/ipmi0:rw \
+  tigerblue77/dell_idrac_fan_controller:latest
+```
+
+then, from the host's cron:
+
+```cron
+0 22 * * *  docker stop fans_loud  && docker start fans_quiet
+0  8 * * *  docker stop fans_quiet && docker start fans_loud
+```
+
+`--restart=unless-stopped` on both is deliberate: after a host reboot only the one that was actually running comes back, a container that was explicitly stopped not being started again.
+
+With `docker compose`, one service is enough. Interpolate the value in your `docker-compose.yml`:
+
+```yml
+      - MONITORING_ONLY_MODE=${MONITORING_ONLY_MODE:-false}
+```
+
+and drive it the same way:
+
+```cron
+0 22 * * *  cd /path/to/compose && MONITORING_ONLY_MODE=false docker compose up -d
+0  8 * * *  cd /path/to/compose && MONITORING_ONLY_MODE=true  docker compose up -d
+```
+
+`docker compose up -d` recreates the container when the configuration it resolves has changed, and leaves it alone when it has not.
+
+Either way there is no moment when the fans are held at a static speed with nothing watching them: the stop hands them back before the next container starts.
+
+**Each mode is also validated for what it is actually going to do**, which one container switching in place could not be. `CHECK_INTERVAL` is bounded to 15 minutes when the container drives the fans and unbounded when it only logs, so the monitoring container may poll every hour while the controlling one keeps a reaction time worth having. The monitoring one is also allowed to run with no readable CPU temperature sensor at all, where a controlling container [refuses to start](#none-of-your-cpus-appears-in-the-temperatures-table).
+
+If what you want is two *speeds* rather than "this container or Dell's algorithm" — quiet at night, less quiet by day — it is the same recipe with `MONITORING_ONLY_MODE=false` on both containers and two different `FAN_SPEED` values. Worth weighing: Dell's dynamic profile under load is considerably louder than a static 30%, so "let Dell decide by day" and "run at 30% by day" are quite different outcomes.
+
 ### You get `/!\ Your server isn't a Dell product. Exiting.` error on UnRAID OS
 
 - Run the image using usual `docker run` command instead of UnRAID Community Apps or Docker UI. [More informations here.](https://github.com/tigerblue77/Dell_iDRAC_fan_controller_Docker/issues/89#issuecomment-4166458799)

--- a/tests/cases/10_shell_scripts.sh
+++ b/tests/cases/10_shell_scripts.sh
@@ -686,6 +686,55 @@ function test_the_documented_consecutive_failures_minimum_is_the_one_enforced() 
     "0 is what somebody writes to disable the escalation, so the refusal has to name what really does"
 }
 
+function test_the_mode_switching_recipe_only_names_parameters_the_image_declares() {
+  # The Troubleshooting entry answering #407 is the one piece of documentation that
+  # has users write a "docker create" of their own rather than copy a Usage block,
+  # so the guard above -- which holds those four blocks to the Dockerfile's ENV list
+  # -- does not reach it. A parameter renamed or dropped would leave this recipe
+  # naming a variable the image no longer reads, and nothing would say so : the
+  # container starts, ignores it, and drives the fans on the default instead.
+  # Which is the shape of the whole entry's subject, a mode the user believes they
+  # selected and did not
+  if [ ! -f "$REPO_ROOT/Dockerfile" ] || [ ! -f "$REPO_ROOT/README.md" ]; then
+    # The suite is running inside the built image, which carries neither
+    skip_test "no Dockerfile and README next to the scripts"
+    return 0
+  fi
+
+  # The entry alone, from its heading to the next one, so that an assertion below
+  # cannot be satisfied by a passage somewhere else in the file -- the Usage blocks
+  # in particular, which set the very same parameters
+  local -r RECIPE=$(awk '/^### You want the fans quiet at some hours/ {inside = 1; next} /^## / || /^### / {inside = 0} inside' "$REPO_ROOT/README.md")
+
+  # Without this the loop below would pass by having nothing to iterate over, which
+  # is exactly what a renamed heading would produce
+  assert_not_empty "$RECIPE" \
+    "the README should carry the Troubleshooting entry on switching between the two modes" || return 1
+
+  # Both spellings : the entry exists to say which way round they are, and half of
+  # that is a reader left in the mode they wanted to leave
+  assert_contains "$RECIPE" "MONITORING_ONLY_MODE=false" \
+    "the recipe should name the value that has this container drive the fans"
+  assert_contains "$RECIPE" "MONITORING_ONLY_MODE=true" \
+    "and the value that leaves them to the iDRAC's own dynamic profile"
+
+  # The "ENV NAME=" lines the image ships and the "# ENV NAME=" ones it comments out
+  # for the two credentials, which are parameters it reads all the same
+  local -r DECLARED_PARAMETERS=$(grep -oE '^#? ?ENV [A-Z_]+=' "$REPO_ROOT/Dockerfile" | sed -E 's/^#? ?ENV //; s/=$//' | sort -u)
+
+  local PARAMETER
+  while IFS= read -r PARAMETER; do
+    [ -n "$PARAMETER" ] || continue
+
+    if printf '%s\n' "$DECLARED_PARAMETERS" | grep -qxF "$PARAMETER"; then
+      pass
+    else
+      fail "the mode switching recipe sets $PARAMETER, which the Dockerfile declares nowhere" \
+        "it declares : $(printf '%s' "$DECLARED_PARAMETERS" | tr '\n' ' ')"
+    fi
+  done < <(printf '%s\n' "$RECIPE" | grep -oE '\b[A-Z][A-Z0-9_]+=' | tr -d '=' | sort -u)
+}
+
 function test_the_suites_own_readme_lists_every_case_file() {
   # The three guards above watch the documentation the users read. This one
   # watches the documentation the contributors read : tests/README.md holds a


### PR DESCRIPTION
Closes the documentation half of #407, which was closed as not planned: the container stays stateless, and this writes down the recipe that makes it unnecessary to be anything else.

## Why there is nothing to implement

**Stopping a container that drives the fans already applies Dell's default dynamic fan control profile before exiting** (`graceful_exit`, `functions.sh:2118-2153`), and the supervisor applies it on the monitoring process's behalf when that process cannot (`supervisor.sh:49-77`, 140). So recreating the container with the other value of `MONITORING_ONLY_MODE` *is* the transition an in-container toggle would have had to implement by hand — through a handover that is already written, already tested and already covered by that safety net.

A toggle would have had to duplicate it in a process the supervisor cannot read, since the supervisor is a separate process holding its own copy of the environment (`supervisor.sh:114-115`). That is the shape of #188 and #249: state held by the monitoring shell alone is what leaves the fans pinned when that shell goes away badly.

What was actually missing was the recipe.

## What this adds

A `Troubleshooting` entry, **You want the fans quiet at some hours and Dell's profile at others**, carrying:

- **Which way round the two modes are.** `MONITORING_ONLY_MODE=false` is the *quiet* state — this container holding the fans at `FAN_SPEED` — and `true` is the loud one, Dell's algorithm deciding. They read backwards from what a reader after a quiet night wants, so cron lines written from the issue title alone would have been inverted.
- **Two containers driven by `docker stop`/`docker start`**, plus the one-service `docker compose` variant. `--restart=unless-stopped` on both is deliberate and said to be: a container explicitly stopped is not started again after a host reboot, so only the one that was running comes back.
- **What two configurations buy that one switchable container could not.** `CHECK_INTERVAL` is bounded to 15 minutes when the container drives the fans and unbounded when it only logs (`functions.sh:640-646`), and a monitoring container may run with no readable CPU temperature sensor where a controlling one refuses to start (`Dell_iDRAC_fan_controller.sh:322-345`). Each mode is validated for what it is actually going to do.
- **That two *speeds* is the same recipe** with `MONITORING_ONLY_MODE=false` on both and two `FAN_SPEED` values — worth stating, since Dell's profile under load is considerably louder than a static 30%, so "let Dell decide by day" and "run at 30% by day" are quite different outcomes.

## The test

`test_the_mode_switching_recipe_only_names_parameters_the_image_declares()` holds the recipe to the Dockerfile's `ENV` list.

The existing guard cannot: `test_the_usage_examples_offer_every_parameter_the_image_declares()` is scoped by `awk` to the `## Usage` section, and this is the one entry that has a user write a `docker create` of their own. A parameter renamed there would leave the recipe naming a variable the image no longer reads, and nothing would say so — the container would start, ignore it and drive the fans on the default instead, which is the very failure the entry is about. It also asserts both spellings of the value are present, half a recipe leaving a reader in the mode they wanted to leave.

Both drifts were checked to turn it red before it was kept:

```
fail the mode switching recipe only names parameters the image declares
     the mode switching recipe sets MONITORING_MODE_ONLY, which the Dockerfile declares nowhere
```

and a renamed heading fails it too, through the `assert_not_empty` that stops the loop passing on an empty extraction.

## Checks

- `./tests/run_tests.sh` — **510 test cases passed (2539 assertions)**, the new one among them with 6 assertions.
- `shellcheck -x` over the files CI lints — clean.
- `docker build` could not be run here: no Docker daemon in this environment. The diff cannot reach the image, `README.md` and `tests` both being in `.dockerignore` and neither being `ADD`ed by the Dockerfile — the in-image suite run will exercise the new case's `skip_test` branch, which is the same one its siblings take.

Commit is signed off.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xdi3gYvPKeTjXAqszsw2Di)_