### PR TITLE
Say what the extra sensors fixture emits, and hold the sentence to it (#433)

### DIFF
--- a/tests/cases/40_temperature_parsing.sh
+++ b/tests/cases/40_temperature_parsing.sh
@@ -207,3 +207,32 @@ function test_a_power_supplys_own_intake_does_not_answer_for_the_chassis_one() {
   assert_equals "36" "$(retrieve_temperature_by_sensor_name "$SDR_DATA" "Exhaust")" \
     "the exhaust sensor is unaffected, but goes through the same matching rule"
 }
+
+# The option's own documentation is the only place saying what those four rows represent, and
+# it named the wrong hardware until issue #433 : "board, PCIe risers" for rows that are all on
+# entity 10, the power supply. Nothing held the sentence against the data, so it drifted from
+# the fixture the test above rests on, and a reader checking what a Dell reports beyond the
+# CPUs got an answer the rows do not support.
+#
+# Pinned here rather than left to the comment alone, for the reason #344 and #328 were : a
+# description nothing compares to its subject is one the next edit is free to invalidate
+function test_the_extra_sensors_are_the_power_supply_rows_the_option_describes() {
+  local SDR_DATA
+  SDR_DATA=$(make_sdr_output --no-inlet --no-exhaust --cpus 0 --with-extra-sensors)
+
+  # Read off the 4th pipe-delimited column, trimmed, the way every entity check in the
+  # production code does, so that this agrees with what detect_CPU_temperature_sensors() sees
+  local EXTRA_SENSOR_ENTITIES
+  EXTRA_SENSOR_ENTITIES=$(printf '%s\n' "$SDR_DATA" | awk -F'|' '{ gsub(/^[[:space:]]+|[[:space:]]+$/, "", $4); print $4 }' | sort -u)
+
+  assert_equals "$(printf '10.1\n10.2')" "$EXTRA_SENSOR_ENTITIES" \
+    "every extra row sits on entity 10, \"Power Supply\" in IPMI v2.0 table 43-13, and not on the system board (7) nor an add-in card (11) the option used to name"
+
+  # The pair the option exists for : both names contain "Inlet", which is what makes
+  # retrieve_temperature_by_sensor_name()'s anchoring load-bearing rather than decorative
+  local NUMBER_OF_PSU_INLET_ROWS
+  NUMBER_OF_PSU_INLET_ROWS=$(printf '%s\n' "$SDR_DATA" | grep -c '^PSU[0-9] Inlet Temp')
+
+  assert_equals "2" "$NUMBER_OF_PSU_INLET_ROWS" \
+    "the two \"PSU<n> Inlet Temp\" rows are the shape issue #231 was about"
+}

--- a/tests/lib/fixtures.sh
+++ b/tests/lib/fixtures.sh
@@ -227,7 +227,18 @@ function make_sdr_line() {
 #                              no processor row at all -- a shape no reported hardware
 #                              produces, and the one the fallback used to be tested on
 #   --with-extra-sensors       add the non-CPU, non-inlet, non-exhaust temperature
-#                              sensors bigger servers report (board, PCIe risers)
+#                              sensors bigger servers report : four power supply
+#                              rows, entity 10 being "Power Supply" in IPMI v2.0
+#                              table 43-13. Two carry the same uninformative
+#                              "Temp" name the CPU rows do, and two are named
+#                              "PSU1 Inlet Temp" and "PSU2 Inlet Temp".
+#                              That second pair is what the option is for : both
+#                              names contain "Inlet", so they are what makes the
+#                              anchored match in retrieve_temperature_by_sensor_name()
+#                              load-bearing rather than decorative -- unanchored,
+#                              a power supply's own intake answers for the chassis
+#                              air intake and the intake column shows a sensor
+#                              several degrees too hot (issue #231)
 #   --eleventh-generation-sensor-names
 #                              name the chassis sensors the way iDRAC6 does on 11G
 #                              servers (R610, R710, R510, T610...) : "Ambient Temp"


### PR DESCRIPTION
Closes #433.

## What was wrong

`make_sdr_output`'s `--with-extra-sensors` documented itself as adding `(board, PCIe risers)`. It emits four rows, and all four are on **entity 10** — `Power Supply` in IPMI v2.0 table 43-13 — two of them named `PSU1 Inlet Temp` and `PSU2 Inlet Temp` outright:

```bash
make_sdr_line "Temp"            "0Ah" "ok" "10.1" "38 degrees C"
make_sdr_line "Temp"            "0Bh" "ok" "10.2" "37 degrees C"
make_sdr_line "PSU1 Inlet Temp" "68h" "ok" "10.1" "29 degrees C"
make_sdr_line "PSU2 Inlet Temp" "69h" "ok" "10.2" "30 degrees C"
```

No board sensor, no riser sensor.

## Why it mattered

That parenthetical was the only place saying what those rows represent, and it said it about the fixture the #231 regression rests on. The `PSU<n> Inlet Temp` pair is the whole point of the option: both names contain `Inlet`, so an unanchored match in `retrieve_temperature_by_sensor_name()` lets a power supply's own intake — several degrees hotter, sitting downstream of its own losses — be shown as the chassis air intake. Read against the old comment, `test_a_power_supplys_own_intake_does_not_answer_for_the_chassis_one()` looked like it was built on board and riser sensors, which would make the anchoring decorative rather than load-bearing.

It is also the shape a reader consults when asking what a Dell reports beyond the CPUs, the inlet and the exhaust — the question #408 arrived with. Naming hardware the rows do not contain is worse there than saying nothing.

## What this changes

- **`tests/lib/fixtures.sh`** — the option's description now says what the rows are, and why the named pair is there.
- **`tests/cases/40_temperature_parsing.sh`** — one new case, `test_the_extra_sensors_are_the_power_supply_rows_the_option_describes()`, pinning the entities the option emits and the count of the `PSU<n> Inlet Temp` pair. Nothing held the sentence against the data, which is how it drifted; this is the treatment #344 gave the cooling response column and #328 gave `FAN_SPEED`'s range.

The emitted rows are unchanged and no production code reads them, so **no behaviour moves with this**.

## Verification

```
./tests/run_tests.sh          ->  533 test cases passed (2650 assertions)
shellcheck -x <CI scope>      ->  clean
.github/check_sign_off.sh     ->  All 1 commits carry a sign-off
```

The new case was confirmed to actually fail: moving one row to entity 11 and renaming it `Riser Temp` trips both assertions (`expected [10.1\n10.2]` / `actual [10.1\n10.2\n11.1]`, and `expected [2]` / `actual [1]`).

---
_Generated by [Claude Code](https://claude.ai/code/session_018mE1fAM3HGnC9KwxSifTaN)_