### PR TITLE
Answer for the suite's own sandboxes, not for the machine under them (#461)

### DIFF
--- a/tests/cases/11_claude_code_settings.sh
+++ b/tests/cases/11_claude_code_settings.sh
@@ -383,31 +383,27 @@ function session_setup_block() {
 # them would be made and lost. The same boundary CLAUDE.md warns about, arrived at from the
 # test's side.
 #
-# The machine's own git configuration is taken out of the way while it runs. Not tidiness :
-# "url.<base>.insteadOf" rewrites a remote AT READ TIME, so a machine carrying one hands the
-# SSH case the HTTPS form -- the case then passes without ever reaching the branch written
-# for it, and goes on passing once that branch is deleted. Measured, on the first version of
-# these cases. THREE sources, and the third is the one that surprised this file : two are
-# files, silenced by pointing them at /dev/null, and the third is the environment, where
-# GIT_CONFIG_COUNT and its GIT_CONFIG_KEY_n / GIT_CONFIG_VALUE_n pairs are read before
-# either file and are what carries the rewrite in Claude Code on the web. Dropping the count
-# disables them : git reads exactly that many pairs and no more.
+# No git configuration of its own is needed here : the runner takes the machine's out of the
+# way for the whole suite (#461). That is load-bearing rather than tidy, and this file is
+# where it shows first -- "url.<base>.insteadOf" rewrites a remote AT READ TIME, so a machine
+# carrying one hands the SSH case below the HTTPS form, and that case then passes without
+# ever reaching the branch written for it. It did, and it went on passing once that branch
+# was deleted. If the runner ever stops silencing it, this file is the canary.
 # Usage : run_session_setup_for_origin "https://github.com/owner/repository"
 #         -> sets SESSION_SETUP_OUTPUT and SANDBOX
 function run_session_setup_for_origin() {
   local -r ORIGIN="$1"
-  local -r HERMETIC=(env -u GIT_CONFIG_COUNT GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null)
 
   SANDBOX=$(mktemp -d)
-  "${HERMETIC[@]}" git init --quiet --initial-branch=master "$SANDBOX"
-  "${HERMETIC[@]}" git -C "$SANDBOX" config commit.gpgsign false
+  git init --quiet --initial-branch=master "$SANDBOX"
+  git -C "$SANDBOX" config commit.gpgsign false
 
   if [ -n "$ORIGIN" ]; then
-    "${HERMETIC[@]}" git -C "$SANDBOX" remote add origin "$ORIGIN"
+    git -C "$SANDBOX" remote add origin "$ORIGIN"
   fi
 
   local -r BLOCK=$(session_setup_block)
-  SESSION_SETUP_OUTPUT=$("${HERMETIC[@]}" CLAUDE_PROJECT_DIR="$SANDBOX" bash -c "$BLOCK" 2>&1)
+  SESSION_SETUP_OUTPUT=$(CLAUDE_PROJECT_DIR="$SANDBOX" bash -c "$BLOCK" 2>&1)
 }
 
 # Usage : if ! the_session_setup_can_be_run; then skip_test "..."; return 0; fi

--- a/tests/cases/15_test_runner.sh
+++ b/tests/cases/15_test_runner.sh
@@ -205,3 +205,52 @@ PROBE
   assert_contains "$PROBE_OUTPUT" "meets_a_controller_that_will_not_stop" \
     "naming the case it happened in, which is what an unbounded wait could never do"
 }
