### PR TITLE
Hold all three documents that run the suite to its parser, and state its third exit code (#437)

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -15,13 +15,16 @@ enough.
 ./tests/run_tests.sh --no-color      # disable colored output
 ```
 
-It exits `0` when every test case passed, `1` otherwise.
+It exits `0` when every test case passed, `1` when one failed or the run refused
+to start — a test case name declared twice, a case file that ends the runner while
+it is being sourced — and `2` when it was given an option it does not take, or one
+without the value it takes.
 
 ## What is covered
 
 | File | What it checks |
 | --- | --- |
-| `cases/10_shell_scripts.sh` | Syntax of every script, the licence header each one and the `Dockerfile` carry, files shipped in the Docker image, drift between the code and what documents it — the two lint invocations, one a hand-maintained list and one a set of globs that has to keep reaching every file of this tree, `CLAUDE.md`'s layout table, paths, figures, dependency graph and worked example, the runner options both `CLAUDE.md` and the runner's own help name against the parser that decides them, and the packages its Environment section promises — healthcheck |
+| `cases/10_shell_scripts.sh` | Syntax of every script, the licence header each one and the `Dockerfile` carry, files shipped in the Docker image, drift between the code and what documents it — the two lint invocations, one a hand-maintained list and one a set of globs that has to keep reaching every file of this tree, `CLAUDE.md`'s layout table, paths, figures, dependency graph and worked example, the runner options all three documents that run the suite name — and the runner's own help — against the parser that decides them, the exit codes this file states against the ones the runner can reach, and the packages its Environment section promises — healthcheck |
 | `cases/11_claude_code_settings.sh` | The settings a Claude Code session starts from, which no server ever reads : that the file still parses, that the rules letting any session run a command without asking are the ones argued for — in the shape they were argued in, still runnable, only those, and all of them still there — and that the `SessionStart` hook is still wired to a script that exists, under a budget outlasting what that script allows itself. Skipped where `jq` is missing, the list being read out of JSON |
 | `cases/12_github_workflows.sh` | The two publishing workflows no pull request ever runs : the release build and the base image refresh. Also two checks over the whole directory rather than those two : that every workflow carries the licence header, and that the shell every `run:` block holds — the several hundred lines no linter here reads — still parses |
 | `cases/13_dockerhub_description.sh` | The page Docker Hub shows on the image's repository, built by a workflow no pull request fires either : that it stays a pointer at the documentation rather than a copy of it, and that no change to `README.md` can alter it |

--- a/tests/cases/10_shell_scripts.sh
+++ b/tests/cases/10_shell_scripts.sh
@@ -970,35 +970,78 @@ function test_the_runner_help_lists_exactly_the_options_its_parser_accepts() {
   done
 }
 
-function test_the_runner_options_claude_md_documents_are_ones_the_runner_accepts() {
-  if [ ! -f "$REPO_ROOT/CLAUDE.md" ]; then
-    skip_test "no CLAUDE.md next to the scripts"
-    return 0
-  fi
+# Every option a document runs the suite with, read out of its fenced blocks
+# alone : that is where a document runs a command, while in prose it quotes them,
+# and a quoted option next to the runner's name is a reference rather than an
+# invocation. Sentence "`./tests/run_tests.sh` exactly, then `shellcheck` and
+# `bash -n`" cost this case a false failure over a -n the runner was never asked for
+# Usage : runner_options_documented_in FILE -> one per line
+function runner_options_documented_in() {
+  awk '/^```/ { IS_FENCED = !IS_FENCED; next } IS_FENCED' "$1" |
+    grep -oE '(\./)?tests/run_tests\.sh[^#]*' |
+    grep -oE ' -{1,2}[A-Za-z][A-Za-z-]*' | tr -d ' ' | sort -u
+}
 
