### PR TITLE
Set an identity only where this repository is the origin (#459)

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -56,107 +56,128 @@ if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
   exit 0
 fi
 
-# The two identities a commit made here carries, set before anything below can exit
-# early : the container is cached once this has run, so a second session reaches the
-# "already installed" return and nothing after it.
+# WHOSE COPY OF THIS REPOSITORY THIS IS, which decides everything below it.
 #
-# A commit has three identity fields, and they answer two different questions. WHO WROTE IT
-# is the author, and that is the tool : git log, git blame, git shortlog and GitHub's
-# contributor graph all read that field, so recording the tool anywhere else is not
-# recording it. WHO CERTIFIES IT is the Signed-off-by trailer -- CONTRIBUTING.md asks for
-# "a real name and a reachable address" and the DCO's own text is first-person, "I certify
-# that", which a tool cannot say -- so that one is the maintainer's.
-#
-# Collapsing the two is what issue #388 refused to leave standing, and it can be collapsed
-# in either direction. Left alone, a session writes "Signed-off-by: Claude
-# <noreply@anthropic.com>", a trailer that satisfies the gate in .github/check_sign_off.sh
-# while naming nobody who could make the attestation. Setting user.* to the maintainer
-# repairs that trailer but moves the confusion into the author field, where the log then
-# says the maintainer typed what a tool wrote (#439). Setting each field to the identity it
-# is actually asking about is what says both things at once.
-#
-# The trailer therefore cannot come from "commit -s", which derives it from user.* -- the
-# very fields that have to stay the tool's. It is passed explicitly instead, wrapped in an
-# alias so that it is a command rather than something to remember : a rule that needs a
-# human to recall it every time is a rule that will be forgotten, which is why #421 put the
-# identity here in the first place.
-#
-# /!\ Do not fold this into "trailer.<token>.key". That config does work -- with the key
-# spelled exactly "Signed-off-by", git supplies the ": " separator and the gate accepts the
-# result -- but it fails invisibly when the key is spelled with the separator already in it.
-# "Signed-off-by: " (trailing space) emits a line that is byte-for-byte identical to a valid
-# sign-off, that "git log" displays normally and that %(trailers) lists, while a keyed read
-# of it returns empty : git stored the key WITH the separator, so the gate looks for
-# "Signed-off-by", finds nothing, and refuses a commit whose message looks perfectly right.
-# There is no symptom to notice and nothing reports it. The alias carries the whole trailer
-# as one string instead, where a mistake shows up in the line itself.
-#
-# What this does not do is make the certification true by itself : the maintainer certifies
-# by reviewing and merging. It only stops either field from saying something else meanwhile.
-# See CONTRIBUTING.md, "Contributions written by an agent".
-#
-# Repository-local on purpose -- this is this project's rule, and nothing here should reach
-# into a configuration the session may share with other work
-readonly SIGN_OFF_NAME="Tigerblue77"
-readonly SIGN_OFF_EMAIL="37409593+tigerblue77@users.noreply.github.com"
-readonly AGENT_NAME="Claude"
-readonly AGENT_EMAIL="noreply@anthropic.com"
-
-if ! git -C "${CLAUDE_PROJECT_DIR:-.}" config user.name "$AGENT_NAME" 2> /dev/null ||
-  ! git -C "${CLAUDE_PROJECT_DIR:-.}" config user.email "$AGENT_EMAIL" 2> /dev/null ||
-  ! git -C "${CLAUDE_PROJECT_DIR:-.}" config alias.signoff "commit --trailer \"Signed-off-by: $SIGN_OFF_NAME <$SIGN_OFF_EMAIL>\"" 2> /dev/null; then
-  echo "session-start : could not set the git identity and its sign-off alias, so a commit made here would be authored and signed off by the session's default rather than by the tool and the maintainer"
-fi
-
-# The other half of what a session here has to know before it touches GitHub, and the half
-# there is nothing to configure for : an issue and a pull request are not settings, they are
-# created through the platform's API with whatever the caller passes, and both fields below
-# are decided at that call. A web session is told by its harness to open a pull request as a
-# DRAFT, and told by nobody to assign anything, so both end up at a value nobody here chose --
-# and the session that would come back to repair them has ended by then.
-#
-# Draft is the one with a price on it. .github/workflows/auto_update_pull_request_branches.yml
-# skips drafts deliberately, so a draft opened here is the single pull request master's moves
-# never reach : it falls behind at every merge and owes a hand-pressed "Update branch" at the
-# moment somebody wanted to merge it, having bought nothing, since it has to be converted
-# before it can be merged at all. Unassigned is quieter and costs the same way, one list
-# further : what is not on the maintainer's is not scheduled, it is remembered instead.
-#
-# Said at the start of every session rather than left in CLAUDE.md alone, for the reason the
-# alias above exists : a rule that has to be recalled every time is a rule that gets forgotten
-# (#448). CLAUDE.md carries the argument, this carries the reminder -- and it is printed
-# before the early return below, so the second session on a cached container is told too.
-#
-# The login is this repository's maintainer, the same person the trailer above names.
-# tests/cases/11_claude_code_settings.sh checks it against that address rather than trusting
-# the two to stay in step : a wrong login is refused by nothing, GitHub accepts any name that
-# exists, and the work simply lands on a stranger's list
-readonly MAINTAINER_GITHUB_LOGIN="tigerblue77"
-
-# Said to the maintainer's own sessions, and to nobody else's. This file is repository
-# content : it is cloned with the tree, so a contributor working on their FORK runs it too,
-# and neither half of the sentence is true there. GitHub silently drops "assignees" from a
-# caller without write access -- the call succeeds, the field stays empty, and nothing says
-# so -- and a contributor's draft is exactly what the branch updater's filter was written to
-# leave alone. Telling somebody else's agent otherwise is the one way this rule can do harm
-# rather than none (#457).
+# This file is repository content : it is cloned with the tree, so a contributor working on
+# their own FORK runs it exactly as the maintainer's session does. Everything this script
+# has to say is about this project's conventions -- an identity to commit under, an issue
+# and pull request rule -- and none of it is addressed to them. Said there anyway, it does
+# real harm rather than none : the sign-off alias puts THE MAINTAINER'S Developer
+# Certificate of Origin attestation on work the maintainer has never seen, silently, on a
+# commit .github/check_sign_off.sh is built to accept because that pairing is the one #439
+# asked it to enforce. CONTRIBUTING.md has always said the opposite to a contributor --
+# "sign your own work, with your own name" -- and this was the one thing in the tree
+# contradicting it (#459).
 #
 # The fork is visible in one command, in either URL form : "https://github.com/<owner>/..."
 # and "git@github.com:<owner>/...". Lower-cased because a clone URL keeps whatever case was
 # typed, while a GitHub login compares case-insensitively.
 #
-# Silence is the default on every other answer, deliberately. A checkout with no origin, or
-# with the remote under another name, loses the reminder rather than handing it to a
-# stranger : CLAUDE.md still carries the rule for the sessions it is addressed to, so what
-# is lost there is the belt and not the braces, where the opposite mistake instructs
-# somebody else's agent
+# Any other answer is treated as "not this repository", deliberately. A checkout with no
+# origin, or with the remote under another name, loses what CLAUDE.md still carries in
+# writing -- the belt, not the braces -- where the opposite default hands a stranger's
+# session an identity and a rule that are not theirs (#457, #459).
+#
+# The login is this repository's maintainer, the same person the trailer below names.
+# tests/cases/11_claude_code_settings.sh checks it against that address rather than trusting
+# the two to stay in step : a wrong login is refused by nothing, GitHub accepts any name that
+# exists, and the work simply lands on a stranger's list.
+#
+# Written as two tests and no "fi" of its own so that the region below closes on the first
+# one at column zero, which is how the suite lifts it out to run it against an origin of its
+# choosing -- the only way to see what a fork is told without owning one
+readonly MAINTAINER_GITHUB_LOGIN="tigerblue77"
+
 ORIGIN_URL=""
 ORIGIN_URL="$(git -C "${CLAUDE_PROJECT_DIR:-.}" remote get-url origin 2> /dev/null)"
 ORIGIN_URL="${ORIGIN_URL,,}"
 
-if [[ "$ORIGIN_URL" == *"/${MAINTAINER_GITHUB_LOGIN,,}/"* ]] ||
-  [[ "$ORIGIN_URL" == *":${MAINTAINER_GITHUB_LOGIN,,}/"* ]]; then
+IS_THIS_REPOSITORY=false
+[[ "$ORIGIN_URL" == *"/${MAINTAINER_GITHUB_LOGIN,,}/"* ]] && IS_THIS_REPOSITORY=true
+[[ "$ORIGIN_URL" == *":${MAINTAINER_GITHUB_LOGIN,,}/"* ]] && IS_THIS_REPOSITORY=true
+readonly IS_THIS_REPOSITORY
+
+if "$IS_THIS_REPOSITORY"; then
+  # The two identities a commit made here carries, set before anything below can exit
+  # early : the container is cached once this has run, so a second session reaches the
+  # "already installed" return and nothing after it.
+  #
+  # A commit has three identity fields, and they answer two different questions. WHO WROTE IT
+  # is the author, and that is the tool : git log, git blame, git shortlog and GitHub's
+  # contributor graph all read that field, so recording the tool anywhere else is not
+  # recording it. WHO CERTIFIES IT is the Signed-off-by trailer -- CONTRIBUTING.md asks for
+  # "a real name and a reachable address" and the DCO's own text is first-person, "I certify
+  # that", which a tool cannot say -- so that one is the maintainer's.
+  #
+  # Collapsing the two is what issue #388 refused to leave standing, and it can be collapsed
+  # in either direction. Left alone, a session writes "Signed-off-by: Claude
+  # <noreply@anthropic.com>", a trailer that satisfies the gate in .github/check_sign_off.sh
+  # while naming nobody who could make the attestation. Setting user.* to the maintainer
+  # repairs that trailer but moves the confusion into the author field, where the log then
+  # says the maintainer typed what a tool wrote (#439). Setting each field to the identity it
+  # is actually asking about is what says both things at once.
+  #
+  # The trailer therefore cannot come from "commit -s", which derives it from user.* -- the
+  # very fields that have to stay the tool's. It is passed explicitly instead, wrapped in an
+  # alias so that it is a command rather than something to remember : a rule that needs a
+  # human to recall it every time is a rule that will be forgotten, which is why #421 put the
+  # identity here in the first place.
+  #
+  # /!\ Do not fold this into "trailer.<token>.key". That config does work -- with the key
+  # spelled exactly "Signed-off-by", git supplies the ": " separator and the gate accepts the
+  # result -- but it fails invisibly when the key is spelled with the separator already in it.
+  # "Signed-off-by: " (trailing space) emits a line that is byte-for-byte identical to a valid
+  # sign-off, that "git log" displays normally and that %(trailers) lists, while a keyed read
+  # of it returns empty : git stored the key WITH the separator, so the gate looks for
+  # "Signed-off-by", finds nothing, and refuses a commit whose message looks perfectly right.
+  # There is no symptom to notice and nothing reports it. The alias carries the whole trailer
+  # as one string instead, where a mistake shows up in the line itself.
+  #
+  # What this does not do is make the certification true by itself : the maintainer certifies
+  # by reviewing and merging. It only stops either field from saying something else meanwhile.
+  # See CONTRIBUTING.md, "Contributions written by an agent".
+  #
+  # Repository-local on purpose -- this is this project's rule, and nothing here should reach
+  # into a configuration the session may share with other work
+  readonly SIGN_OFF_NAME="Tigerblue77"
+  readonly SIGN_OFF_EMAIL="37409593+tigerblue77@users.noreply.github.com"
+  readonly AGENT_NAME="Claude"
+  readonly AGENT_EMAIL="noreply@anthropic.com"
+
+  if ! git -C "${CLAUDE_PROJECT_DIR:-.}" config user.name "$AGENT_NAME" 2> /dev/null ||
+    ! git -C "${CLAUDE_PROJECT_DIR:-.}" config user.email "$AGENT_EMAIL" 2> /dev/null ||
+    ! git -C "${CLAUDE_PROJECT_DIR:-.}" config alias.signoff "commit --trailer \"Signed-off-by: $SIGN_OFF_NAME <$SIGN_OFF_EMAIL>\"" 2> /dev/null; then
+    echo "session-start : could not set the git identity and its sign-off alias, so a commit made here would be authored and signed off by the session's default rather than by the tool and the maintainer"
+  fi
+
+  # The other half of what a session here has to know before it touches GitHub, and the half
+  # there is nothing to configure for : an issue and a pull request are not settings, they
+  # are created through the platform's API with whatever the caller passes, and both fields
+  # are decided at that call. A web session is told by its harness to open a pull request as
+  # a DRAFT, and told by nobody to assign anything, so both end up at a value nobody here
+  # chose -- and the session that would come back to repair them has ended by then.
+  #
+  # Draft is the one with a price on it.
+  # .github/workflows/auto_update_pull_request_branches.yml skips drafts deliberately, so a
+  # draft opened here is the single pull request master's moves never reach : it falls behind
+  # at every merge and owes a hand-pressed "Update branch" at the moment somebody wanted to
+  # merge it, having bought nothing, since it has to be converted before it can be merged at
+  # all. Unassigned is quieter and costs the same way, one list further : what is not on the
+  # maintainer's is not scheduled, it is remembered instead.
+  #
+  # Said at the start of every session rather than left in CLAUDE.md alone, for the reason
+  # the alias above exists : a rule that has to be recalled every time is a rule that gets
+  # forgotten (#448). CLAUDE.md carries the argument, this carries the reminder -- and it is
+  # printed before the early return below, so the second session on a cached container is
+  # told too
   echo "session-start : an issue or pull request opened here is assigned to $MAINTAINER_GITHUB_LOGIN and is never a draft -- see CLAUDE.md, \"Conventions\""
+else
+  # Not silence, but the only sentence that is theirs rather than this repository's. An
+  # agent working on a fork has an obligation of its own -- CONTRIBUTING.md requires a
+  # sign-off on every commit, and .github/check_sign_off.sh refuses the pull request without
+  # one -- and learning it here rather than from a failed run is the same trade this script
+  # already makes by installing shellcheck up front : one CI round trip saved
+  echo "session-start : this is not $MAINTAINER_GITHUB_LOGIN's copy of the repository, so no identity and no issue or pull request convention has been set for it here -- sign your own work, with your own name (CONTRIBUTING.md)"
 fi
 
 # Bounded so that a mirror which accepts a connection and then goes quiet cannot hold the

--- a/tests/cases/11_claude_code_settings.sh
+++ b/tests/cases/11_claude_code_settings.sh
@@ -350,45 +350,81 @@ function test_the_session_start_hook_sets_that_identity_before_it_can_return_ear
   fi
 }
 