+
+function test_a_hostile_git_environment_cannot_reach_a_test_case() {
+  if ! command -v git > /dev/null 2>&1; then
+    skip_test "git is not available, and it is what this case hands a hostile environment to"
+    return 0
+  fi
+
+  # cases/11 and cases/18 build a repository under a temporary directory and configure an
+  # identity in it locally, and cases/18 states the promise both rest on : "no test depends
+  # on how the machine running it is set up". A local configuration is not enough to keep
+  # it. GIT_CONFIG_COUNT with its GIT_CONFIG_KEY_n / GIT_CONFIG_VALUE_n pairs is read
+  # before either configuration FILE and outranks a repository's own, so one variable
+  # rewrites what every sandbox in the suite answers -- measured, one key turning two
+  # sign-off cases red against a tree nobody had touched (#461).
+  #
+  # The runner drops the count for this reason. Guarded here end to end rather than by
+  # reading its text : the probe below is handed exactly the environment the promise has to
+  # survive, and asks git the one question a sandbox exists to control
+  local -r PROBE_BODY=$(cat << 'PROBE_CASE'
+() {
+  local SANDBOX
+  SANDBOX=$(mktemp -d)
+  git init --quiet "$SANDBOX"
+  git -C "$SANDBOX" config user.email "the.sandbox@example.org"
+
+  local IDENTITY
+  IDENTITY=$(git -C "$SANDBOX" config --get user.email)
+
+  rm -rf "$SANDBOX"
+
+  assert_equals "the.sandbox@example.org" "$IDENTITY" \
+    "a sandbox should answer with its own identity, whatever the run was started with"
+}
+PROBE_CASE
+  )
+
+  export GIT_CONFIG_COUNT=1
+  export GIT_CONFIG_KEY_0="user.email"
+  export GIT_CONFIG_VALUE_0="the.machine@example.org"
+
+  run_the_runner_on_a_probe_case_file "function ${PROBE_PREFIX}_reads_its_own_sandbox_identity$PROBE_BODY"
+
+  unset GIT_CONFIG_COUNT GIT_CONFIG_KEY_0 GIT_CONFIG_VALUE_0
+
+  assert_equals 0 "$PROBE_EXIT_CODE" \
+    "a run started with git configuration in its environment should still answer for its own sandboxes"
+  assert_not_contains "$PROBE_OUTPUT" "the.machine@example.org" \
+    "the environment's value should not have reached the case at all"
+}

--- a/tests/cases/18_sign_off.sh
+++ b/tests/cases/18_sign_off.sh
@@ -16,6 +16,13 @@
 # The sandbox is a repository of its own under a temporary directory, with its own
 # identity configured locally, so nothing here reads or writes the contributor's
 # git configuration and no test depends on how the machine running it is set up.
+#
+# The local identity is not what makes that last clause true, and for a long time it was
+# not true at all : git reads GIT_CONFIG_COUNT and its GIT_CONFIG_KEY_n pairs out of the
+# ENVIRONMENT, before either configuration file and above a repository's own, so one
+# variable turned two cases here red against a tree nobody had touched. The runner drops
+# that count for the whole suite, and cases/15 hands a probe run the hostile environment
+# to prove it (#461).
 
 readonly SIGN_OFF_SCRIPT=".github/check_sign_off.sh"
 readonly SIGN_OFF_WORKFLOW=".github/workflows/sign_off.yml"

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -23,6 +23,34 @@ REPO_ROOT="$(cd "$TESTS_DIRECTORY/.." && pwd)"
 readonly TESTS_DIRECTORY REPO_ROOT
 export TESTS_DIRECTORY REPO_ROOT
 
+# The git the cases get answers for their own sandbox, and not for the machine the run
+# happens to be on. cases/11 and cases/18 each build a repository under a temporary
+# directory and configure an identity in it locally, which is not enough on its own :
+# git has THREE sources above that, and only two of them are files.
+#
+# The third is the environment. GIT_CONFIG_COUNT with its GIT_CONFIG_KEY_n /
+# GIT_CONFIG_VALUE_n pairs is read before either file and outranks a repository's local
+# config, so a single variable rewrites what those sandboxes answer. Measured, on this
+# tree, with nothing else changed :
+#
+#   ./tests/run_tests.sh -f sign_off                                  17 passed
+#   GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=user.email \
+#     GIT_CONFIG_VALUE_0=noreply@anthropic.com ./tests/run_tests.sh -f sign_off
+#                                                                     2 failed, 15 passed
+#
+# Not hypothetical : Claude Code on the web sets three such pairs, two of them
+# "url.https://github.com/.insteadOf", which is what made a case asserting the SSH form of
+# a remote pass without ever reaching the branch written for it -- and go on passing once
+# that branch was deleted (#461).
+#
+# Here rather than in the cases, because the runner is the one place every case goes
+# through, and it calls git nowhere itself : this costs the run nothing and covers the
+# cases not yet written. Dropping the count is what disables the pairs -- git reads
+# exactly that many and no more
+export GIT_CONFIG_GLOBAL=/dev/null
+export GIT_CONFIG_SYSTEM=/dev/null
+unset GIT_CONFIG_COUNT
+
 FILTER=""
 LIST_ONLY=false
 TAP_OUTPUT=false


