### PR TITLE
Say the assignment rule only where this repository is the origin (#457)

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -133,7 +133,31 @@ fi
 # exists, and the work simply lands on a stranger's list
 readonly MAINTAINER_GITHUB_LOGIN="tigerblue77"
 
-echo "session-start : an issue or pull request opened here is assigned to $MAINTAINER_GITHUB_LOGIN and is never a draft -- see CLAUDE.md, \"Conventions\""
+# Said to the maintainer's own sessions, and to nobody else's. This file is repository
+# content : it is cloned with the tree, so a contributor working on their FORK runs it too,
+# and neither half of the sentence is true there. GitHub silently drops "assignees" from a
+# caller without write access -- the call succeeds, the field stays empty, and nothing says
+# so -- and a contributor's draft is exactly what the branch updater's filter was written to
+# leave alone. Telling somebody else's agent otherwise is the one way this rule can do harm
+# rather than none (#457).
+#
+# The fork is visible in one command, in either URL form : "https://github.com/<owner>/..."
+# and "git@github.com:<owner>/...". Lower-cased because a clone URL keeps whatever case was
+# typed, while a GitHub login compares case-insensitively.
+#
+# Silence is the default on every other answer, deliberately. A checkout with no origin, or
+# with the remote under another name, loses the reminder rather than handing it to a
+# stranger : CLAUDE.md still carries the rule for the sessions it is addressed to, so what
+# is lost there is the belt and not the braces, where the opposite mistake instructs
+# somebody else's agent
+ORIGIN_URL=""
+ORIGIN_URL="$(git -C "${CLAUDE_PROJECT_DIR:-.}" remote get-url origin 2> /dev/null)"
+ORIGIN_URL="${ORIGIN_URL,,}"
+
+if [[ "$ORIGIN_URL" == *"/${MAINTAINER_GITHUB_LOGIN,,}/"* ]] ||
+  [[ "$ORIGIN_URL" == *":${MAINTAINER_GITHUB_LOGIN,,}/"* ]]; then
+  echo "session-start : an issue or pull request opened here is assigned to $MAINTAINER_GITHUB_LOGIN and is never a draft -- see CLAUDE.md, \"Conventions\""
+fi
 
 # Bounded so that a mirror which accepts a connection and then goes quiet cannot hold the
 # session open : two acquire timeouts because a source line may be either scheme, one retry

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,12 @@ reach `.shellcheckrc`, so the scripts above keep the full lint (issue #432).
   not on it has to be remembered instead. A contributor's own draft is untouched by this —
   the rule is what a session opens, not what that workflow does with a draft it finds.
   `.claude/hooks/session-start.sh` says both at the start of every session and
-  `tests/cases/11_claude_code_settings.sh` holds them (#448).
+  `tests/cases/11_claude_code_settings.sh` holds them (#448). **This governs the
+  maintainer's sessions, not everyone who clones the repository** : the two documents that
+  carry the rule travel with the tree, so the hook checks that `origin` is this repository
+  before it says any of it, and says nothing on a fork. A contributor's session is not
+  addressed by this at all — its pull request is theirs to assign and theirs to open as a
+  draft, which is what the branch updater's filter is there to protect (#457).
 - **Every new shell script carries the two SPDX lines** right after the shebang, test
   cases, mocks and helpers included. Copy them from any existing script.
 - **A new script under the repository root, `.github/` or `.claude/` must be added

--- a/tests/cases/11_claude_code_settings.sh
+++ b/tests/cases/11_claude_code_settings.sh
@@ -419,32 +419,137 @@ function test_the_session_start_hook_authors_as_the_session_and_signs_off_as_the
 #
 # A sentence is all it is, which is exactly why it is guarded : nothing downstream refuses a
 # pull request for being a draft, and nothing refuses an assignee for being the wrong
-# person, so a line quietly lost here has no symptom at all
+# person, so a line quietly lost here has no symptom at all.
+#
+# And it is said to the maintainer's sessions only. This file travels with the tree, so a
+# contributor's session on their fork runs the same hook, where neither half holds : GitHub
+# drops "assignees" from a caller without write access, silently, and their draft is what
+# the branch updater's filter exists to leave alone (#457). The cases below run the block
+# against a repository whose origin they choose, which is the only way to see what a fork
+# is told without owning one.
+
+# The announcement, taken from the constant to the "fi" that closes its guard, so a rewrite
+# moving either end fails these loudly rather than quietly running more of the hook than was
+# meant -- everything below it installs packages.
+# Usage : announcement_block
+function announcement_block() {
+  awk '/^readonly MAINTAINER_GITHUB_LOGIN=/ { IS_BLOCK = 1 }
+       IS_BLOCK
+       IS_BLOCK && /^fi$/ { exit }' "$REPO_ROOT/$SESSION_START_HOOK_SCRIPT"
+}
+
+# What the hook prints in a repository whose origin is the URL given, or nothing at all when
+# it is called with none. Run rather than read : the login reaches the message through a
+# variable and the fork check through git itself, and reading the text would prove that both
+# are mentioned while saying nothing about what either one answers.
+# Usage : announcement_for_origin "https://github.com/owner/repository" -> what it says
+function announcement_for_origin() {
+  local -r ORIGIN="$1"
+
+  local SANDBOX
+  SANDBOX=$(mktemp -d)
+
+  # Every git configuration the machine can supply is taken out of the way, here and around
+  # the block below. Not tidiness : "url.<base>.insteadOf" rewrites a remote AT READ TIME,
+  # so a machine carrying one hands the SSH case the HTTPS form -- the case then passes
+  # without ever reaching the branch written for it, and goes on passing once that branch is
+  # deleted. Measured on the first version of these cases, where deleting it changed nothing.
+  #
+  # THREE sources, and the third is the one that surprised this file. Two are files, silenced
+  # by pointing them at /dev/null. The third is the environment : GIT_CONFIG_COUNT with its
+  # GIT_CONFIG_KEY_n / GIT_CONFIG_VALUE_n pairs is configuration git reads before either
+  # file, unaffected by silencing them, and it is what carries the rewrite in Claude Code on
+  # the web -- three pairs, two of them "url.https://github.com/.insteadOf". Dropping the
+  # count is what disables them : git reads exactly that many pairs and no more.
+  #
+  # A sandbox that reads the machine it runs on is not a sandbox, which is the reason
+  # cases/18 gives for building a repository of its own rather than trusting the developer's
+  local -r HERMETIC_GIT=(env -u GIT_CONFIG_COUNT GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null)
+
+  "${HERMETIC_GIT[@]}" git init --quiet --initial-branch=master "$SANDBOX"
+
+  if [ -n "$ORIGIN" ]; then
+    "${HERMETIC_GIT[@]}" git -C "$SANDBOX" remote add origin "$ORIGIN"
+  fi
+
+  local -r BLOCK=$(announcement_block)
+  local OUTPUT
+  OUTPUT=$("${HERMETIC_GIT[@]}" CLAUDE_PROJECT_DIR="$SANDBOX" bash -c "$BLOCK" 2>&1)
+
+  rm -rf "$SANDBOX"
+
+  printf '%s' "$OUTPUT"
+}
+
+# Usage : if ! the_announcement_can_be_run; then skip_test "..."; return 0; fi
+function the_announcement_can_be_run() {
+  [ -f "$REPO_ROOT/$SESSION_START_HOOK_SCRIPT" ] && command -v git > /dev/null 2>&1
+}
+
 function test_the_session_start_hook_states_how_an_issue_or_pull_request_is_opened() {
-  if [ ! -f "$REPO_ROOT/$SESSION_START_HOOK_SCRIPT" ]; then
-    skip_test "no hook script next to the settings"
+  if ! the_announcement_can_be_run; then
+    skip_test "no hook script next to the settings, or no git to read a remote with"
     return 0
   fi
 
-  # Run rather than grepped, for the reason the sign-off case above is run : the login
-  # reaches the message through a variable, and reading the line's text would prove that
-  # the variable is mentioned while saying nothing about which name comes out of it.
-  # Taken from the constant to the echo that uses it, so a rewrite moving either end
-  # fails here rather than silently narrowing what is checked
-  local -r ANNOUNCEMENT_BLOCK=$(awk '/^readonly MAINTAINER_GITHUB_LOGIN=/ { IS_BLOCK = 1 }
-       IS_BLOCK
-       IS_BLOCK && /^echo / { exit }' "$REPO_ROOT/$SESSION_START_HOOK_SCRIPT")
-
-  assert_not_empty "$ANNOUNCEMENT_BLOCK" \
+  assert_not_empty "$(announcement_block)" \
     "the hook should still name the login a session opens an issue and a pull request under" || return 1
 
-  local ANNOUNCEMENT
-  ANNOUNCEMENT=$(bash -c "$ANNOUNCEMENT_BLOCK")
+  local -r ANNOUNCEMENT=$(announcement_for_origin "https://github.com/tigerblue77/Dell_iDRAC_fan_controller_Docker.git")
 
   assert_contains "$ANNOUNCEMENT" "assigned to tigerblue77" \
     "the session should be told who an issue and a pull request opened here belong to"
   assert_contains "$ANNOUNCEMENT" "never a draft" \
     "the session should be told that a pull request opened here is not a draft, its harness having told it otherwise"
+}
+
+function test_the_ssh_form_of_this_repositorys_origin_is_recognised_too() {
+  if ! the_announcement_can_be_run; then
+    skip_test "no hook script next to the settings, or no git to read a remote with"
+    return 0
+  fi
+
+  # "git@github.com:owner/repository" carries the owner behind a colon rather than a slash,
+  # and a clone URL keeps whatever case was typed while a GitHub login compares
+  # case-insensitively. A check that reads only the HTTPS form, or only lower case, would
+  # leave the maintainer's own session silently unaddressed -- the failure this whole rule
+  # exists to prevent, arrived at from the other side
+  local -r ANNOUNCEMENT=$(announcement_for_origin "git@github.com:Tigerblue77/Dell_iDRAC_fan_controller_Docker.git")
+
+  assert_contains "$ANNOUNCEMENT" "assigned to tigerblue77" \
+    "an SSH remote, in any case, is still this repository"
+}
+
+function test_a_session_on_a_contributors_fork_is_told_none_of_it() {
+  if ! the_announcement_can_be_run; then
+    skip_test "no hook script next to the settings, or no git to read a remote with"
+    return 0
+  fi
+
+  # The case #457 was opened over. A contributor forks, opens a session, and this hook runs
+  # for them exactly as it does here : telling them to assign the maintainer is an
+  # instruction GitHub will drop without a word, and telling them not to open a draft
+  # contradicts the one carve-out the branch updater makes for their benefit
+  local -r ANNOUNCEMENT=$(announcement_for_origin "https://github.com/a-contributor/Dell_iDRAC_fan_controller_Docker.git")
+
+  assert_empty "$ANNOUNCEMENT" \
+    "a fork is somebody else's repository, and this rule is not addressed to their session"
+}
+
+function test_a_checkout_with_no_origin_is_told_nothing_either() {
+  if ! the_announcement_can_be_run; then
+    skip_test "no hook script next to the settings, or no git to read a remote with"
+    return 0
+  fi
+
+  # Silence on every answer that is not this repository, including no answer at all. The
+  # trade is deliberate and it is not symmetrical : a checkout with no origin loses a
+  # reminder CLAUDE.md still carries, while the opposite default would hand the rule to
+  # whoever happens to have cloned the tree
+  local -r ANNOUNCEMENT=$(announcement_for_origin "")
+
+  assert_empty "$ANNOUNCEMENT" \
+    "a checkout with no remote is not evidence that this is the maintainer's own"
 }
 
 function test_the_session_start_hook_says_that_before_it_can_return_early() {


### PR DESCRIPTION
Closes #457. Follow-up to #448, merged in #451.

## The gap

The rule lives in the two places a session reads — `CLAUDE.md` and `.claude/hooks/session-start.sh` — and both are **repository content**. Cloned with the tree, they reach a contributor's own session on their fork, which is then told to open its pull request assigned to `tigerblue77` and never as a draft. Neither is true there :

- GitHub **silently drops** `assignees` from a caller without write access. The call succeeds, the field stays empty, nothing reports it.
- A contributor's draft is exactly what the branch updater's filter exists to leave alone — a carve-out #448 quotes approvingly, while telling the people it protects to stop.

The sentence already in `CLAUDE.md`, *"a contributor's own draft is untouched by this"*, was written about the **workflow's filter**, not about the reader : it says what happens to a draft that exists, not that the rule is unaddressed to a contributor's session.

## The change

A document can only state who it is addressed to, so `CLAUDE.md` now does. The hook can check, and does :

```bash
ORIGIN_URL="$(git -C "${CLAUDE_PROJECT_DIR:-.}" remote get-url origin 2> /dev/null)"
ORIGIN_URL="${ORIGIN_URL,,}"

if [[ "$ORIGIN_URL" == *"/${MAINTAINER_GITHUB_LOGIN,,}/"* ]] ||
  [[ "$ORIGIN_URL" == *":${MAINTAINER_GITHUB_LOGIN,,}/"* ]]; then
```

Both URL forms, because `git@github.com:owner/…` carries the owner behind a colon. Lower-cased, because a clone URL keeps whatever case was typed while a GitHub login compares case-insensitively.

**Silence is the answer everywhere else**, including a checkout with no origin at all. The trade is deliberate and asymmetric : that case loses a reminder `CLAUDE.md` still carries — the belt, not the braces — where the opposite default hands the rule to whoever cloned the tree.

## The sandbox had to be made hermetic first

The four new cases run the block against a repository whose `origin` they choose. The first version of them was **passing for the wrong reason**, and the mutation that should have caught it did not :

> `url.<base>.insteadOf` rewrites a remote **at read time**, and Claude Code on the web carries one — so the SSH case was handed the HTTPS form, passed without ever reaching the branch written for it, and went on passing with that branch deleted.

Pointing `GIT_CONFIG_GLOBAL` and `GIT_CONFIG_SYSTEM` at `/dev/null` did not fix it, because the rewrite arrives through a **third** source : `GIT_CONFIG_COUNT` with its `GIT_CONFIG_KEY_n` / `GIT_CONFIG_VALUE_n` pairs, configuration git reads before either file. Three pairs here, two of them `url.https://github.com/.insteadOf`. Dropping the count disables them — git reads exactly that many and no more.

| Mutation | Case that fails |
| --- | --- |
| the guard removed, announcement unconditional | the fork case, and the no-origin case |
| `${ORIGIN_URL,,}` dropped | the SSH case (mixed-case owner) |
| the `:owner/` branch dropped | the SSH case — **only once the sandbox is hermetic** |

## What this is not

- **Not a permission check.** It changes what a session is *told*, not what it can do.
- **Not the branch updater.** Its draft filter is untouched.
- **Not the commit identities** (#439). Whether the hook should set the maintainer's sign-off trailer on a fork is a separate question, deliberately not answered here.

## Checks

- `./tests/run_tests.sh` — 577 cases, 2 823 assertions, green (4 of them new)
- Both `shellcheck` invocations CI runs — clean
- `.github/check_sign_off.sh` over `master..HEAD` — accepted
- `docker build` not run : this session's container has no Docker daemon, and no shipped file is touched (CI builds the image for the in-image suite anyway)

---
_Generated by [Claude Code](https://claude.ai/code/session_018bahjop4eoofAGhfnfzQiP)_