### PR TITLE
Take back the mock delay that shipped with nothing using it (#453)

### DIFF
--- a/tests/mocks/ipmitool
+++ b/tests/mocks/ipmitool
@@ -15,11 +15,6 @@
 #
 # Recognized environment variables:
 #   MOCK_IPMITOOL_CALL_LOG         file the invocations are appended to
-#   MOCK_IPMITOOL_DELAY_IN_SECONDS how long every call takes to answer. A real iDRAC
-#                                  is not instant, and a cycle's worth of them is the
-#                                  work the monitoring loop is built to fit inside
-#                                  CHECK_INTERVAL rather than to add to it, which is
-#                                  what tests/cases/28_monitoring_cadence.sh measures
 #   MOCK_IPMITOOL_FRU_OUTPUT       stdout of "ipmitool fru"
 #   MOCK_IPMITOOL_FRU_EXIT_CODE    exit code of "ipmitool fru" (default 0). When
 #                                  non-zero, MOCK_IPMITOOL_FRU_OUTPUT is printed
@@ -87,12 +82,6 @@
 #                                  firmware >= 3.34.34.34 rejecting 0x30 0x30, or
 #                                  a Gen 14+ server rejecting 0x30 0xce) while
 #                                  the others keep succeeding
-
-if [ -n "${MOCK_IPMITOOL_DELAY_IN_SECONDS:-}" ]; then
-  # "command -p" looks the real sleep up in the system's default PATH, this directory
-  # being first in the PATH of everything the suite runs
-  command -p sleep "$MOCK_IPMITOOL_DELAY_IN_SECONDS"
-fi
 
 if [ -n "${MOCK_IPMITOOL_CALL_LOG:-}" ]; then
   printf '%s\n' "$*" >> "$MOCK_IPMITOOL_CALL_LOG"


### PR DESCRIPTION
Closes #453.

#444 gave `tests/mocks/ipmitool` a `MOCK_IPMITOOL_DELAY_IN_SECONDS` for a wall-clock cadence case. That case was dropped — separating `max(I, W)` from `I + W` needs `W` to be an appreciable share of `I`, and the two spans then differ by that same share, about two seconds either side of any threshold — and the guard was rewritten to pin the loop's shape instead.

The option went out anyway. `grep -rl MOCK_IPMITOOL_DELAY_IN_SECONDS tests/cases/` returns nothing, and its paragraph closed on:

> which is what `tests/cases/28_monitoring_cadence.sh` measures

That file measures nothing of the sort; it reads the source. So the mock documented a collaboration that does not exist, in the file a contributor reads to learn what the mock can do.

Four lines to bring back the day a case needs them, against a comment that is false today. `MOCK_PERL_DELAY_IN_SECONDS`, from the same commit, is what the slow-iDRAC cases drive and stays.

## Verification

| | |
| --- | --- |
| runner | **565 cases / 2796 assertions**, unchanged |
| the suite lint | clean |

Nothing else moves: the option had no readers.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LbwwtnuQyHu1tAuQiaRZ3f)_