### PR TITLE
Author an agent's commits under the tool, and sign them off under the maintainer (#439)

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -81,9 +81,15 @@ fi
 # human to recall it every time is a rule that will be forgotten, which is why #421 put the
 # identity here in the first place.
 #
-# /!\ The alias is the mechanism and "trailer.<token>.key" is not : configuring the trailer
-# there makes git append its own separator, producing "Signed-off-by: Tigerblue77 <...>:",
-# a malformed trailer that the gate does not match and that nothing else reports either.
+# /!\ Do not fold this into "trailer.<token>.key". That config does work -- with the key
+# spelled exactly "Signed-off-by", git supplies the ": " separator and the gate accepts the
+# result -- but it fails invisibly when the key is spelled with the separator already in it.
+# "Signed-off-by: " (trailing space) emits a line that is byte-for-byte identical to a valid
+# sign-off, that "git log" displays normally and that %(trailers) lists, while a keyed read
+# of it returns empty : git stored the key WITH the separator, so the gate looks for
+# "Signed-off-by", finds nothing, and refuses a commit whose message looks perfectly right.
+# There is no symptom to notice and nothing reports it. The alias carries the whole trailer
+# as one string instead, where a mistake shows up in the line itself.
 #
 # What this does not do is make the certification true by itself : the maintainer certifies
 # by reviewing and merging. It only stops either field from saying something else meanwhile.

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -56,35 +56,50 @@ if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
   exit 0
 fi
 
-# The identity a commit made here is signed off with, set before anything below can exit
+# The two identities a commit made here carries, set before anything below can exit
 # early : the container is cached once this has run, so a second session reaches the
 # "already installed" return and nothing after it.
 #
-# CONTRIBUTING.md requires a Signed-off-by on every commit and asks for "a real name and a
-# reachable address" ; the DCO's own text is first-person -- "I certify that". A session's
-# default identity is neither. Left alone it writes "Signed-off-by: Claude
-# <noreply@anthropic.com>", which satisfies the gate in .github/check_sign_off.sh while
-# naming nobody who could make the attestation -- the third state issue #388 set out and
-# would not leave standing, where the document asks for one thing and the log shows another.
+# A commit has three identity fields, and they answer two different questions. WHO WROTE IT
+# is the author, and that is the tool : git log, git blame, git shortlog and GitHub's
+# contributor graph all read that field, so recording the tool anywhere else is not
+# recording it. WHO CERTIFIES IT is the Signed-off-by trailer -- CONTRIBUTING.md asks for
+# "a real name and a reachable address" and the DCO's own text is first-person, "I certify
+# that", which a tool cannot say -- so that one is the maintainer's.
 #
-# So the trailer carries the maintainer's identity, set here rather than typed before every
-# merge : it comes out of git config, and a rule that needs a human to remember it every
-# time is a rule that will be forgotten. The address is the GitHub noreply one already
-# throughout this history, not a personal mailbox. Authorship of the work stays recorded by
-# the Co-Authored-By trailer, which is what a tool can honestly claim.
+# Collapsing the two is what issue #388 refused to leave standing, and it can be collapsed
+# in either direction. Left alone, a session writes "Signed-off-by: Claude
+# <noreply@anthropic.com>", a trailer that satisfies the gate in .github/check_sign_off.sh
+# while naming nobody who could make the attestation. Setting user.* to the maintainer
+# repairs that trailer but moves the confusion into the author field, where the log then
+# says the maintainer typed what a tool wrote (#439). Setting each field to the identity it
+# is actually asking about is what says both things at once.
+#
+# The trailer therefore cannot come from "commit -s", which derives it from user.* -- the
+# very fields that have to stay the tool's. It is passed explicitly instead, wrapped in an
+# alias so that it is a command rather than something to remember : a rule that needs a
+# human to recall it every time is a rule that will be forgotten, which is why #421 put the
+# identity here in the first place.
+#
+# /!\ The alias is the mechanism and "trailer.<token>.key" is not : configuring the trailer
+# there makes git append its own separator, producing "Signed-off-by: Tigerblue77 <...>:",
+# a malformed trailer that the gate does not match and that nothing else reports either.
 #
 # What this does not do is make the certification true by itself : the maintainer certifies
