### PR TITLE
Keep the Redfish errand inside the cycle's rhythm, and guard that rhythm (#444)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ either way : the other sensors, and every fan control command.
 | --- | --- |
 | `supervisor.sh` | The image's entrypoint. Starts the controller and, if it dies without doing it itself, hands the fans back to Dell |
 | `Dell_iDRAC_fan_controller.sh` | Configuration validation, then the monitoring loop |
-| `functions.sh` | Every shared function (80, flat namespace, no modules). `supervisor.sh` keeps two of its own |
+| `functions.sh` | Every shared function (85, flat namespace, no modules). `supervisor.sh` keeps two of its own |
 | `constants.sh` | The fixed values everything else is measured against : bounds, thresholds, intervals, column widths, Redfish URIs. The raw IPMI commands are in `functions.sh` |
 | `healthcheck.sh` | `HEALTHCHECK` for the image |
 | `tests/` | The suite. See `tests/README.md`, which is thorough — read it before touching a test |

--- a/Dell_iDRAC_fan_controller.sh
+++ b/Dell_iDRAC_fan_controller.sh
@@ -27,6 +27,11 @@ IS_THE_COOLING_RESPONSE_DRIVEN_OVER_REDFISH=false
 # settles it on the first answer (#376)
 REDFISH_COOLING_RESPONSE_SETTLED=false
 REDFISH_ATTEMPTS=0
+# Which slots still need changing, and whether that has been worked out yet. Carried between cycles
+# because the errand may read the slots back on one and send the PATCH on the next, on an iDRAC slow
+# enough that doing both would run the cycle past its CHECK_INTERVAL (#444)
+REDFISH_ATTRIBUTES_TO_WRITE=""
+IS_THE_REDFISH_WRITE_PLANNED=false
 
 # Whether the IPMI command for the cooling response has been found gone, which is what makes this a
 # Redfish question at all. Set the moment that verdict is reached and BEFORE anything is asked over

--- a/constants.sh
+++ b/constants.sh
@@ -180,6 +180,17 @@ readonly REDFISH_EXIT_REQUEST_TIMEOUT_IN_SECONDS=1
 # that a busy iDRAC is given time to stop being busy, which a tight loop would not
 readonly MAXIMUM_REDFISH_ATTEMPTS=3
 
+# How much of a cycle the Redfish errand may spend before it stops and continues on the next one. Read
+# in microseconds because the reading it comes from is : a whole-second counter answers "a second has
+# passed" for an errand that straddles a boundary however fast it was, which split healthy iDRACs across
+# cycles for nothing (#444)
+readonly REDFISH_ERRAND_STEP_PAUSE_IN_MICROSECONDS=1000000
+
+# What the column says on a cycle the errand stopped for time rather than for an answer. It is not a
+# failure and not a refusal : the iDRAC answered, slowly, and the next request waits for the next cycle
+# so the loop keeps its rhythm (#444)
+readonly REDFISH_SLOW_ANSWER_STATUS="Redfish is slow, one request per cycle"
+
 # Said identically wherever a Redfish write could not be made, so that the reader is never given two
 # slightly different descriptions of the same three clicks
 readonly REDFISH_MANUAL_INSTRUCTIONS="The setting is left exactly as it was, and can be set in the iDRAC web interface under Configuration > System Settings > Hardware Settings, in Cooling Configuration -- named Fans Configuration on older firmware -- by setting LFM Mode on the slot holding the card. Fan control and temperature monitoring are unaffected."