-# What the two identities actually produce, run rather than grepped. The trap this exists for
-# is not a missing line but a working-looking one, and the sign-off has a failure mode with no
-# symptom at all : a trailer key spelled "Signed-off-by: ", separator included, emits a line
-# byte-for-byte identical to a valid sign-off, which "git log" shows and %(trailers) lists,
-# while a keyed read of it comes back empty and .github/check_sign_off.sh refuses the commit.
-# Reading the hook's text cannot tell that apart from a correct one, and neither can reading
-# the commit message ; only asking git for the trailer BY KEY can, which is what this does.
-# The alias's quoting can break just as quietly (#439).
+# What the setup a session starts from actually produces, run rather than grepped, and run
+# against an origin the case chooses.
 #
-# git is the thing under test as much as the hook is, which is why this builds a real
+# Two reasons it is run. The identities have a failure mode with no symptom at all : a
+# trailer key spelled "Signed-off-by: ", separator included, emits a line byte-for-byte
+# identical to a valid sign-off, which "git log" shows and %(trailers) lists, while a keyed
+# read comes back empty and .github/check_sign_off.sh refuses the commit. Reading the hook's
+# text cannot tell that apart from a correct one (#439). And WHOSE repository this is, which
+# now decides whether any of it is set at all, is answered by git rather than by the text :
+# reading the lines would prove the check is mentioned and say nothing about what it answers.
+#
+# git is as much the thing under test as the hook is, which is why these build a real
 # repository like tests/cases/18_sign_off.sh does instead of asserting on the text