-# by reviewing and merging. It only stops the trailer from saying something else meanwhile.
+# by reviewing and merging. It only stops either field from saying something else meanwhile.
 # See CONTRIBUTING.md, "Contributions written by an agent".
 #
 # Repository-local on purpose -- this is this project's rule, and nothing here should reach
 # into a configuration the session may share with other work
 readonly SIGN_OFF_NAME="Tigerblue77"
 readonly SIGN_OFF_EMAIL="37409593+tigerblue77@users.noreply.github.com"
+readonly AGENT_NAME="Claude"
+readonly AGENT_EMAIL="noreply@anthropic.com"
 
-if ! git -C "${CLAUDE_PROJECT_DIR:-.}" config user.name "$SIGN_OFF_NAME" 2> /dev/null ||
-  ! git -C "${CLAUDE_PROJECT_DIR:-.}" config user.email "$SIGN_OFF_EMAIL" 2> /dev/null; then
-  echo "session-start : could not set the git identity, so a commit made here would be signed off by the session's default rather than by the maintainer"
+if ! git -C "${CLAUDE_PROJECT_DIR:-.}" config user.name "$AGENT_NAME" 2> /dev/null ||
+  ! git -C "${CLAUDE_PROJECT_DIR:-.}" config user.email "$AGENT_EMAIL" 2> /dev/null ||
+  ! git -C "${CLAUDE_PROJECT_DIR:-.}" config alias.signoff "commit --trailer \"Signed-off-by: $SIGN_OFF_NAME <$SIGN_OFF_EMAIL>\"" 2> /dev/null; then
+  echo "session-start : could not set the git identity and its sign-off alias, so a commit made here would be authored and signed off by the session's default rather than by the tool and the maintainer"
 fi
 
 # Bounded so that a mirror which accepts a connection and then goes quiet cannot hold the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,12 +59,14 @@ reach `.shellcheckrc`, so the scripts above keep the full lint (issue #432).
 
 ## Conventions
 