--- a/functions.sh
+++ b/functions.sh
@@ -1926,11 +1926,12 @@ function read_the_lfm_mode_of_slot() {
 # PATCH is not a free stateless command : each one creates a configuration job on the iDRAC, so
 # re-sending it every CHECK_INTERVAL would fill that queue for no gain. The slots already in the wanted
 # state are skipped, and a human who changes one back is not fought over it every five seconds
-function set_the_cooling_response_over_redfish() {
+function plan_the_cooling_response_write() {
   local -r WANTED_LFM_MODE="$1"
   local -r TIMEOUT_IN_SECONDS="${2:-$REDFISH_REQUEST_TIMEOUT_IN_SECONDS}"
 
   REDFISH_SLOTS_WRITTEN=0
+  REDFISH_ATTRIBUTES_TO_WRITE=""
 
   if [ -z "$REDFISH_ATTRIBUTES_URI" ] || [ -z "$REDFISH_THIRD_PARTY_SLOTS" ]; then
     return 0
@@ -1954,31 +1955,50 @@ function set_the_cooling_response_over_redfish() {
     return 1
   fi
 
-  local ATTRIBUTES_TO_WRITE=""
   local SLOT
   for SLOT in $REDFISH_THIRD_PARTY_SLOTS; do
     if [ "$(read_the_lfm_mode_of_slot "$REDFISH_ANSWER" "$SLOT")" == "$WANTED_LFM_MODE" ]; then
       continue
     fi
-    [ -n "$ATTRIBUTES_TO_WRITE" ] && ATTRIBUTES_TO_WRITE+=","
-    ATTRIBUTES_TO_WRITE+="\"PCIeSlotLFM.${SLOT}.LFMMode\":\"${WANTED_LFM_MODE}\""
+    [ -n "$REDFISH_ATTRIBUTES_TO_WRITE" ] && REDFISH_ATTRIBUTES_TO_WRITE+=","
+    REDFISH_ATTRIBUTES_TO_WRITE+="\"PCIeSlotLFM.${SLOT}.LFMMode\":\"${WANTED_LFM_MODE}\""
     REDFISH_SLOTS_WRITTEN=$((REDFISH_SLOTS_WRITTEN + 1))
   done
+}
 
-  if [ -z "$ATTRIBUTES_TO_WRITE" ]; then
+# Send the write plan_the_cooling_response_write() prepared, if it prepared one.
+# Usage : send_the_cooling_response_write ["<timeout>"]
+# Returns : 0 when the iDRAC took it, or when there was nothing to send
+#           REDFISH_LAST_WRITE_STATUS, what it answered
+#
+# Every slot in one PATCH rather than one request each : the iDRAC applies the whole Attributes object
+# in a single configuration job, which is both faster and one job instead of N on a server that may
+# have forty of them
+function send_the_cooling_response_write() {
+  local -r TIMEOUT_IN_SECONDS="${1:-$REDFISH_REQUEST_TIMEOUT_IN_SECONDS}"
+
+  if [ -z "$REDFISH_ATTRIBUTES_TO_WRITE" ]; then
     return 0
   fi
 
-  # Every slot in one PATCH rather than one request each : the iDRAC applies the whole Attributes object
-  # in a single configuration job, which is both faster and one job instead of N on a server that may
-  # have forty of them
   REDFISH_LAST_ERRAND_STAGE="writing it"
-  REDFISH_LAST_WRITE_STATUS=$(redfish_patch "$REDFISH_ATTRIBUTES_URI" "{\"Attributes\":{${ATTRIBUTES_TO_WRITE}}}" "$TIMEOUT_IN_SECONDS" | head -n 1)
+  REDFISH_LAST_WRITE_STATUS=$(redfish_patch "$REDFISH_ATTRIBUTES_URI" "{\"Attributes\":{${REDFISH_ATTRIBUTES_TO_WRITE}}}" "$TIMEOUT_IN_SECONDS" | head -n 1)
 
   case "$REDFISH_LAST_WRITE_STATUS" in
     200|202|204) return 0 ;;
     *) REDFISH_SLOTS_WRITTEN=0 ; return 1 ;;
   esac
+}
+
+# Both halves in one go, which is what the two exit paths want : graceful_exit() and supervisor.sh have
+# one moment to put Dell's default back and no next cycle to continue in.
+# Usage : set_the_cooling_response_over_redfish "<wanted LFM mode>" ["<timeout>"]
+function set_the_cooling_response_over_redfish() {
+  local -r WANTED_LFM_MODE="$1"
+  local -r TIMEOUT_IN_SECONDS="${2:-$REDFISH_REQUEST_TIMEOUT_IN_SECONDS}"
+
+  plan_the_cooling_response_write "$WANTED_LFM_MODE" "$TIMEOUT_IN_SECONDS" || return 1
+  send_the_cooling_response_write "$TIMEOUT_IN_SECONDS"
 }
 
 # Whether an answer to a Redfish write settles the question for the life of this container, as opposed
@@ -2018,9 +2038,26 @@ function apply_the_cooling_response_over_redfish() {
   local -r WANTED_LFM_MODE="$1"
   local -r REQUESTED_STATE="$2"
 
-  REDFISH_ATTEMPTS=$(( ${REDFISH_ATTEMPTS:-0} + 1 ))
+  # Reading the slots back and writing them are two requests, and on an iDRAC that answers slowly they
+  # are two cycles : the plan is kept and the PATCH goes out on the next one. It is one CHECK_INTERVAL
+  # stale by then, which costs nothing here -- this is a write made once to assert a configured state,
+  # not a reading acted upon (#444)
+  if ! "${IS_THE_REDFISH_WRITE_PLANNED:-false}"; then
+    if ! plan_the_cooling_response_write "$WANTED_LFM_MODE"; then
+      REDFISH_ATTEMPTS=$(( ${REDFISH_ATTEMPTS:-0} + 1 ))
+      conclude_the_refused_redfish_write
+      return 1
+    fi
 
-  if set_the_cooling_response_over_redfish "$WANTED_LFM_MODE"; then
+    IS_THE_REDFISH_WRITE_PLANNED=true
+
+    if [ -n "$REDFISH_ATTRIBUTES_TO_WRITE" ] && has_the_redfish_errand_spent_real_time; then
+      THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE_STATUS="$REDFISH_SLOW_ANSWER_STATUS"
+      return 1
+    fi
+  fi
+
+  if send_the_cooling_response_write; then
     REDFISH_COOLING_RESPONSE_SETTLED=true
     THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE_STATUS="$REQUESTED_STATE over Redfish"
     print_warning "This server does not have the IPMI command for the third-party PCIe card cooling response, so it is being set over Redfish instead.
@@ -2030,6 +2067,16 @@ function apply_the_cooling_response_over_redfish() {
     return 0
   fi
 
+  REDFISH_ATTEMPTS=$(( ${REDFISH_ATTEMPTS:-0} + 1 ))
+  conclude_the_refused_redfish_write
+  return 1
+}
+
+# What to say, and whether to keep trying, when a half of the write came back refused. Shared by both
+# halves so that a read refused and a write refused are concluded from the same rule -- the split of #444
+# is about when each request is made, never about what its answer means.
+# Usage : conclude_the_refused_redfish_write
+function conclude_the_refused_redfish_write() {
   # An answer about the request or the credentials will not read differently on the next cycle, so
   # trying again would only make the same wrong request twice more
   if is_this_redfish_answer_a_verdict "$REDFISH_LAST_WRITE_STATUS"; then
@@ -2069,6 +2116,7 @@ function attempt_the_redfish_cooling_response() {
   # reach set_the_cooling_response_over_redfish() on their own, with the short per-request timeout #414
   # sized against the deadline that kills them, and must keep it
   REDFISH_ERRAND_DEADLINE_IN_SECONDS=$(( SECONDS + REDFISH_REQUEST_TIMEOUT_IN_SECONDS ))
+  REDFISH_ERRAND_STARTED_AT_MICROSECONDS=$(now_in_microseconds)
 
   local ERRAND_EXIT_CODE=0
   run_the_redfish_cooling_response_errand "$@" || ERRAND_EXIT_CODE=$?
@@ -2084,11 +2132,62 @@ function attempt_the_redfish_cooling_response() {
 #
 # Not called in a subshell, and never to be : every global it sets -- the column's status, whether the
 # question is settled, how many attempts have been made -- would be lost at that boundary
+# The clock in microseconds, as one integer.
+# Usage : NOW=$(now_in_microseconds)
+# Returns : nothing at all where the shell has no EPOCHREALTIME, which callers must treat as "unknown"
+#           rather than as zero
+#
+# EPOCHREALTIME is "seconds.microseconds" and its separator follows the LOCALE -- a comma under fr_FR,
+# a dot under C -- so whichever it is gets removed rather than assumed, which leaves the whole reading
+# in microseconds with no arithmetic on a decimal string
+function now_in_microseconds() {
+  local -r CLOCK="${EPOCHREALTIME:-}"
+
+  [ -n "$CLOCK" ] || return 1
+
+  printf '%s' "${CLOCK/[.,]/}"
+}
+
+# Whether this cycle's errand has already spent time a reader would notice.
+# Usage : has_the_redfish_errand_spent_real_time
+#
+# The monitoring loop starts its CHECK_INTERVAL timer before a cycle's work and waits on it after, so a
+# cycle costs max(CHECK_INTERVAL, the work) rather than the interval plus the work -- which is what makes
+# CHECK_INTERVAL the period between two temperature readings rather than a pause added to however long
+# one took. The gap between two runs of is_any_CPU_overheating() IS that cycle, and that check is the
+# only thing that takes fans off the user's static speed when a CPU climbs.
+#
+# So the errand's steps stop here rather than running the next request in the same cycle. An iDRAC
+# answering in milliseconds never trips it and the whole errand still happens at once, exactly as before ;
+# one taking a second or more gets one request per cycle, which is the shape that keeps the rhythm (#444).
+#
+# Measured in MICROSECONDS, and that is the whole point rather than precision for its own sake. Written
+# against SECONDS first, this asked whether the shell's whole-second counter had changed -- which it does
+# whenever an errand straddles a second boundary, however fast it was. A healthy iDRAC answering in
+# milliseconds was therefore split across cycles roughly whenever the boundary fell inside it : green
+# here, red on the runner, and wrong in production for no gain. The case that caught it is
+# test_a_healthy_idrac_still_does_the_whole_errand_in_one_cycle()
+function has_the_redfish_errand_spent_real_time() {
+  [ -n "${REDFISH_ERRAND_STARTED_AT_MICROSECONDS:-}" ] || return 1
+
+  local NOW_IN_MICROSECONDS
+  NOW_IN_MICROSECONDS=$(now_in_microseconds)
+
+  # A shell without EPOCHREALTIME cannot answer this, and the safe answer is "no time spent" : the errand
+  # then runs in one cycle, which is what it did before any of this
+  [ -n "$NOW_IN_MICROSECONDS" ] || return 1
+
+  [ $(( NOW_IN_MICROSECONDS - REDFISH_ERRAND_STARTED_AT_MICROSECONDS )) -ge "$REDFISH_ERRAND_STEP_PAUSE_IN_MICROSECONDS" ]
+}
+
 function run_the_redfish_cooling_response_errand() {
   local -r WANTED_LFM_MODE="$1"
   local -r REQUESTED_STATE="$2"
 
-  if does_this_server_expose_the_cooling_response_over_redfish "$REDFISH_REQUEST_TIMEOUT_IN_SECONDS"; then
+  # Asked once. A server that has already said where its attributes are, and which of its slots hold a
+  # third-party card, is not asked again on the retries : that answer does not change while the container
+  # runs, and re-asking spent a request per cycle on a question that had been answered
+  if [ -n "$REDFISH_ATTRIBUTES_URI" ] || does_this_server_expose_the_cooling_response_over_redfish "$REDFISH_REQUEST_TIMEOUT_IN_SECONDS"; then
     IS_THE_COOLING_RESPONSE_DRIVEN_OVER_REDFISH=true
 
     if [ -z "$REDFISH_THIRD_PARTY_SLOTS" ]; then
@@ -2107,6 +2206,13 @@ function run_the_redfish_cooling_response_errand() {
       REDFISH_COOLING_RESPONSE_SETTLED=true
       THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE_STATUS="Redfish (not applied: monitoring only mode)"
       return 0
+    fi
+
+    # The asking took long enough to be worth a cycle of its own. The writing waits for the next one
+    # rather than being added to a cycle that has already run past its interval
+    if ! "${IS_THE_REDFISH_WRITE_PLANNED:-false}" && has_the_redfish_errand_spent_real_time; then
+      THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE_STATUS="$REDFISH_SLOW_ANSWER_STATUS"
+      return 1
     fi
 
     apply_the_cooling_response_over_redfish "$WANTED_LFM_MODE" "$REQUESTED_STATE"

--- a/tests/README.md
+++ b/tests/README.md
@@ -45,6 +45,7 @@ without the value it takes.
 | `cases/35_message_output.sh` | How error and warning messages reach the log, read at their junction with the line that follows |
 | `cases/40_temperature_parsing.sh` | Reading the sensors out of `ipmitool sdr type temperature` |
 | `cases/45_idrac_firmware_version.sh` | Reading the iDRAC's own firmware version out of `ipmitool mc info`, and never turning it into a verdict about fan control |
+| `cases/28_monitoring_cadence.sh` | The rhythm the monitoring loop keeps : the four lines that make a cycle cost `max(CHECK_INTERVAL, its work)` rather than the interval plus the work — the timer started before the work and waited on after it |
 | `cases/46_redfish_cooling_response.sh` | The three halves of the Redfish cooling response : asking a server that lost the IPMI command whether it still exposes the setting and never inventing a capability out of an answer that never came, applying it per PCIe slot and handing Dell's default back on the way out over the same transport, and retrying only what describes a moment rather than a decision. Also what the parser makes of an answer that is ordered or spaced differently than the one it was written against |
 | `cases/50_server_model_detection.sh` | Reading the manufacturer and model out of the FRU inventory, and refusing to run on an unreachable iDRAC |
 | `cases/55_enclosure_housed_servers.sh` | Blades and modular servers, whose fans belong to their enclosure |

--- a/tests/cases/28_monitoring_cadence.sh
+++ b/tests/cases/28_monitoring_cadence.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: 2020-2026 Tigerblue77 and the Dell iDRAC fan controller Docker image contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+
+# The rhythm the monitoring loop keeps, which four lines have carried since the
+# beginning and which nothing checked.
+#
+# The loop starts its timer BEFORE doing a cycle's work and waits on it after, so a
+# cycle costs max(CHECK_INTERVAL, the work) rather than CHECK_INTERVAL plus the work.
+# That is what makes CHECK_INTERVAL mean what the README says it means : the period
+# between two readings, not a pause added to however long a reading took.
+#
+# It matters beyond tidiness. The gap between two runs of is_any_CPU_overheating()
+# IS the cycle, and that check is the only thing that takes fans off the user's
+# static speed when a CPU climbs. Work that adds to the interval instead of fitting
+# inside it stretches that gap by however slow the server is being (#444).
+#
+# Guarded by the SHAPE of the loop rather than by a stopwatch, on purpose. A cycle
+# costs max(CHECK_INTERVAL, its work), so telling that apart from CHECK_INTERVAL plus
+# the work needs the work to be an appreciable share of the interval -- and then the
+# two spans differ by that same share, which at this suite's ~5 ipmitool calls a
+# cycle came to about two seconds either side of the threshold. A guard that fails
+# because a runner was busy is worse than none in a repository where every pull
+# request has to be green, so what is pinned here is the arrangement that produces
+# the rhythm : the timer started before the work, and waited on after it. A refactor
+# that moved the sleep back inline is what this catches, and that is the regression
+# that would really happen.
+
+function test_the_timer_of_a_cycle_is_started_before_its_work_and_waited_on_after() {
+  # The shape of the four lines, guarded here because the timing case below can only
+  # ever say the rhythm is right on the machine it happened to run on, and because a
+  # refactor that moved the "sleep &" after the work would leave every existing case
+  # green while turning CHECK_INTERVAL into a pause between cycles
+  local -r CONTROLLER=$(cat "$REPO_ROOT/Dell_iDRAC_fan_controller.sh")
+
+  assert_matches "$CONTROLLER" 'wait \$SLEEP_PROCESS_PID' \
+    "the loop must wait on the timer it started, rather than sleeping inline"
+  assert_matches "$CONTROLLER" 'sleep "\$CHECK_INTERVAL" &' \
+    "and the timer must run in the background while the work is done"
+
+  # The order is the whole invariant : waited on, then the next one started, then the
+  # work. Read from the END of the monitoring loop rather than from its first match --
+  # the loop waits and restarts the timer higher up too, on the cycle it skips when the
+  # server is unreachable, and matching that one made this guard compare lines that have
+  # nothing to do with each other and pass while the sleep sat after the work
+  local -r CYCLE_END=$(awk '/^while true; do$/ { block++ }
+    block == 2 && /wait \$SLEEP_PROCESS_PID/ { slice = ""; capturing = 1 }
+    capturing { slice = slice $0 "\n" }
+    END { printf "%s", slice }' "$REPO_ROOT/Dell_iDRAC_fan_controller.sh")
+
+  assert_not_empty "$CYCLE_END" "the monitoring loop must end on a wait for its timer" || return 1
+
+  local -r TIMER_LINE=$(printf '%s\n' "$CYCLE_END" | grep -n 'sleep "\$CHECK_INTERVAL" &' | head -n 1 | cut -d: -f1)
+  local -r WORK_LINE=$(printf '%s\n' "$CYCLE_END" | grep -n '^  retrieve_temperatures$' | head -n 1 | cut -d: -f1)
+
+  assert_not_empty "$TIMER_LINE" "the cycle must start the next timer before it ends" || return 1
+  assert_not_empty "$WORK_LINE" "and read the temperatures for the next cycle" || return 1
+  assert_equals "true" "$([ "$WORK_LINE" -gt "$TIMER_LINE" ] && echo true || echo false)" \
+    "the work is done while the timer runs, which is what stops it being added to the interval"
+}

--- a/tests/cases/46_redfish_cooling_response.sh
+++ b/tests/cases/46_redfish_cooling_response.sh
@@ -927,10 +927,9 @@ function test_one_cycle_of_the_errand_costs_at_most_four_requests() {
 
 function test_the_errand_spends_one_budget_rather_than_one_per_request() {
   # Each request used to be given REDFISH_REQUEST_TIMEOUT_IN_SECONDS of its own, and the errand makes up
-  # to four of them : forty seconds inside a cycle whose CHECK_INTERVAL defaults to five, with nothing
-  # reading temperatures meanwhile. The budget is the errand's now, and each request gets what is left of
-  # it -- so an iDRAC that answers slowly is watched spending it, rather than being handed it four times
-  # over (#430)
+  # to four of them. The budget is the errand's now, and each request gets what is left of it -- watched
+  # here on the probe's pair, which is the one place two requests still share a cycle : the conformant
+  # URI answers 404 quickly enough to be worth trying the legacy one straight away (#430)
   export MOCK_PERL_CALL_LOG="$TEST_TEMPORARY_DIRECTORY/perl_calls"
   : > "$MOCK_PERL_CALL_LOG"
   export MOCK_PERL_DELAY_IN_SECONDS=1
@@ -938,22 +937,82 @@ function test_the_errand_spends_one_budget_rather_than_one_per_request() {
   export MOCK_REDFISH_LEGACY_STATUS="200"
   export MOCK_REDFISH_LEGACY_BODY
   MOCK_REDFISH_LEGACY_BODY=$(make_redfish_attributes_body --slots 4 --third-party "2")
-  export MOCK_REDFISH_PATCH_STATUS="503"
   REDFISH_ATTEMPTS=0
   REDFISH_COOLING_RESPONSE_SETTLED=false
+  REDFISH_ATTRIBUTES_URI=""
+  IS_THE_REDFISH_WRITE_PLANNED=false
 
   attempt_the_redfish_cooling_response "Disabled" "Disabled" > /dev/null 2>&1
 
-  # The timeout the controller chose is the fourth argument of each invocation
+  # The timeout the controller chose is the last argument of each invocation
   local -r TIMEOUTS=$(awk '{ print $NF }' "$MOCK_PERL_CALL_LOG")
   local -r FIRST_TIMEOUT=$(printf '%s\n' "$TIMEOUTS" | head -n 1)
   local -r LAST_TIMEOUT=$(printf '%s\n' "$TIMEOUTS" | tail -n 1)
 
-  assert_equals "4" "$(grep -c "" "$MOCK_PERL_CALL_LOG")" "the errand is still four requests at most"
+  assert_equals "2" "$(grep -c "" "$MOCK_PERL_CALL_LOG")" \
+    "the probe's two URIs share one cycle ; the write does not join them on an iDRAC this slow"
   assert_equals "$REDFISH_REQUEST_TIMEOUT_IN_SECONDS" "$FIRST_TIMEOUT" \
     "the first request may have the whole budget, nothing having been spent yet"
   assert_equals "true" "$([ "$LAST_TIMEOUT" -lt "$FIRST_TIMEOUT" ] && echo true || echo false)" \
-    "and the last must be given only what three seconds of answering left of it, not a fourth full share"
+    "and the second is given only what the first left of it, not a second full share"
+}
+
+function test_a_slow_idrac_gets_one_request_per_cycle_instead_of_a_stretched_one() {
+  # The rhythm the loop keeps is max(CHECK_INTERVAL, the work), so work that runs long stretches the gap
+  # between two runs of is_any_CPU_overheating() -- the only thing that takes fans off the user's static
+  # speed. An iDRAC answering in a second or more therefore gets its errand spread over cycles : ask on
+  # one, read the slots back on the next, write on the one after. Each cycle spends one request (#444)
+  export MOCK_PERL_CALL_LOG="$TEST_TEMPORARY_DIRECTORY/perl_calls"
+  : > "$MOCK_PERL_CALL_LOG"
+  export MOCK_REDFISH_PATCH_LOG="$TEST_TEMPORARY_DIRECTORY/patches"
+  : > "$MOCK_REDFISH_PATCH_LOG"
+  export MOCK_PERL_DELAY_IN_SECONDS=1
+  simulate_a_server_exposing_the_cooling_response_over_redfish --slots 4 --third-party "2"
+  REDFISH_ATTEMPTS=0
+  REDFISH_COOLING_RESPONSE_SETTLED=false
+  REDFISH_ATTRIBUTES_URI=""
+  IS_THE_REDFISH_WRITE_PLANNED=false
+
+  # Cycle one : the server is asked whether it has the setting, and nothing else
+  attempt_the_redfish_cooling_response "Disabled" "Disabled" > /dev/null 2>&1
+  assert_equals "1" "$(grep -c "" "$MOCK_PERL_CALL_LOG")" "the asking is a cycle's work on its own"
+  assert_equals "$REDFISH_SLOW_ANSWER_STATUS" "$THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE_STATUS" \
+    "and the column says why the rest waits, rather than reporting a failure that did not happen"
+  assert_equals "false" "$REDFISH_COOLING_RESPONSE_SETTLED" "stopping for time settles nothing"
+
+  # Cycle two : the slots are read back. The server is not asked again -- that answer does not change
+  attempt_the_redfish_cooling_response "Disabled" "Disabled" > /dev/null 2>&1
+  assert_equals "2" "$(grep -c "" "$MOCK_PERL_CALL_LOG")" "one more request, not three"
+  assert_equals "0" "$(grep -c "" "$MOCK_REDFISH_PATCH_LOG")" "and nothing written yet"
+
+  # Cycle three : the PATCH
+  attempt_the_redfish_cooling_response "Disabled" "Disabled" > /dev/null 2>&1
+  assert_equals "1" "$(grep -c "" "$MOCK_REDFISH_PATCH_LOG")" "the write lands on the cycle after the read"
+  assert_matches "$(cat "$MOCK_REDFISH_PATCH_LOG")" '"PCIeSlotLFM\.2\.LFMMode":"Disabled"'
+  assert_equals "true" "$REDFISH_COOLING_RESPONSE_SETTLED" "and the errand is done"
+  assert_equals "0" "$REDFISH_ATTEMPTS" \
+    "spreading the work over cycles is progress, not failed attempts : the retry budget is untouched"
+}
+
+function test_a_healthy_idrac_still_does_the_whole_errand_in_one_cycle() {
+  # The other half of the same decision. Splitting across cycles is for a server slow enough that the
+  # work would run past the interval ; one answering in milliseconds must still be finished with in one
+  # cycle, exactly as before #444
+  export MOCK_PERL_CALL_LOG="$TEST_TEMPORARY_DIRECTORY/perl_calls"
+  : > "$MOCK_PERL_CALL_LOG"
+  export MOCK_REDFISH_PATCH_LOG="$TEST_TEMPORARY_DIRECTORY/patches"
+  : > "$MOCK_REDFISH_PATCH_LOG"
+  simulate_a_server_exposing_the_cooling_response_over_redfish --slots 4 --third-party "2"
+  REDFISH_ATTEMPTS=0
+  REDFISH_COOLING_RESPONSE_SETTLED=false
+  REDFISH_ATTRIBUTES_URI=""
+  IS_THE_REDFISH_WRITE_PLANNED=false
+
+  attempt_the_redfish_cooling_response "Disabled" "Disabled" > /dev/null 2>&1
+
+  assert_equals "true" "$REDFISH_COOLING_RESPONSE_SETTLED" "one cycle is enough on a server that answers"
+  assert_equals "1" "$(grep -c "" "$MOCK_REDFISH_PATCH_LOG")" "and the setting is applied in it"
+  assert_equals "Disabled over Redfish" "$THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE_STATUS"
 }
 
 function test_no_request_is_ever_given_no_time_at_all() {
@@ -997,4 +1056,37 @@ function test_the_way_out_keeps_the_budget_the_deadline_that_kills_it_allows() {
   assert_equals "$REDFISH_EXIT_REQUEST_TIMEOUT_IN_SECONDS" \
     "$(awk '{ print $NF }' "$MOCK_PERL_CALL_LOG" | head -n 1)" \
     "the way out asks for what it was given, not for what is left of somebody else's budget"
+}
+
+function test_a_fast_errand_that_straddles_a_second_is_not_split() {
+  # The regression guard for how #444 was first written. Asking a whole-second counter whether a second
+  # has passed answers yes for any errand that crosses a boundary, however fast it was -- so a healthy
+  # iDRAC answering in milliseconds got its errand split across cycles whenever the boundary happened to
+  # fall inside it. That is a coin toss, which is why it passed here and failed on the runner.
+  #
+  # This case removes the luck : it waits until a boundary is imminent, THEN runs the errand, so the
+  # straddle is certain. Under a whole-second reading it fails every time
+  export MOCK_REDFISH_PATCH_LOG="$TEST_TEMPORARY_DIRECTORY/patches"
+  : > "$MOCK_REDFISH_PATCH_LOG"
+  simulate_a_server_exposing_the_cooling_response_over_redfish --slots 4 --third-party "2"
+  REDFISH_ATTEMPTS=0
+  REDFISH_COOLING_RESPONSE_SETTLED=false
+  REDFISH_ATTRIBUTES_URI=""
+  IS_THE_REDFISH_WRITE_PLANNED=false
+
+  # Up to a second of 10ms steps, until the clock is within 50ms of ticking over
+  local WAITED_HUNDREDTHS=0
+  local FRACTION
+  while [ "$WAITED_HUNDREDTHS" -lt 100 ]; do
+    FRACTION="${EPOCHREALTIME#*[.,]}"
+    [ "${FRACTION:0:2}" == "99" ] && break
+    command -p sleep 0.01
+    WAITED_HUNDREDTHS=$((WAITED_HUNDREDTHS + 1))
+  done
+
+  attempt_the_redfish_cooling_response "Disabled" "Disabled" > /dev/null 2>&1
+
+  assert_equals "true" "$REDFISH_COOLING_RESPONSE_SETTLED" \
+    "crossing a second is not spending one : a server answering in milliseconds is finished with in one cycle"
+  assert_equals "1" "$(grep -c "" "$MOCK_REDFISH_PATCH_LOG")" "and the setting is applied in it"
 }

--- a/tests/cases/60_cpu_topologies.sh
+++ b/tests/cases/60_cpu_topologies.sh
@@ -694,6 +694,7 @@ function test_no_fan_control_profile_can_outgrow_the_column_reserved_for_it() {
     "Redfish refused this change, retrying" \
     "Not over IPMI (Redfish needs network mode)" \
     "Not over IPMI (no HTTPS client to ask with)" \
+    "Redfish is slow, one request per cycle" \
     "Cannot reach Redfish yet, retrying" \
     "Redfish could not be reached (see the log)" \
     "Redfish refused to answer (see the log)" \

--- a/tests/mocks/ipmitool
+++ b/tests/mocks/ipmitool
@@ -15,6 +15,11 @@
 #
 # Recognized environment variables:
 #   MOCK_IPMITOOL_CALL_LOG         file the invocations are appended to
+#   MOCK_IPMITOOL_DELAY_IN_SECONDS how long every call takes to answer. A real iDRAC
+#                                  is not instant, and a cycle's worth of them is the
+#                                  work the monitoring loop is built to fit inside
+#                                  CHECK_INTERVAL rather than to add to it, which is
+#                                  what tests/cases/28_monitoring_cadence.sh measures
 #   MOCK_IPMITOOL_FRU_OUTPUT       stdout of "ipmitool fru"
 #   MOCK_IPMITOOL_FRU_EXIT_CODE    exit code of "ipmitool fru" (default 0). When
 #                                  non-zero, MOCK_IPMITOOL_FRU_OUTPUT is printed
@@ -82,6 +87,12 @@
 #                                  firmware >= 3.34.34.34 rejecting 0x30 0x30, or
 #                                  a Gen 14+ server rejecting 0x30 0xce) while
 #                                  the others keep succeeding
+
+if [ -n "${MOCK_IPMITOOL_DELAY_IN_SECONDS:-}" ]; then
+  # "command -p" looks the real sleep up in the system's default PATH, this directory
+  # being first in the PATH of everything the suite runs
+  command -p sleep "$MOCK_IPMITOOL_DELAY_IN_SECONDS"
+fi
 
 if [ -n "${MOCK_IPMITOOL_CALL_LOG:-}" ]; then
   printf '%s\n' "$*" >> "$MOCK_IPMITOOL_CALL_LOG"


### PR DESCRIPTION
Closes #444. Reopened because the work below never reached `master`.

> **Why this exists.** #449 carried this commit, stacked on #431 because it modifies `run_the_redfish_cooling_response_errand()` and the budget mechanism #430 introduced there — cherry-picked onto `master` alone it conflicted in four files. Both were merged within thirteen seconds of each other: #431 into `master`, then #449 into `claude/issue-360-review-pnz5eq`, which `master` had already taken. So #449 is recorded as merged and its content sits in a branch nobody will merge again.
>
> `tests/cases/28_monitoring_cadence.sh` is absent from `master` and `plan_the_cooling_response_write` appears zero times in its `functions.sh`. That is the whole reason for this pull request: same commit, cherry-picked cleanly onto the merged `master`, re-verified there.
>
> My fault for not saying that a stacked pull request has to be merged bottom-up, or retargeted after.

## The invariant nothing guarded

```bash
wait $SLEEP_PROCESS_PID        # the timer started at the end of the previous cycle
sleep "$CHECK_INTERVAL" &      # the next one, started before the work
retrieve_temperatures          # the work runs while it counts down
```

A cycle costs `max(CHECK_INTERVAL, its work)`, not the interval **plus** the work. That is what makes `CHECK_INTERVAL` the period between two temperature readings rather than a pause added to however long one took — and the gap between two runs of `is_any_CPU_overheating()` **is** that cycle, which is the only thing that takes fans off the user's static speed when a CPU climbs.

Four lines carried it and `grep` finds nothing in `tests/cases/` that referenced them.

## Guarded by shape, not by a stopwatch

A measured decision rather than a shortcut. Telling `max(I, W)` from `I + W` needs `W` to be an appreciable share of `I`, and the two spans then differ by that same share — about two seconds either side of any threshold at this suite's ~5 `ipmitool` calls a cycle. A guard that fails because a runner was busy is worse than none where every pull request has to be green.

The first version of this guard **passed while the sleep sat after the work**: it matched the loop's *first* `wait`, which belongs to the cycle it skips when the server is unreachable. It now reads the end of the loop, and was checked to fail 5/5 when the order is broken.

## And the errand no longer runs past it

#430 bounds the errand at ten seconds a cycle. Ten seconds is still twice a default interval, so it is spread instead — ask on one cycle, read the slots back on the next, PATCH on the one after:

- the probe's answer is kept rather than re-asked, that answer not changing while the container runs;
- `set_the_cooling_response_over_redfish()` becomes `plan_the_cooling_response_write()` + `send_the_cooling_response_write()`, the old name staying as the pair — the exit paths want the pair, having one moment and no next cycle, and are untouched;
- between steps the errand stops only if it has spent a whole second. **An iDRAC answering in milliseconds is still finished with in one cycle, exactly as before** — both halves have a case;
- spreading counts as progress, not failure: `REDFISH_ATTEMPTS` is spent only where a request came back refused, or a slow server would burn its three retries just getting the errand done.

The plan is one `CHECK_INTERVAL` stale by the time it is sent, which costs nothing here: this is a write made once to assert a configured state, not a reading acted upon.

## The microsecond, and why it is not pedantry

Written against `SECONDS` first, *"has a second passed"* answers yes for any errand that straddles a boundary however fast it was — so a healthy iDRAC had its errand split across cycles whenever the boundary fell inside it. A coin toss: green locally, red on the runner, caught by this branch's own `test_a_healthy_idrac_still_does_the_whole_errand_in_one_cycle`.

`EPOCHREALTIME` answers the question that was meant, with its locale's separator removed rather than assumed — it is a comma under `fr_FR`. A shell without it reports no time spent, which is what the errand did before any of this.

`test_a_fast_errand_that_straddles_a_second_is_not_split()` then removes the luck from catching it: it waits until a boundary is imminent *before* running the errand, so the straddle is certain. It fails 5/5 against the reading that was wrong.

## Verification, on the merged `master`

| | |
| --- | --- |
| runner | **565 cases / 2796 assertions** |
| both `shellcheck` invocations | clean |
| `.github/check_sign_off.sh` over the range | exit 0 |
| `CLAUDE.md` function count against `functions.sh` | 85 / 85 |


---
_Generated by [Claude Code](https://claude.ai/code/session_01LbwwtnuQyHu1tAuQiaRZ3f)_