-function test_the_session_start_hook_authors_as_the_session_and_signs_off_as_the_maintainer() {
-  if [ ! -f "$REPO_ROOT/$SESSION_START_HOOK_SCRIPT" ]; then
-    skip_test "no hook script next to the settings"
-    return 0
-  fi
 
-  if ! command -v git > /dev/null 2>&1; then
-    skip_test "git is not available, and it is what this case exercises"
-    return 0
-  fi
+# The region the hook devotes to this repository's conventions, from the login it measures
+# an origin against to the "fi" at column zero that closes the branch. Everything below it
+# installs packages, which these cases have no business doing.
+# Usage : session_setup_block
+function session_setup_block() {
+  awk '/^readonly MAINTAINER_GITHUB_LOGIN=/ { IS_BLOCK = 1 }
+       IS_BLOCK
+       IS_BLOCK && /^fi$/ { exit }' "$REPO_ROOT/$SESSION_START_HOOK_SCRIPT"
+}
 
-  local SANDBOX
+# Runs that region in a fresh repository whose origin is the URL given -- or with no origin
+# at all, when called with an empty one -- and leaves both what it printed and the
+# repository itself behind for the caller to look at.
+#
+# Two globals rather than a return value, and called directly rather than through "$( )" :
+# a command substitution runs the function in a subshell, where an assignment to either of
+# them would be made and lost. The same boundary CLAUDE.md warns about, arrived at from the
+# test's side.
+#
+# The machine's own git configuration is taken out of the way while it runs. Not tidiness :
+# "url.<base>.insteadOf" rewrites a remote AT READ TIME, so a machine carrying one hands the
+# SSH case the HTTPS form -- the case then passes without ever reaching the branch written
+# for it, and goes on passing once that branch is deleted. Measured, on the first version of
+# these cases. THREE sources, and the third is the one that surprised this file : two are
+# files, silenced by pointing them at /dev/null, and the third is the environment, where
+# GIT_CONFIG_COUNT and its GIT_CONFIG_KEY_n / GIT_CONFIG_VALUE_n pairs are read before
+# either file and are what carries the rewrite in Claude Code on the web. Dropping the count
+# disables them : git reads exactly that many pairs and no more.
+# Usage : run_session_setup_for_origin "https://github.com/owner/repository"
+#         -> sets SESSION_SETUP_OUTPUT and SANDBOX
+function run_session_setup_for_origin() {
+  local -r ORIGIN="$1"
+  local -r HERMETIC=(env -u GIT_CONFIG_COUNT GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null)
+
   SANDBOX=$(mktemp -d)
+  "${HERMETIC[@]}" git init --quiet --initial-branch=master "$SANDBOX"
+  "${HERMETIC[@]}" git -C "$SANDBOX" config commit.gpgsign false
 
-  # Only the identity block is run : everything below it in the hook installs packages,
-  # which this has no business doing. Taken from the first constant to the "fi" closing
-  # the branch that applies them, so a rewrite that moves either end fails here loudly
-  local IDENTITY_BLOCK
-  IDENTITY_BLOCK=$(sed -n '/^readonly SIGN_OFF_NAME/,/^fi$/p' "$REPO_ROOT/$SESSION_START_HOOK_SCRIPT")
-
-  if ! assert_not_empty "$IDENTITY_BLOCK" "the hook should still carry an identity block"; then
-    rm -rf "$SANDBOX"
-    return 1
+  if [ -n "$ORIGIN" ]; then
+    "${HERMETIC[@]}" git -C "$SANDBOX" remote add origin "$ORIGIN"
   fi
 
-  git init --quiet --initial-branch=master "$SANDBOX"
-  git -C "$SANDBOX" config commit.gpgsign false
-  CLAUDE_PROJECT_DIR="$SANDBOX" bash -c "$IDENTITY_BLOCK" > /dev/null 2>&1
+  local -r BLOCK=$(session_setup_block)
+  SESSION_SETUP_OUTPUT=$("${HERMETIC[@]}" CLAUDE_PROJECT_DIR="$SANDBOX" bash -c "$BLOCK" 2>&1)
+}
+
+# Usage : if ! the_session_setup_can_be_run; then skip_test "..."; return 0; fi
+function the_session_setup_can_be_run() {
+  [ -f "$REPO_ROOT/$SESSION_START_HOOK_SCRIPT" ] && command -v git > /dev/null 2>&1
+}
+
+readonly THIS_REPOSITORY_HTTPS="https://github.com/tigerblue77/Dell_iDRAC_fan_controller_Docker.git"
+readonly A_CONTRIBUTORS_FORK="https://github.com/a-contributor/Dell_iDRAC_fan_controller_Docker.git"
+
+function test_the_session_start_hook_authors_as_the_session_and_signs_off_as_the_maintainer() {
+  if ! the_session_setup_can_be_run; then
+    skip_test "no hook script next to the settings, or no git to run it against"
+    return 0
+  fi
+
+  run_session_setup_for_origin "$THIS_REPOSITORY_HTTPS"
 
   printf 'x\n' > "$SANDBOX/file.txt"
   git -C "$SANDBOX" add file.txt
@@ -407,149 +443,122 @@ function test_the_session_start_hook_authors_as_the_session_and_signs_off_as_the
     "the trailer names who certifies it, which is the maintainer"
 }
 
-# The GitHub half of what a session starts with. The identity above governs the commits it
-# makes ; this governs the two things it opens, and neither of them is a setting anywhere :
-# an issue and a pull request are created through the platform's API with whatever the
-# caller passes, so the only place this repository's answer can live is a sentence the
-# session is handed. Two fields, both decided at that call, both left to a default nobody
-# here chose until #448 : assigned, because what is not on the maintainer's list is not
-# scheduled ; not a draft, because
-# .github/workflows/auto_update_pull_request_branches.yml skips drafts, which makes one
-# opened here the single pull request master's moves never reach.
-#
-# A sentence is all it is, which is exactly why it is guarded : nothing downstream refuses a
-# pull request for being a draft, and nothing refuses an assignee for being the wrong
-# person, so a line quietly lost here has no symptom at all.
-#
-# And it is said to the maintainer's sessions only. This file travels with the tree, so a
-# contributor's session on their fork runs the same hook, where neither half holds : GitHub
-# drops "assignees" from a caller without write access, silently, and their draft is what
-# the branch updater's filter exists to leave alone (#457). The cases below run the block
-# against a repository whose origin they choose, which is the only way to see what a fork
-# is told without owning one.
-
-# The announcement, taken from the constant to the "fi" that closes its guard, so a rewrite
-# moving either end fails these loudly rather than quietly running more of the hook than was
-# meant -- everything below it installs packages.
-# Usage : announcement_block
-function announcement_block() {
-  awk '/^readonly MAINTAINER_GITHUB_LOGIN=/ { IS_BLOCK = 1 }
-       IS_BLOCK
-       IS_BLOCK && /^fi$/ { exit }' "$REPO_ROOT/$SESSION_START_HOOK_SCRIPT"
-}
-
-# What the hook prints in a repository whose origin is the URL given, or nothing at all when
-# it is called with none. Run rather than read : the login reaches the message through a
-# variable and the fork check through git itself, and reading the text would prove that both
-# are mentioned while saying nothing about what either one answers.
-# Usage : announcement_for_origin "https://github.com/owner/repository" -> what it says
-function announcement_for_origin() {
-  local -r ORIGIN="$1"
-
-  local SANDBOX
-  SANDBOX=$(mktemp -d)
-
-  # Every git configuration the machine can supply is taken out of the way, here and around
-  # the block below. Not tidiness : "url.<base>.insteadOf" rewrites a remote AT READ TIME,
-  # so a machine carrying one hands the SSH case the HTTPS form -- the case then passes
-  # without ever reaching the branch written for it, and goes on passing once that branch is
-  # deleted. Measured on the first version of these cases, where deleting it changed nothing.
-  #
-  # THREE sources, and the third is the one that surprised this file. Two are files, silenced
-  # by pointing them at /dev/null. The third is the environment : GIT_CONFIG_COUNT with its
-  # GIT_CONFIG_KEY_n / GIT_CONFIG_VALUE_n pairs is configuration git reads before either
-  # file, unaffected by silencing them, and it is what carries the rewrite in Claude Code on
-  # the web -- three pairs, two of them "url.https://github.com/.insteadOf". Dropping the
-  # count is what disables them : git reads exactly that many pairs and no more.
-  #
-  # A sandbox that reads the machine it runs on is not a sandbox, which is the reason
-  # cases/18 gives for building a repository of its own rather than trusting the developer's
-  local -r HERMETIC_GIT=(env -u GIT_CONFIG_COUNT GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null)
-
-  "${HERMETIC_GIT[@]}" git init --quiet --initial-branch=master "$SANDBOX"
-
-  if [ -n "$ORIGIN" ]; then
-    "${HERMETIC_GIT[@]}" git -C "$SANDBOX" remote add origin "$ORIGIN"
-  fi
-
-  local -r BLOCK=$(announcement_block)
-  local OUTPUT
-  OUTPUT=$("${HERMETIC_GIT[@]}" CLAUDE_PROJECT_DIR="$SANDBOX" bash -c "$BLOCK" 2>&1)
-
-  rm -rf "$SANDBOX"
-
-  printf '%s' "$OUTPUT"
-}
-
-# Usage : if ! the_announcement_can_be_run; then skip_test "..."; return 0; fi
-function the_announcement_can_be_run() {
-  [ -f "$REPO_ROOT/$SESSION_START_HOOK_SCRIPT" ] && command -v git > /dev/null 2>&1
-}
-
-function test_the_session_start_hook_states_how_an_issue_or_pull_request_is_opened() {
-  if ! the_announcement_can_be_run; then
-    skip_test "no hook script next to the settings, or no git to read a remote with"
+function test_a_contributors_fork_is_left_without_the_maintainers_identity() {
+  if ! the_session_setup_can_be_run; then
+    skip_test "no hook script next to the settings, or no git to run it against"
     return 0
   fi
 
-  assert_not_empty "$(announcement_block)" \
-    "the hook should still name the login a session opens an issue and a pull request under" || return 1
+  # The case #459 was opened over, and the one that cost something rather than nothing.
+  # Left alone, the alias put the MAINTAINER'S Developer Certificate of Origin attestation
+  # on a contributor's commit -- silently, on work the maintainer has never seen, and on a
+  # commit .github/check_sign_off.sh accepts, that pairing being the one #439 asked it to
+  # enforce. Measured before this was written : the gate returned "All 1 commits carry a
+  # sign-off" and exit 0. Nothing downstream can catch it, the two repositories producing
+  # byte-identical commits, so the only place it can be refused is here
+  run_session_setup_for_origin "$A_CONTRIBUTORS_FORK"
 
-  local -r ANNOUNCEMENT=$(announcement_for_origin "https://github.com/tigerblue77/Dell_iDRAC_fan_controller_Docker.git")
+  # --local, all three. The hook writes repository-local configuration on purpose, and the
+  # machine underneath carries an identity of its own : Claude Code on the web sets a global
+  # "Claude <noreply@anthropic.com>", which a plain read here would return and call a
+  # failure. Measured on the first version of this case, which failed against a hook that
+  # was behaving correctly
+  local -r ALIAS=$(git -C "$SANDBOX" config --local --get alias.signoff)
+  local -r NAME=$(git -C "$SANDBOX" config --local --get user.name)
+  local -r EMAIL=$(git -C "$SANDBOX" config --local --get user.email)
 
-  assert_contains "$ANNOUNCEMENT" "assigned to tigerblue77" \
+  rm -rf "$SANDBOX"
+
+  assert_empty "$ALIAS" \
+    "a fork should not be handed an alias that signs its commits off under somebody else"
+  assert_empty "$NAME" \
+    "nor an author name : a contributor's session keeps the identity it came with"
+  assert_empty "$EMAIL" "nor the address that goes with it"
+}
+
+function test_the_session_start_hook_states_how_an_issue_or_pull_request_is_opened() {
+  if ! the_session_setup_can_be_run; then
+    skip_test "no hook script next to the settings, or no git to run it against"
+    return 0
+  fi
+
+  assert_not_empty "$(session_setup_block)" \
+    "the hook should still carry the region that sets up a session here" || return 1
+
+  run_session_setup_for_origin "$THIS_REPOSITORY_HTTPS"
+  rm -rf "$SANDBOX"
+
+  assert_contains "$SESSION_SETUP_OUTPUT" "assigned to tigerblue77" \
     "the session should be told who an issue and a pull request opened here belong to"
-  assert_contains "$ANNOUNCEMENT" "never a draft" \
+  assert_contains "$SESSION_SETUP_OUTPUT" "never a draft" \
     "the session should be told that a pull request opened here is not a draft, its harness having told it otherwise"
 }
 
 function test_the_ssh_form_of_this_repositorys_origin_is_recognised_too() {
-  if ! the_announcement_can_be_run; then
-    skip_test "no hook script next to the settings, or no git to read a remote with"
+  if ! the_session_setup_can_be_run; then
+    skip_test "no hook script next to the settings, or no git to run it against"
     return 0
   fi
 
   # "git@github.com:owner/repository" carries the owner behind a colon rather than a slash,
   # and a clone URL keeps whatever case was typed while a GitHub login compares
-  # case-insensitively. A check that reads only the HTTPS form, or only lower case, would
-  # leave the maintainer's own session silently unaddressed -- the failure this whole rule
+  # case-insensitively. A check reading only the HTTPS form, or only lower case, would leave
+  # the maintainer's own session unaddressed and unconfigured -- the failure this whole rule
   # exists to prevent, arrived at from the other side
-  local -r ANNOUNCEMENT=$(announcement_for_origin "git@github.com:Tigerblue77/Dell_iDRAC_fan_controller_Docker.git")
+  run_session_setup_for_origin "git@github.com:Tigerblue77/Dell_iDRAC_fan_controller_Docker.git"
 
-  assert_contains "$ANNOUNCEMENT" "assigned to tigerblue77" \
+  local -r ALIAS=$(git -C "$SANDBOX" config --local --get alias.signoff)
+
+  rm -rf "$SANDBOX"
+
+  assert_contains "$SESSION_SETUP_OUTPUT" "assigned to tigerblue77" \
     "an SSH remote, in any case, is still this repository"
+  assert_contains "$ALIAS" "Signed-off-by: Tigerblue77" \
+    "and its session is still the one that signs off under the maintainer"
 }
 
 function test_a_session_on_a_contributors_fork_is_told_none_of_it() {
-  if ! the_announcement_can_be_run; then
-    skip_test "no hook script next to the settings, or no git to read a remote with"
+  if ! the_session_setup_can_be_run; then
+    skip_test "no hook script next to the settings, or no git to run it against"
     return 0
   fi
 
-  # The case #457 was opened over. A contributor forks, opens a session, and this hook runs
-  # for them exactly as it does here : telling them to assign the maintainer is an
-  # instruction GitHub will drop without a word, and telling them not to open a draft
-  # contradicts the one carve-out the branch updater makes for their benefit
-  local -r ANNOUNCEMENT=$(announcement_for_origin "https://github.com/a-contributor/Dell_iDRAC_fan_controller_Docker.git")
+  # GitHub silently drops "assignees" from a caller without write access -- the call
+  # succeeds, the field stays empty, and nothing reports it -- and a contributor's draft is
+  # exactly what the branch updater's filter was written to leave alone (#457). What they
+  # are told instead is the one thing that IS theirs : CONTRIBUTING.md's sign-off, learnt
+  # here rather than from a refused pull request
+  run_session_setup_for_origin "$A_CONTRIBUTORS_FORK"
+  rm -rf "$SANDBOX"
 
-  assert_empty "$ANNOUNCEMENT" \
+  assert_not_contains "$SESSION_SETUP_OUTPUT" "assigned to" \
     "a fork is somebody else's repository, and this rule is not addressed to their session"
+  assert_not_contains "$SESSION_SETUP_OUTPUT" "never a draft" \
+    "nor is the state their own work in progress is entitled to"
+  assert_contains "$SESSION_SETUP_OUTPUT" "sign your own work" \
+    "what they are told is their own obligation, which CONTRIBUTING.md has always stated"
 }
 
-function test_a_checkout_with_no_origin_is_told_nothing_either() {
-  if ! the_announcement_can_be_run; then
-    skip_test "no hook script next to the settings, or no git to read a remote with"
+function test_a_checkout_with_no_origin_is_treated_as_somebody_elses() {
+  if ! the_session_setup_can_be_run; then
+    skip_test "no hook script next to the settings, or no git to run it against"
     return 0
   fi
 
-  # Silence on every answer that is not this repository, including no answer at all. The
-  # trade is deliberate and it is not symmetrical : a checkout with no origin loses a
-  # reminder CLAUDE.md still carries, while the opposite default would hand the rule to
-  # whoever happens to have cloned the tree
-  local -r ANNOUNCEMENT=$(announcement_for_origin "")
+  # Every answer that is not this repository is treated the same way, including no answer at
+  # all. The trade is deliberate and it is not symmetrical : a checkout with no origin loses
+  # what CLAUDE.md still carries in writing, where the opposite default hands an identity
+  # and a rule to whoever happens to have cloned the tree
+  run_session_setup_for_origin ""
 
-  assert_empty "$ANNOUNCEMENT" \
+  local -r ALIAS=$(git -C "$SANDBOX" config --local --get alias.signoff)
+
+  rm -rf "$SANDBOX"
+
+  assert_empty "$ALIAS" \
     "a checkout with no remote is not evidence that this is the maintainer's own"
+  assert_not_contains "$SESSION_SETUP_OUTPUT" "assigned to" \
+    "and it is not told a rule that belongs to a repository it may not be a copy of"
 }
 
 function test_the_session_start_hook_says_that_before_it_can_return_early() {
@@ -591,7 +600,7 @@ function test_the_login_a_session_assigns_to_is_the_maintainer_the_commits_are_s
   #
   # The address is the half with a gate behind it, so it is the one the login is measured
   # against : GitHub's no-reply form is "<id>+<login>@users.noreply.github.com"
-  local -r SIGN_OFF_ADDRESS=$(sed -nE 's/^readonly SIGN_OFF_EMAIL="(.*)"$/\1/p' "$REPO_ROOT/$SESSION_START_HOOK_SCRIPT" | head -1)
+  local -r SIGN_OFF_ADDRESS=$(sed -nE 's/^[[:space:]]*readonly SIGN_OFF_EMAIL="(.*)"$/\1/p' "$REPO_ROOT/$SESSION_START_HOOK_SCRIPT" | head -1)
   local -r ASSIGNEE_LOGIN=$(sed -nE 's/^readonly MAINTAINER_GITHUB_LOGIN="(.*)"$/\1/p' "$REPO_ROOT/$SESSION_START_HOOK_SCRIPT" | head -1)
 
   assert_not_empty "$SIGN_OFF_ADDRESS" "the hook should still name the address a commit is signed off with" || return 1

--- a/tests/cases/18_sign_off.sh
+++ b/tests/cases/18_sign_off.sh
@@ -436,7 +436,11 @@ function test_the_sign_off_gate_knows_the_identities_the_hook_sets() {
   # The gate runs in a workflow that never sources the hook, so the two addresses are
   # written in both files. Held together here rather than left to agree by hand : a
   # change to either that missed the other would not fail, it would quietly stop
-  # matching, and the gate would go green on the very commits it exists to refuse
+  # matching, and the gate would go green on the very commits it exists to refuse.
+  #
+  # Read allowing indentation on the hook's side : those constants sit inside the branch
+  # that only runs where this repository is the origin (#459), and an anchored read of them
+  # is exactly the "quietly stops matching" this case was written about
   local -r HOOK="$REPO_ROOT/.claude/hooks/session-start.sh"
 
   if [ ! -f "$HOOK" ] || [ ! -f "$REPO_ROOT/$SIGN_OFF_SCRIPT" ]; then
@@ -445,7 +449,7 @@ function test_the_sign_off_gate_knows_the_identities_the_hook_sets() {
   fi
 
   local HOOK_AGENT_EMAIL GATE_AGENT_EMAIL
-  HOOK_AGENT_EMAIL=$(sed -n 's/^readonly AGENT_EMAIL="\(.*\)"$/\1/p' "$HOOK")
+  HOOK_AGENT_EMAIL=$(sed -n 's/^[[:space:]]*readonly AGENT_EMAIL="\(.*\)"$/\1/p' "$HOOK")
   GATE_AGENT_EMAIL=$(sed -n 's/^readonly AGENT_EMAIL="\(.*\)"$/\1/p' "$REPO_ROOT/$SIGN_OFF_SCRIPT")
 
   assert_not_empty "$HOOK_AGENT_EMAIL" "the hook should state the address it authors under" || return 1
@@ -453,7 +457,7 @@ function test_the_sign_off_gate_knows_the_identities_the_hook_sets() {
     "the gate has to look for the address the hook actually authors under"
 
   local HOOK_SIGN_OFF_EMAIL GATE_SIGN_OFF_EMAIL
-  HOOK_SIGN_OFF_EMAIL=$(sed -n 's/^readonly SIGN_OFF_EMAIL="\(.*\)"$/\1/p' "$HOOK")
+  HOOK_SIGN_OFF_EMAIL=$(sed -n 's/^[[:space:]]*readonly SIGN_OFF_EMAIL="\(.*\)"$/\1/p' "$HOOK")
   GATE_SIGN_OFF_EMAIL=$(sed -n 's/^readonly SIGN_OFF_EMAIL="\(.*\)"$/\1/p' "$REPO_ROOT/$SIGN_OFF_SCRIPT")
 
   assert_not_empty "$HOOK_SIGN_OFF_EMAIL" "and the address it puts on the trailer" || return 1


### PR DESCRIPTION
Closes #459. Finishes what #458 started : that one stopped the *rule* reaching a fork, this one stops the *identity*.

## Measured before the change

A sandbox whose `origin` is a fork, with the identity block run in it exactly as a session runs it :

```console
$ git config --get alias.signoff
commit --trailer "Signed-off-by: Tigerblue77 <37409593+tigerblue77@users.noreply.github.com>"

$ git log -1 --format='%an <%ae> | %(trailers:key=Signed-off-by,valueonly)'
Claude <noreply@anthropic.com> | Tigerblue77 <37409593+tigerblue77@users.noreply.github.com>

$ bash .github/check_sign_off.sh "$BASE" HEAD
All 1 commits carry a sign-off        # exit 0
```

A contributor's agent putting **the maintainer's DCO attestation** on work the maintainer has never seen. Nothing downstream catches it, and nothing is malfunctioning : the two repositories produce byte-identical commits, and that exact pairing is what #446 taught the gate to accept. `CONTRIBUTING.md` has always said the opposite to a contributor — *"sign your own work, with your own name"* — and the hook was the one thing in the tree contradicting it.

## After

| | The maintainer's own copy | Anything else |
| --- | --- | --- |
| `user.name` / `user.email` | `Claude <noreply@anthropic.com>` (#439) | untouched — the session keeps what it came with |
| `alias.signoff` | the maintainer's trailer | not set |
| the issue and pull request rule | announced (#448) | not mentioned |
| printed | the rule | one line : sign your own work, `CONTRIBUTING.md` |

The failure lands the right way round. A fork session keeps whatever identity it came with — on Claude Code that is the agent's — so `git commit -s` there produces a trailer naming the tool, which the gate **refuses loudly** (#446), instead of accepting a false attestation quietly.

A checkout with no `origin`, or with the remote under another name, is treated as somebody else's : that loses what `CLAUDE.md` still carries in writing — the belt, not the braces — where the opposite default hands an identity to whoever cloned the tree.

## The suite

The cases now lift the whole region out and run it against an origin of their choosing — the only way to see what a fork is told without owning one : this repository in **both** URL forms, a fork, and no origin at all.

**Two traps were paid for while writing them**, both worth recording :

- The first version read the sandbox's identity **without `--local`** and failed against a hook that was behaving correctly. Claude Code on the web carries a global `Claude <noreply@anthropic.com>` of its own, and the plain read was answering with the machine's identity rather than the sandbox's.
- `tests/cases/18_sign_off.sh` reads the two addresses out of this file to hold the gate to them, **anchored at column zero**. It stopped matching the moment the constants were nested — which is exactly the *"quietly stops matching"* that case was written to name, arriving in the case itself.

| Mutation | Cases that fail |
| --- | --- |
| the ownership branch removed, identity set unconditionally | the fork identity case, and the fork announcement case |

## What does not change

- **The maintainer's sessions.** Same author, same trailer, same alias, same announcement.
- **`.github/check_sign_off.sh`** and every case in `tests/cases/18_sign_off.sh`. The gate is right ; it was being fed a commit that should never have been made.
- **History.** Every commit on `master` was made from this repository.

## Checks

- `./tests/run_tests.sh` — 578 cases, 2 829 assertions, green
- Both `shellcheck` invocations CI runs — clean
- `.github/check_sign_off.sh` over `master..HEAD` — accepted
- `docker build` not run : this session's container has no Docker daemon, and no shipped file is touched

---
_Generated by [Claude Code](https://claude.ai/code/session_018bahjop4eoofAGhfnfzQiP)_