-- **Sign off every commit.** `git commit -s`. A commit without `Signed-off-by` is not
-  mergeable ; see `CONTRIBUTING.md` for what it certifies in a dual-licensed project.
-  The trailer names the **maintainer**, not the session : a tool certifies nothing, and
-  `.claude/hooks/session-start.sh` sets that identity at the start of every session so it
-  never has to be remembered. Record yourself as `Co-Authored-By` and leave the sign-off
-  alone.
+- **Sign off every commit** with **`git signoff`**, never `git commit -s`. A commit without
+  `Signed-off-by` is not mergeable ; see `CONTRIBUTING.md` for what it certifies in a
+  dual-licensed project. Two identities are involved and they answer different questions :
+  the commit is **authored** by the session, because that is who wrote it, and the trailer
+  names the **maintainer**, because a tool certifies nothing. `-s` derives the trailer from
+  the author and would collapse the two, so the alias carrying the right one is set by
+  `.claude/hooks/session-start.sh` at the start of every session and nothing has to be
+  remembered (#439). No `Co-Authored-By` is needed : the author field already says it.
 - **Every new shell script carries the two SPDX lines** right after the shebang, test
   cases, mocks and helpers included. Copy them from any existing script.
 - **A new script under the repository root, `.github/` or `.claude/` must be added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,11 +59,13 @@ Forgot it on the last commit ? `git commit --amend -s`. On several ? `git rebase
 
 Some of the code here is written by a coding agent working on the maintainer's instruction. The DCO does not bend for that, and this project cannot afford it to : the sign-off is what records that a contribution could be offered under **both** licences, which is what keeps the commercial arm grantable.
 
-An agent is a tool. A tool cannot certify anything, and a `Signed-off-by` naming one would be a trailer that satisfies a checker while naming nobody who could make the statement above. So for those commits :
+An agent is a tool. A tool cannot certify anything, and a `Signed-off-by` naming one would be a trailer that satisfies a checker while naming nobody who could make the statement above. But it is also what actually wrote the code, and a commit has room to say both. So for those commits :
 
-- **the `Signed-off-by` is the maintainer's**, set from the repository's git configuration rather than typed before each merge — `.claude/hooks/session-start.sh` does it at the start of every session, because a rule that has to be remembered every time is a rule that gets forgotten ;
-- **the agent is recorded as `Co-Authored-By`**, which is what a tool can honestly claim ;
+- **the author is the agent.** `git log`, `git blame`, `git shortlog` and GitHub's contributor graph all read that field, so it is the one place where recording who wrote the work counts. Naming the maintainer there would say they typed what a tool wrote ;
+- **the `Signed-off-by` is the maintainer's**, because the certification is theirs to make. It cannot come from `git commit -s`, which derives the trailer from the author — the field that has to stay the agent's — so it is passed explicitly through the `git signoff` alias that `.claude/hooks/session-start.sh` sets at the start of every session, a rule that has to be remembered every time being a rule that gets forgotten ;
 - **the certification is the maintainer's act of reviewing and merging.** The trailer states it ; the review is what makes it true. A pull request merged unread carries a sign-off that means nothing, and no workflow can tell the difference — [`.github/check_sign_off.sh`](./.github/check_sign_off.sh) reads the trailer's shape, never who stands behind it.
+
+No `Co-Authored-By` accompanies them : the author field already names the agent, and a secondary attribution repeating it would only be another place to fall out of step.
 
 If you are a contributor rather than the maintainer, none of this concerns you : sign your own work, with your own name.
 

--- a/tests/cases/11_claude_code_settings.sh
+++ b/tests/cases/11_claude_code_settings.sh
@@ -305,17 +305,20 @@ function test_the_session_start_hook_names_the_identity_a_commit_is_signed_with(
     return 0
   fi
 
-  # CONTRIBUTING.md requires a Signed-off-by naming a real person, and a session's
-  # default identity is the tool rather than one. The hook sets the maintainer's
-  # so the trailer never has to be typed before a merge -- drop these two lines and
-  # every commit made here goes back to certifying under a name that certifies
-  # nothing, silently, which is the state issue #388 was opened over
+  # Two identities, answering two questions. The author says who wrote the commit and
+  # is the session ; the Signed-off-by says who certifies it and is the maintainer,
+  # CONTRIBUTING.md requiring a trailer that names a real person and a tool being none.
+  # Drop the first pair and every commit here goes back to certifying under a name that
+  # certifies nothing, which is the state issue #388 was opened over ; drop the alias and
+  # "-s" derives the trailer from the author, collapsing the two the other way (#439)
   local -r HOOK=$(cat "$REPO_ROOT/$SESSION_START_HOOK_SCRIPT")
 
   assert_contains "$HOOK" "config user.name" \
-    "the hook should still set the name a commit made here is signed off with"
+    "the hook should still set the name a commit made here is authored under"
   assert_contains "$HOOK" "config user.email" \
     "the hook should still set the address that goes with it"
+  assert_contains "$HOOK" "config alias.signoff" \
+    "the hook should still set the alias carrying the maintainer's sign-off trailer"
 }
 
 function test_the_session_start_hook_sets_that_identity_before_it_can_return_early() {
@@ -345,4 +348,59 @@ function test_the_session_start_hook_sets_that_identity_before_it_can_return_ear
     fail "the identity is set at line $IDENTITY_LINE, after the early return at line $EARLY_RETURN_LINE" \
       "every session but the first on a fresh container would stop before reaching it"
   fi
+}
+
+# What the two identities actually produce, run rather than grepped. The trap this exists
+# for is not a missing line but a working-looking one : configuring the trailer through
+# "trailer.<token>.key" makes git append its own separator and emit
+# "Signed-off-by: Tigerblue77 <...>:", which .github/check_sign_off.sh does not match and
+# nothing else reports, so the hook would look right and every commit would land uncertified.
+# The alias's quoting can break the same way and just as quietly (#439).
+#
+# git is the thing under test as much as the hook is, which is why this builds a real
+# repository like tests/cases/18_sign_off.sh does instead of asserting on the text
+function test_the_session_start_hook_authors_as_the_session_and_signs_off_as_the_maintainer() {
+  if [ ! -f "$REPO_ROOT/$SESSION_START_HOOK_SCRIPT" ]; then
+    skip_test "no hook script next to the settings"
+    return 0
+  fi
+
+  if ! command -v git > /dev/null 2>&1; then
+    skip_test "git is not available, and it is what this case exercises"
+    return 0
+  fi
+
+  local SANDBOX
+  SANDBOX=$(mktemp -d)
+
+  # Only the identity block is run : everything below it in the hook installs packages,
+  # which this has no business doing. Taken from the first constant to the "fi" closing
+  # the branch that applies them, so a rewrite that moves either end fails here loudly
+  local IDENTITY_BLOCK
+  IDENTITY_BLOCK=$(sed -n '/^readonly SIGN_OFF_NAME/,/^fi$/p' "$REPO_ROOT/$SESSION_START_HOOK_SCRIPT")
+
+  if ! assert_not_empty "$IDENTITY_BLOCK" "the hook should still carry an identity block"; then
+    rm -rf "$SANDBOX"
+    return 1
+  fi
+
+  git init --quiet --initial-branch=master "$SANDBOX"
+  git -C "$SANDBOX" config commit.gpgsign false
+  CLAUDE_PROJECT_DIR="$SANDBOX" bash -c "$IDENTITY_BLOCK" > /dev/null 2>&1
+
+  printf 'x\n' > "$SANDBOX/file.txt"
+  git -C "$SANDBOX" add file.txt
+  git -C "$SANDBOX" signoff --quiet -m "A commit made the way a session here makes one" --no-verify
+
+  local COMMIT_AUTHOR
+  COMMIT_AUTHOR=$(git -C "$SANDBOX" log -1 --format='%an <%ae>')
+  local COMMIT_SIGN_OFF
+  COMMIT_SIGN_OFF=$(git -C "$SANDBOX" log -1 --format='%(trailers:key=Signed-off-by,valueonly)')
+
+  rm -rf "$SANDBOX"
+
+  assert_equals "Claude <noreply@anthropic.com>" "$COMMIT_AUTHOR" \
+    "the author names who wrote the commit, which is the session"
+  assert_equals "Tigerblue77 <37409593+tigerblue77@users.noreply.github.com>" "${COMMIT_SIGN_OFF//$'\n'/}" \
+    "the trailer names who certifies it, which is the maintainer"
 }

--- a/tests/cases/11_claude_code_settings.sh
+++ b/tests/cases/11_claude_code_settings.sh
@@ -350,12 +350,14 @@ function test_the_session_start_hook_sets_that_identity_before_it_can_return_ear
   fi
 }
 
-# What the two identities actually produce, run rather than grepped. The trap this exists
-# for is not a missing line but a working-looking one : configuring the trailer through
-# "trailer.<token>.key" makes git append its own separator and emit
-# "Signed-off-by: Tigerblue77 <...>:", which .github/check_sign_off.sh does not match and
-# nothing else reports, so the hook would look right and every commit would land uncertified.
-# The alias's quoting can break the same way and just as quietly (#439).
+# What the two identities actually produce, run rather than grepped. The trap this exists for
+# is not a missing line but a working-looking one, and the sign-off has a failure mode with no
+# symptom at all : a trailer key spelled "Signed-off-by: ", separator included, emits a line
+# byte-for-byte identical to a valid sign-off, which "git log" shows and %(trailers) lists,
+# while a keyed read of it comes back empty and .github/check_sign_off.sh refuses the commit.
+# Reading the hook's text cannot tell that apart from a correct one, and neither can reading
+# the commit message ; only asking git for the trailer BY KEY can, which is what this does.
+# The alias's quoting can break just as quietly (#439).
 #
 # git is the thing under test as much as the hook is, which is why this builds a real
 # repository like tests/cases/18_sign_off.sh does instead of asserting on the text


### PR DESCRIPTION
Closes #439.

## What changes

| Field | Before | After |
| --- | --- | --- |
| `Author` | Tigerblue77 | **Claude `<noreply@anthropic.com>`** |
| `Committer` | Tigerblue77 | **Claude `<noreply@anthropic.com>`** |
| `Signed-off-by` | Tigerblue77 | Tigerblue77 *(unchanged)* |

#421 set `user.name` / `user.email` to the maintainer so `git commit -s` would stop writing a trailer naming a tool. That trailer was the problem and it stays fixed. But those two settings also drive the **author** field, so agent commits since read `Author: Tigerblue77` for work a tool wrote — and that is the field `git log`, `git blame`, `git shortlog` and GitHub's contributor graph read.

A commit has three identity fields answering two questions, so both answers fit: the author says who wrote it, the trailer says who certifies it.

## Files

- **`.claude/hooks/session-start.sh`** — sets `user.*` to the tool, plus a repository-local `git signoff` alias carrying the maintainer's trailer explicitly.
- **`CLAUDE.md`** — the convention becomes `git signoff`, never `git commit -s`.
- **`CONTRIBUTING.md`** — the agent section states both fields and drops `Co-Authored-By`, now redundant with the author.
- **`tests/cases/11_claude_code_settings.sh`** — one new case, plus an alias assertion on the existing one.

## Correction: the first version of this branch stated something false

It warned that `trailer.<token>.key` makes git append its own separator and emit a malformed `Signed-off-by: Tigerblue77 <…>:`. **That is wrong**, and it was engraved in two places. Re-measured on git 2.43.0:

| `trailer.sign.key` | Line produced | Gate |
|---|---|---|
| `Signed-off-by` | `Signed-off-by: Tigerblue77 <…>` | ✅ accepted |
| `Signed-off-by:` | `Signed-off-by:Tigerblue77 <…>` (no space) | ❌ refused |
| `Signed-off-by: ` | `Signed-off-by: Tigerblue77 <…>` | ❌ refused |

The trailing colon came from misusing the config — the whole trailer, key *and* value, had been put in the key, and `--trailer sob` then passed no value of its own. An error in the measurement, written up as a fact about git.

It also pointed away from the failure that **does** exist and has no symptom: row three. That line is byte-for-byte identical to a valid sign-off (`od -c` confirms), `git log` displays it normally, `%(trailers)` lists it — and a *keyed* read comes back empty, because git stored the separator as part of the key. `check_sign_off.sh` looks for `Signed-off-by`, finds nothing, and refuses a commit whose message looks perfectly right. A session sent hunting for a stray colon finds none and concludes the hook is fine.

Both comments now say which spelling works, which fails, and that the failure is invisible in the message. This is also why `test_the_session_start_hook_authors_as_the_session_and_signs_off_as_the_maintainer()` builds a real repository and asks git for the trailer **by key**, rather than grepping the hook or the commit message — neither of which can tell the two apart.

Found by another session reviewing this branch. Re-measured here before anything was changed.

## What does not change

`.github/check_sign_off.sh`, every case in `tests/cases/18_sign_off.sh`, what the trailer certifies, and the maintainer's review being what makes it true. History is untouched — this governs commits made from here on.

## Verification

```
./tests/run_tests.sh          ->  539 test cases passed (2718 assertions)
shellcheck -x <CI scope>      ->  clean
shellcheck -x <suite scope>   ->  clean
.github/check_sign_off.sh     ->  All commits carry a sign-off
```

The new case passes on the runner and skips inside the Docker image, where git is absent — visible in the results as `+1` passed and `+1` skipped.

## Note on this PR's own commits

They are authored and signed off by the maintainer, i.e. they follow the arrangement **in force** rather than the one proposed — mirroring what #421's own commit did in the other direction, #439 not being settled until this merges.