### PR DESCRIPTION
Closes #461.

## The promise, and the measurement that breaks it

`tests/cases/18_sign_off.sh` states what the git cases rest on :

> The sandbox is a repository of its own under a temporary directory, with its own identity configured locally, so nothing here reads or writes the contributor's git configuration and **no test depends on how the machine running it is set up.**

```console
$ ./tests/run_tests.sh -f sign_off
17 test cases passed (39 assertions)

$ GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=user.email GIT_CONFIG_VALUE_0=noreply@anthropic.com \
    ./tests/run_tests.sh -f sign_off
  fail a branch whose commits are all signed is accepted
  fail a merge commit is not asked for a sign off
2 test cases failed, 15 passed (39 assertions)
```

One variable, two green cases red, against a tree nobody touched.

## Why a local identity is not enough

`GIT_CONFIG_COUNT` with its `GIT_CONFIG_KEY_n` / `GIT_CONFIG_VALUE_n` pairs is configuration supplied through the **environment** — read before either configuration file, and above a repository's own :

```console
$ git config user.name "Identité locale du bac à sable"
$ git config --get user.name
Identité locale du bac à sable
$ GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=user.name GIT_CONFIG_VALUE_0="Injectée par l'environnement" \
    git config --get user.name
Injectée par l'environnement
```

Pointing `GIT_CONFIG_GLOBAL` / `GIT_CONFIG_SYSTEM` at `/dev/null` does not touch it : those are the two files, this is a third source above both.

## It had already been paid for twice

Claude Code on the web sets three such pairs, two of them `url.https://github.com/.insteadOf`, plus a global identity of its own. Both landed on real cases while #459 was being written :

- a case asserting the **SSH form** of a remote passed **without ever reaching the branch written for it** — the rewrite handed it the HTTPS form — and went on passing once that branch was deleted. A guard watching nothing, reported green ;
- a case reading a sandbox's identity **without `--local`** failed against a hook that was behaving correctly.

Both were caught by mutation-testing the guard rather than by the suite. That is luck, not method.

## The change

| Source | Silenced by |
| --- | --- |
| system file | `GIT_CONFIG_SYSTEM=/dev/null` |
| global file | `GIT_CONFIG_GLOBAL=/dev/null` |
| the environment | dropping `GIT_CONFIG_COUNT` — git reads exactly that many pairs and no more |

In the runner, because it is the one place every case goes through and it calls `git` nowhere itself : the run pays nothing, and cases not yet written are covered.

- **`cases/11` stops carrying its own neutralisation** and becomes the canary : its SSH case fails the moment the runner stops doing this.
- **`cases/15` guards it end to end** rather than by reading the runner's text — it hands a probe run exactly the hostile environment and asserts the probe still answers for its own sandbox.
- **`cases/18`** now says what makes its promise true.

| Mutation | Case that fails |
| --- | --- |
| the three lines removed from the runner | `a hostile git environment cannot reach a test case` |

## Checks

Re-run after the rebase onto `master` that followed #460's merge — the branch now carries this change alone :

- `./tests/run_tests.sh` — 579 cases, 2 831 assertions, green
- The same, **run under the hostile environment above** — 579 cases, green
- Both `shellcheck` invocations CI runs — clean
- `.github/check_sign_off.sh` over `master..HEAD` — accepted