### PR TITLE
Open every issue and pull request assigned, and never as a draft (#448)

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -108,6 +108,33 @@ if ! git -C "${CLAUDE_PROJECT_DIR:-.}" config user.name "$AGENT_NAME" 2> /dev/nu
   echo "session-start : could not set the git identity and its sign-off alias, so a commit made here would be authored and signed off by the session's default rather than by the tool and the maintainer"
 fi
 
+# The other half of what a session here has to know before it touches GitHub, and the half
+# there is nothing to configure for : an issue and a pull request are not settings, they are
+# created through the platform's API with whatever the caller passes, and both fields below
+# are decided at that call. A web session is told by its harness to open a pull request as a
+# DRAFT, and told by nobody to assign anything, so both end up at a value nobody here chose --
+# and the session that would come back to repair them has ended by then.
+#
+# Draft is the one with a price on it. .github/workflows/auto_update_pull_request_branches.yml
+# skips drafts deliberately, so a draft opened here is the single pull request master's moves
+# never reach : it falls behind at every merge and owes a hand-pressed "Update branch" at the
+# moment somebody wanted to merge it, having bought nothing, since it has to be converted
+# before it can be merged at all. Unassigned is quieter and costs the same way, one list
+# further : what is not on the maintainer's is not scheduled, it is remembered instead.
+#
+# Said at the start of every session rather than left in CLAUDE.md alone, for the reason the
+# alias above exists : a rule that has to be recalled every time is a rule that gets forgotten
+# (#448). CLAUDE.md carries the argument, this carries the reminder -- and it is printed
+# before the early return below, so the second session on a cached container is told too.
+#
+# The login is this repository's maintainer, the same person the trailer above names.
+# tests/cases/11_claude_code_settings.sh checks it against that address rather than trusting
+# the two to stay in step : a wrong login is refused by nothing, GitHub accepts any name that
+# exists, and the work simply lands on a stranger's list
+readonly MAINTAINER_GITHUB_LOGIN="tigerblue77"
+
+echo "session-start : an issue or pull request opened here is assigned to $MAINTAINER_GITHUB_LOGIN and is never a draft -- see CLAUDE.md, \"Conventions\""
+
 # Bounded so that a mirror which accepts a connection and then goes quiet cannot hold the
 # session open : two acquire timeouts because a source line may be either scheme, one retry
 # rather than apt's three, and an outer wall clock in case something below the acquire layer

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,19 @@ reach `.shellcheckrc`, so the scripts above keep the full lint (issue #432).
   the author and would collapse the two, so the alias carrying the right one is set by
   `.claude/hooks/session-start.sh` at the start of every session and nothing has to be
   remembered (#439). No `Co-Authored-By` is needed : the author field already says it.
+- **Open every issue and pull request assigned to `tigerblue77`, and never as a draft.**
+  Both are fields on the call that creates the thing, and the session that would come back
+  to repair them afterwards has ended by then. Draft is the half with a price on it :
+  `.github/workflows/auto_update_pull_request_branches.yml` skips drafts deliberately, so a
+  pull request opened as one is the pull request "Require branches to be up to date before
+  merging" leaves further behind `master` at every merge, owing a hand-pressed *Update
+  branch* at the moment somebody wanted to merge it — and it has to be converted before it
+  can be merged at all, so the state buys nothing here. Unassigned is quieter and costs the
+  same way : the maintainer's *Assigned* list is where the work is scheduled, and what is
+  not on it has to be remembered instead. A contributor's own draft is untouched by this —
+  the rule is what a session opens, not what that workflow does with a draft it finds.
+  `.claude/hooks/session-start.sh` says both at the start of every session and
+  `tests/cases/11_claude_code_settings.sh` holds them (#448).
 - **Every new shell script carries the two SPDX lines** right after the shebang, test
   cases, mocks and helpers included. Copy them from any existing script.
 - **A new script under the repository root, `.github/` or `.claude/` must be added

--- a/tests/cases/10_shell_scripts.sh
+++ b/tests/cases/10_shell_scripts.sh
@@ -957,6 +957,32 @@ function test_every_repository_path_claude_md_names_exists() {
   shopt -u nullglob
 }
 
+function test_the_workflow_claude_md_gives_as_its_reason_still_skips_drafts() {
+  if [ ! -f "$REPO_ROOT/CLAUDE.md" ] || [ ! -f "$REPO_ROOT/.github/workflows/auto_update_pull_request_branches.yml" ]; then
+    skip_test "no CLAUDE.md and no .github/workflows next to the scripts"
+    return 0
+  fi
+
+  # CLAUDE.md tells a session never to open a draft, and the reason it gives is this
+  # workflow : drafts are filtered out of what it updates, so a draft opened here would be
+  # the one pull request master's moves never reach, falling behind at every merge under
+  # "Require branches to be up to date before merging" (#448).
+  #
+  # Two documents, one fact, and the rule is only worth its line while the fact holds. The
+  # filter is right for what it was written for -- a contributor's work in progress, often
+  # in a fork -- so nothing here asks for it to go ; what this refuses is the filter going
+  # quietly, leaving an instruction that a session still obeys and nobody can still argue
+  local -r BRANCH_UPDATE_WORKFLOW=$(cat "$REPO_ROOT/.github/workflows/auto_update_pull_request_branches.yml")
+
+  assert_contains "$(cat "$REPO_ROOT/CLAUDE.md")" "never as a draft" \
+    "CLAUDE.md should still tell a session not to open a draft" || return 1
+
+  assert_matches "$BRANCH_UPDATE_WORKFLOW" '\-\-json [A-Za-z,]*isDraft' \
+    "the branch updater should still ask which open pull requests are drafts"
+  assert_matches "$BRANCH_UPDATE_WORKFLOW" 'select\(\.isDraft[[:space:]]*\|[[:space:]]*not\)' \
+    "the branch updater should still leave the drafts out of what it updates, which is why CLAUDE.md refuses to open one"
+}
+
 # What the runner takes is decided in one place : the "case" arms of its option
 # parser, each naming the spellings it accepts, under a "*)" arm that turns
 # everything else into a usage error and exit 2. The help text is a "cat" block

--- a/tests/cases/11_claude_code_settings.sh
+++ b/tests/cases/11_claude_code_settings.sh
@@ -406,3 +406,100 @@ function test_the_session_start_hook_authors_as_the_session_and_signs_off_as_the
   assert_equals "Tigerblue77 <37409593+tigerblue77@users.noreply.github.com>" "${COMMIT_SIGN_OFF//$'\n'/}" \
     "the trailer names who certifies it, which is the maintainer"
 }
+
+# The GitHub half of what a session starts with. The identity above governs the commits it
+# makes ; this governs the two things it opens, and neither of them is a setting anywhere :
+# an issue and a pull request are created through the platform's API with whatever the
+# caller passes, so the only place this repository's answer can live is a sentence the
+# session is handed. Two fields, both decided at that call, both left to a default nobody
+# here chose until #448 : assigned, because what is not on the maintainer's list is not
+# scheduled ; not a draft, because
+# .github/workflows/auto_update_pull_request_branches.yml skips drafts, which makes one
+# opened here the single pull request master's moves never reach.
+#
+# A sentence is all it is, which is exactly why it is guarded : nothing downstream refuses a
+# pull request for being a draft, and nothing refuses an assignee for being the wrong
+# person, so a line quietly lost here has no symptom at all
+function test_the_session_start_hook_states_how_an_issue_or_pull_request_is_opened() {
+  if [ ! -f "$REPO_ROOT/$SESSION_START_HOOK_SCRIPT" ]; then
+    skip_test "no hook script next to the settings"
+    return 0
+  fi
+
+  # Run rather than grepped, for the reason the sign-off case above is run : the login
+  # reaches the message through a variable, and reading the line's text would prove that
+  # the variable is mentioned while saying nothing about which name comes out of it.
+  # Taken from the constant to the echo that uses it, so a rewrite moving either end
+  # fails here rather than silently narrowing what is checked
+  local -r ANNOUNCEMENT_BLOCK=$(awk '/^readonly MAINTAINER_GITHUB_LOGIN=/ { IS_BLOCK = 1 }
+       IS_BLOCK
+       IS_BLOCK && /^echo / { exit }' "$REPO_ROOT/$SESSION_START_HOOK_SCRIPT")
+
+  assert_not_empty "$ANNOUNCEMENT_BLOCK" \
+    "the hook should still name the login a session opens an issue and a pull request under" || return 1
+
+  local ANNOUNCEMENT
+  ANNOUNCEMENT=$(bash -c "$ANNOUNCEMENT_BLOCK")
+
+  assert_contains "$ANNOUNCEMENT" "assigned to tigerblue77" \
+    "the session should be told who an issue and a pull request opened here belong to"
+  assert_contains "$ANNOUNCEMENT" "never a draft" \
+    "the session should be told that a pull request opened here is not a draft, its harness having told it otherwise"
+}
+
+function test_the_session_start_hook_says_that_before_it_can_return_early() {
+  if [ ! -f "$REPO_ROOT/$SESSION_START_HOOK_SCRIPT" ]; then
+    skip_test "no hook script next to the settings"
+    return 0
+  fi
+
+  # The same trap the identity case above pins, and this half falls into it more easily
+  # because it is only an echo : the container is cached once the packages are installed,
+  # so from the second session onwards the run reaches the "already installed" return and
+  # stops there. A reminder printed after that point would be printed once, on a fresh
+  # container, to the one session that happened to open it first
+  local -r ANNOUNCEMENT_LINE=$(grep -n 'MAINTAINER_GITHUB_LOGIN' "$REPO_ROOT/$SESSION_START_HOOK_SCRIPT" | tail -1 | cut -d: -f1)
+  local -r EARLY_RETURN_LINE=$(grep -n 'MISSING_PACKAGES\[@\]} -eq 0' "$REPO_ROOT/$SESSION_START_HOOK_SCRIPT" | head -1 | cut -d: -f1)
+
+  assert_not_empty "$ANNOUNCEMENT_LINE" "the hook should still say how an issue and a pull request are opened" || return 1
+  assert_not_empty "$EARLY_RETURN_LINE" "the hook should still return early once nothing is missing" || return 1
+
+  if [ "$ANNOUNCEMENT_LINE" -lt "$EARLY_RETURN_LINE" ]; then
+    pass
+  else
+    fail "the rule is stated at line $ANNOUNCEMENT_LINE, after the early return at line $EARLY_RETURN_LINE" \
+      "every session but the first on a fresh container would stop before being told it"
+  fi
+}
+
+function test_the_login_a_session_assigns_to_is_the_maintainer_the_commits_are_signed_off_under() {
+  if [ ! -f "$REPO_ROOT/$SESSION_START_HOOK_SCRIPT" ]; then
+    skip_test "no hook script next to the settings"
+    return 0
+  fi
+
+  # One person, written down twice in the same file : the address the sign-off trailer
+  # carries, and the login an issue is assigned to. Nothing makes them agree, and they
+  # fail differently -- a wrong address is refused by .github/check_sign_off.sh, while a
+  # wrong login is refused by nobody, GitHub accepting any name that exists, and the work
+  # simply lands on a stranger's list with everything looking right here.
+  #
+  # The address is the half with a gate behind it, so it is the one the login is measured
+  # against : GitHub's no-reply form is "<id>+<login>@users.noreply.github.com"
+  local -r SIGN_OFF_ADDRESS=$(sed -nE 's/^readonly SIGN_OFF_EMAIL="(.*)"$/\1/p' "$REPO_ROOT/$SESSION_START_HOOK_SCRIPT" | head -1)
+  local -r ASSIGNEE_LOGIN=$(sed -nE 's/^readonly MAINTAINER_GITHUB_LOGIN="(.*)"$/\1/p' "$REPO_ROOT/$SESSION_START_HOOK_SCRIPT" | head -1)
+
+  assert_not_empty "$SIGN_OFF_ADDRESS" "the hook should still name the address a commit is signed off with" || return 1
+  assert_not_empty "$ASSIGNEE_LOGIN" "the hook should still name the login an issue is assigned to" || return 1
+
+  # Checked rather than assumed : the parse below reads a "+" that a plain address does
+  # not carry, and would otherwise compare the login against a whole local part and call
+  # the difference drift
+  assert_matches "$SIGN_OFF_ADDRESS" '^[0-9]+\+[^@]+@users\.noreply\.github\.com$' \
+    "the sign-off address should still be a GitHub no-reply one, which is what carries the login" || return 1
+
+  local -r LOGIN_IN_ADDRESS="${SIGN_OFF_ADDRESS#*+}"
+
+  assert_equals "${LOGIN_IN_ADDRESS%@*}" "$ASSIGNEE_LOGIN" \
+    "the login a session assigns to and the address it signs off under should name the same person"
+}


### PR DESCRIPTION
Closes #448.

Two fields on the calls that open an issue and a pull request, both decided at creation, both left until now to a default nobody here chose : a web session is told by its harness to open a pull request **as a draft**, and told by nobody to assign anything.

## Why draft is the expensive half

`.github/workflows/auto_update_pull_request_branches.yml` skips drafts deliberately, and is right to for what it was written for — a contributor's work in progress, often in a fork, which an unasked-for update would only disturb. It is wrong for the only kind of draft this repository produces : a finished agent change wearing the state by default. That pull request is then the one `master`'s moves never reach. It falls behind at every merge under *"Require branches to be up to date before merging"*, owes a hand-pressed **Update branch** at the moment somebody wanted to merge it, and bought nothing in exchange, since it has to be converted before it can be merged at all.

Unassigned costs the same way, one list further : of the last eight issues opened here, three carry an assignee. What is not on the maintainer's list is not scheduled — it is remembered instead.

Neither is repairable after the fact by the party who caused it : the session that would come back has ended.

## What the change is

| File | What it gains |
| --- | --- |
| `CLAUDE.md` | The rule under *Conventions*, with the argument above behind it |
| `.claude/hooks/session-start.sh` | The reminder, printed at the start of every session — before the early return a cached container reaches, so the second session onwards is told too |
| `tests/cases/11_claude_code_settings.sh` | Three guards over the hook |
| `tests/cases/10_shell_scripts.sh` | One guard over the reason |

The hook says it rather than installs it, because there is nothing to install : an issue and a pull request are not settings, they are created through the platform's API with whatever the caller passes. Same reasoning as #439 — a rule that has to be recalled every time is a rule that gets forgotten — which is why the sentence sits beside the sign-off alias rather than in `CLAUDE.md` alone.

## What the guards actually check

- **The announcement is run, not grepped.** The login reaches the message through a variable, so reading the line's text would prove the variable is mentioned and say nothing about which name comes out of it.
- **It is stated before the early return.** The container is cached once the packages are installed, so from the second session onwards the run stops at *"already installed"*. A reminder printed after that point would be printed once, on a fresh container, to whichever session opened it first — the trap the identity case beside it already pins.
- **The login is measured against the sign-off address.** One person, written down twice in the same file. A wrong address is refused by `.github/check_sign_off.sh` ; a wrong login is refused by nobody, GitHub accepting any name that exists, and the work simply lands on a stranger's list with everything looking right here.
- **The draft filter is pinned.** It is the reason `CLAUDE.md` gives, and the rule is only worth its line while it holds. Nothing here asks for the filter to go — what this refuses is it going quietly, leaving an instruction a session still obeys and nobody can still argue.

Each was checked by breaking what it guards : removing the announcement, changing the login, and dropping `select(.isDraft | not)` from the workflow each fail their case.

## What does not change

- **A contributor's own draft.** The filter is untouched ; this governs only what a session opens. The five drafts open today (#135, #121, #118, #116, #60) are unaffected.
- **The identities a commit carries** (#439). Author, committer and `Signed-off-by` are a separate, settled question.
- **The pre-approved command list** (#382). Opening an issue or a pull request is not a `Bash` rule, so no new permission is involved.
- **Anything the image ships.** `Dockerfile` copies the five runtime scripts, none of which this touches.

## Checks

- `./tests/run_tests.sh` — 569 cases, 2 810 assertions, green, 4 of them new (the figure moved with the two rebases onto `master` : 565 at the first push)
- Both `shellcheck` invocations CI runs — clean
- `.github/check_sign_off.sh` over `master..HEAD` — accepted
- `docker build` could not be run in this session's container, which has no Docker daemon. No shipped file is touched, so the image is unaffected either way.

This pull request is itself opened the way it asks for : assigned, and not a draft.