-  # An option CLAUDE.md documents and the runner no longer accepts sends the
-  # session into a usage error on the first command it was told to run, at the
-  # moment it is trying to find out whether the tree is sound
-  #
-  # Read out of the fenced blocks alone, because that is where the document runs
-  # a command : in prose it quotes them, and a quoted option next to the runner's
-  # name is a reference rather than an invocation. Sentence "`./tests/run_tests.sh`
-  # exactly, then `shellcheck` and `bash -n`" cost this case a false failure over
-  # a -n the runner was never asked for
+function test_every_document_runs_the_suite_with_options_the_runner_accepts() {
   local -r ACCEPTED_OPTIONS=$(runner_options_the_parser_accepts)
 
   assert_contains "$ACCEPTED_OPTIONS" " --filter " \
     "the option parser should still be where the accepted spellings are read from" || return 1
 
-  local DOCUMENTED_OPTION
-  while IFS= read -r DOCUMENTED_OPTION; do
-    [ -n "$DOCUMENTED_OPTION" ] || continue
+  # Three documents run the suite, and until this walked all of them the checked
+  # one was the one carrying the fewest : CLAUDE.md names two options, README.md
+  # three and tests/README.md six. What an option costs when it stops being
+  # accepted only changes reader -- a session meets exit 2 on the first command it
+  # was told to run, a contributor loses the same minute with less to go on --
+  # and CONTRIBUTING.md sends that contributor to tests/README.md by name (#437)
+  local -r DOCUMENTS="CLAUDE.md README.md tests/README.md"
 
-    assert_contains "$ACCEPTED_OPTIONS" " $DOCUMENTED_OPTION " \
-      "CLAUDE.md runs the suite with $DOCUMENTED_OPTION, the runner should still accept it"
-  done < <(awk '/^```/ { IS_FENCED = !IS_FENCED; next } IS_FENCED' "$REPO_ROOT/CLAUDE.md" |
-    grep -oE '(\./)?tests/run_tests\.sh[^#]*' |
-    grep -oE ' -{1,2}[A-Za-z][A-Za-z-]*' | tr -d ' ' | sort -u)
+  local DOCUMENT DOCUMENTED_OPTION READ_ANY_DOCUMENT=false
+  for DOCUMENT in $DOCUMENTS; do
+    [ -f "$REPO_ROOT/$DOCUMENT" ] || continue
+    READ_ANY_DOCUMENT=true
+
+    while IFS= read -r DOCUMENTED_OPTION; do
+      [ -n "$DOCUMENTED_OPTION" ] || continue
+
+      assert_contains "$ACCEPTED_OPTIONS" " $DOCUMENTED_OPTION " \
+        "$DOCUMENT runs the suite with $DOCUMENTED_OPTION, the runner should still accept it"
+    done < <(runner_options_documented_in "$REPO_ROOT/$DOCUMENT")
+  done
+
+  if ! $READ_ANY_DOCUMENT; then
+    skip_test "none of the documents that run the suite is next to the scripts"
+  fi
+}
+
+function test_the_suites_own_readme_states_every_exit_code_the_runner_can_reach() {
+  if [ ! -f "$REPO_ROOT/tests/README.md" ]; then
+    skip_test "no tests/README.md next to the runner"
+    return 0
+  fi
+
+  # The sentence under the usage block is what a CI step reads before it writes
+  # "if [ $? -eq 1 ]". It said "0 when every test case passed, 1 otherwise", and
+  # the runner has a third : the option parser exits 2 on an unknown option or on
+  # one given without its value. Under "1 otherwise" that run takes the else
+  # branch and is reported as a pass -- a usage error read as a green suite
+  local -r REACHABLE_EXIT_CODES=$(grep -oE '^[[:space:]]*exit [0-9]+' "$TESTS_DIRECTORY/run_tests.sh" |
+    grep -oE '[0-9]+' | sort -u)
+
+  assert_not_empty "$REACHABLE_EXIT_CODES" "the runner should still exit with a status of its own" || return 1
+
+  # The whole document rather than the sentence, so that moving the explanation
+  # or splitting it in two is not a failure : what matters is that the number is
+  # written down somewhere a reader of this file meets it
+  local -r SUITE_README=$(< "$REPO_ROOT/tests/README.md")
+
+  local EXIT_CODE
+  while IFS= read -r EXIT_CODE; do
+    [ -n "$EXIT_CODE" ] || continue
+
+    assert_matches "$SUITE_README" "\`$EXIT_CODE\`" \
+      "tests/run_tests.sh can exit $EXIT_CODE, and its README should say when"
+  done <<< "$REACHABLE_EXIT_CODES"
 }
 
 function test_the_function_count_claude_md_states_is_the_one_functions_sh_declares() {


### PR DESCRIPTION
Closes #437.

Both findings were seen by #403's sweep and put in its **"Not worth a diff"** list. That judgement was about cost, and #422 changed the cost : it built `runner_options_the_parser_accepts()`, so the first half is a loop over two more files and the second is one sentence plus a guard over it.

## 1. The checked document was the one carrying the fewest options

| Document | Options it runs the suite with | Held to the parser, before |
| --- | --- | --- |
| `CLAUDE.md` | `-f`, `--list` | **yes**, since #422 |
| `tests/README.md` | `-f`, `--list`, `--tap`, `--junit`, `--summary`, `--no-color` | no |
| `README.md` | `-f`, `--list`, `--tap` | no |

All nine spellings are correct today ; nothing was keeping them that way.

The argument #422 made for `CLAUDE.md` transfers with the reader changed. A session meets `exit 2` on the first command it was told to run. A contributor loses the same minute with less to go on — and `CONTRIBUTING.md` sends them to `tests/README.md` by name : *"See `tests/README.md`, which is thorough — read it before touching a test"*.

`test_the_runner_options_claude_md_documents_are_ones_the_runner_accepts` becomes `test_every_document_runs_the_suite_with_options_the_runner_accepts` and walks all three, naming the offending document in the failure. The fenced-block reading is unchanged and moves into `runner_options_documented_in`, so the reason it exists — a quoted option in prose is a reference, not an invocation — is written once.

## 2. `tests/README.md` was wrong about the exit codes

> It exits `0` when every test case passed, `1` otherwise.

The runner has three :

| Code | Reached when |
| ---: | --- |
| `0` | every case passed |
| `1` | a case failed, or the run refused to start — a name declared twice, a case file that `exit`s while being sourced |
| `2` | an unknown option, or one given without the value it takes |

`2` is the status of a run that **never started**. Under *"`1` otherwise"*, a CI step branching on `[ $? -eq 1 ]` takes the *else* and reports a usage error as a passing suite.

The sentence now names all three, and `test_the_suites_own_readme_states_every_exit_code_the_runner_can_reach` reads the `exit` statements the runner can actually reach and requires each number to appear in the file describing them. It reads the whole document rather than the one sentence, so splitting or moving the explanation is not a failure — only dropping a code is.

## How to test

```bash
./tests/run_tests.sh          # 536 test cases passed (2708 assertions)

shellcheck -x Dell_iDRAC_fan_controller.sh functions.sh constants.sh \
              healthcheck.sh supervisor.sh .github/*.sh \
              .claude/hooks/session-start.sh

shellcheck -x -e SC2155,SC2034,SC2016,SC1091,SC1090 \
              tests/run_tests.sh tests/lib/*.sh \
              tests/cases/*.sh tests/mocks/*
```

Both invocations clean. Each guard mutation-tested against a deliberately broken tree, each mutation reverted :

| Mutation | Result |
| --- | --- |
| `tests/README.md` runs the suite with `--quiet` | red — "tests/README.md runs the suite with --quiet, the runner should still accept it" |
| `README.md` runs the suite with `--verbose` | red — names `README.md` this time |
| The exit-code sentence put back to "`1` otherwise" | red — "tests/run_tests.sh can exit 2, and its README should say when" |
| Clean tree | green |

Rebased on `a591851`, after #434. No production script is touched : one existing case generalised, one added, one false sentence corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AQ1MmPC3pGPywBgr9DVr9g

---
_Generated by [Claude Code](https://claude.ai/code/session_01AQ1MmPC3pGPywBgr9DVr9g)_