### PR TITLE
Read the heartbeat the run wrote, not the one the machine happens to carry (#455)

### DIFF
--- a/tests/cases/10_shell_scripts.sh
+++ b/tests/cases/10_shell_scripts.sh
@@ -1623,3 +1623,19 @@ function test_every_shell_script_carries_the_licence_header() {
     fi
   done
 }
+
+function test_no_case_reaches_the_healthcheck_through_the_repository_root() {
+  # The healthcheck reads HEARTBEAT_FILE, and the only thing that points it at this run's own
+  # directory is the throwaway repository build_throwaway_controller_repository() writes. Reached
+  # from $REPO_ROOT instead, it sources the real functions.sh and reads the real
+  # /run/dell_idrac_fan_controller.heartbeat -- a file belonging to the machine rather than to the
+  # run, left behind by any container that has run here and stopped.
+  #
+  # That cannot be seen in a green run, which is the whole reason for this case : absence is
+  # deliberately not a verdict, so on a fresh runner the real path never exists and every such case
+  # passes. #442 moved two of them and left three behind, and nothing went red for it (issue #455)
+  local -r OFFENDERS=$(grep -rn 'REPO_ROOT" && bash \./healthcheck\.sh' "$TESTS_DIRECTORY/cases")
+
+  assert_empty "$OFFENDERS" \
+    "a case must reach the healthcheck through CONTROLLER_WORKING_DIRECTORY, or it reads the machine's own heartbeat"
+}

--- a/tests/cases/23_cpu_temperature_source.sh
+++ b/tests/cases/23_cpu_temperature_source.sh
@@ -624,7 +624,7 @@ function test_the_healthcheck_asks_lm_sensors_when_that_is_what_the_container_re
   export MOCK_IPMITOOL_SDR_OUTPUT=""
 
   local OUTPUT
-  OUTPUT=$(cd "$REPO_ROOT" && bash ./healthcheck.sh 2>&1)
+  OUTPUT=$(cd "$CONTROLLER_WORKING_DIRECTORY" && bash ./healthcheck.sh 2>&1)
   local -r EXIT_CODE=$?
 
   assert_equals 0 "$EXIT_CODE" "the source the container reads answers, so the container is healthy"
@@ -637,7 +637,7 @@ function test_the_healthcheck_fails_when_the_source_the_container_reads_says_not
   export MOCK_SENSORS_OUTPUT=""
 
   local EXIT_CODE=0
-  (cd "$REPO_ROOT" && bash ./healthcheck.sh) > /dev/null 2>&1 || EXIT_CODE=$?
+  (cd "$CONTROLLER_WORKING_DIRECTORY" && bash ./healthcheck.sh) > /dev/null 2>&1 || EXIT_CODE=$?
 
   assert_not_equals 0 "$EXIT_CODE" "the container can no longer read the temperatures it supervises"
 }
@@ -652,7 +652,7 @@ function test_the_healthcheck_keeps_asking_the_idrac_on_the_automatic_source() {
   export MOCK_IPMITOOL_SDR_OUTPUT=""
 
   local EXIT_CODE=0
-  (cd "$REPO_ROOT" && bash ./healthcheck.sh) > /dev/null 2>&1 || EXIT_CODE=$?
+  (cd "$CONTROLLER_WORKING_DIRECTORY" && bash ./healthcheck.sh) > /dev/null 2>&1 || EXIT_CODE=$?
 
   assert_not_equals 0 "$EXIT_CODE"
 }


### PR DESCRIPTION
Closes #455.

## What

#442 redirected `HEARTBEAT_FILE` into the run's own temporary directory and moved its two healthcheck cases in `10_shell_scripts.sh` to `$CONTROLLER_WORKING_DIRECTORY` so they would read it. **Three cases in `23_cpu_temperature_source.sh` were not moved** (lines 627, 640, 655) and still reach the healthcheck through `$REPO_ROOT`, where it sources the real `functions.sh` and reads the real `/run/dell_idrac_fan_controller.heartbeat` — a file belonging to the machine, not to the run.

## Why nothing went red

Absence is deliberately not a verdict, so on a fresh runner that path never exists and the cases pass. They fail on any machine where the file exists and has stopped moving — every machine this container has run on and been stopped, including the Docker host of anyone running the suite on the server they are cooling.

The failure names the wrong subject:

```
  fail the healthcheck asks lm sensors when that is what the container reads
       the source the container reads answers, so the container is healthy
         expected: [0]   actual: [1]
         text: [The monitoring loop has not completed a cycle for longer than its check interval allows]
```

Nothing about `lm-sensors` is wrong there.

## Changes

- Three lines: those cases now run from `$CONTROLLER_WORKING_DIRECTORY`, exactly as #442 did for the other two.
- One guard, `test_no_case_reaches_the_healthcheck_through_the_repository_root()`. It is the part worth more than the three lines: an omission of this shape **cannot be seen in a green run**, which is how #442 left three behind. The guard fails the moment a fourth appears.

## Testing

- `./tests/run_tests.sh` — 566 cases, 2797 assertions, green.
- `shellcheck -x -e SC2155,SC2034,SC2016,SC1091,SC1090` on `tests/` — clean.
- `./tests/run_tests.sh -f healthcheck` — all seven cases green.

**One caveat on the demonstration.** I hit this failure for real and captured the output above, but I cannot reproduce it on demand right now: a background measurement of mine keeps rewriting that same `/run` path every few seconds, so the staleness condition does not hold while it runs. On a quiet machine the reproduction in #455 is two commands. The defect itself does not depend on reproducing it — it is visible in the three lines.

---
_Generated by [Claude Code](https://claude.ai/code/session_013jBHkLz6u75AyWPgV3ygbv)_