### PR TITLE
Say which of the three commands cannot run where most sessions run (#463)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,16 @@ second one silences are the suite's own shape rather than defects, and they are 
 in `.github/workflows/shellcheck.yml` beside the step that carries them ; they never
 reach `.shellcheckrc`, so the scripts above keep the full lint (issue #432).
 
+**The last of the three needs a Docker daemon, and Claude Code on the web has none** —
+the binary is on the PATH, so it looks runnable until it answers "cannot connect to the
+Docker daemon". Say so rather than reporting a build that did not happen : piped into
+`tail` or `head` it exits 0 whatever docker did, the status being the pipe's last command
+(#463). Nothing is lost by leaving it out where it cannot run — `.github/workflows/tests.yml`
+builds the image on every pull request, in the job that then runs the suite inside it — but
+it costs a CI round trip, which is the cost the SessionStart hook installs `shellcheck` to
+avoid. So the first two are what a session owes on any change ; the build is worth finding
+a daemon for when the change touches the `Dockerfile` or a script the image ships.
+
 ## Conventions
 
 - **Sign off every commit** with **`git signoff`**, never `git commit -s`. A commit without

--- a/tests/cases/10_shell_scripts.sh
+++ b/tests/cases/10_shell_scripts.sh
@@ -957,6 +957,31 @@ function test_every_repository_path_claude_md_names_exists() {
   shopt -u nullglob
 }
 
+function test_the_workflow_claude_md_says_builds_the_image_still_builds_it() {
+  if [ ! -f "$REPO_ROOT/CLAUDE.md" ] || [ ! -f "$REPO_ROOT/.github/workflows/tests.yml" ]; then
+    skip_test "no CLAUDE.md and no .github/workflows next to the scripts"
+    return 0
+  fi
+
+  # CLAUDE.md lists three commands to run before pushing and says the third of them, the
+  # image build, needs a Docker daemon that Claude Code on the web does not have. What
+  # makes leaving it out safe there is the Tests workflow building the image on every pull
+  # request, so a broken Dockerfile is still caught before a merge (#463).
+  #
+  # Two documents, one fact, and the permission rests entirely on it. If that step ever
+  # goes, CLAUDE.md would be telling every session it may skip the only build there is --
+  # the quiet kind of wrong this file exists to refuse
+  local -r TESTS_WORKFLOW=$(cat "$REPO_ROOT/.github/workflows/tests.yml")
+
+  assert_contains "$(cat "$REPO_ROOT/CLAUDE.md")" "builds the image on every pull request" \
+    "CLAUDE.md should still say what covers the build a session cannot run" || return 1
+
+  # Not anchored at a line end : "[[ =~ ]]" matches against the whole file as one string,
+  # where "$" is its last character rather than the end of the line the command sits on
+  assert_matches "$TESTS_WORKFLOW" 'run: docker build ' \
+    "the Tests workflow should still build the image, which is what makes that true"
+}
+
 function test_the_workflow_claude_md_gives_as_its_reason_still_skips_drafts() {
   if [ ! -f "$REPO_ROOT/CLAUDE.md" ] || [ ! -f "$REPO_ROOT/.github/workflows/auto_update_pull_request_branches.yml" ]; then
     skip_test "no CLAUDE.md and no .github/workflows next to the scripts"


### PR DESCRIPTION
Closes #463.

## The instruction, and where it cannot be followed

`CLAUDE.md` lists three commands and says **"Run all three before pushing."** The third is the image build, and Claude Code on the web has no Docker daemon :

```console
$ docker info
failed to connect to the docker API at unix:///var/run/docker.sock; ... no such file or directory
```

The binary is on the PATH, so it looks runnable right up to the point where it is not.

## Why a line rather than a shrug

Three outcomes, and the third is the one that actually happened while #459 was being written :

1. the session spends a detour discovering the daemon is absent ;
2. it drops a third of what the document asked for, without saying so ;
3. **it reports a build that never ran** — `docker build … | tail -15` exits 0 whatever docker did, the status being the pipe's last command. The transcript said "exit code 0" and the build had not started.

That is the *confidently wrong* session #381 was opened over, arriving through the document rather than through the code.

## What is now said

- The last command needs a daemon, and what it answers where there is none.
- Say so rather than reporting a build that did not happen, with the pipe trap named.
- Nothing is lost by omitting it there : `.github/workflows/tests.yml` builds the image on **every pull request**, in the job that then runs the suite inside it.
- What it costs is a CI round trip — the cost the SessionStart hook installs `shellcheck` to avoid — so the build is worth finding a daemon for when the change touches the `Dockerfile` or a script the image ships.

## The guard

`cases/10` holds that permission to the fact it rests on : if the build step ever leaves the Tests workflow, `CLAUDE.md` would be telling every session it may skip the only build there is.

| Mutation | Case that fails |
| --- | --- |
| the workflow's `docker build` step replaced | `the workflow claude md says builds the image still builds it` |

The case carries a note of its own : `[[ =~ ]]` matches the whole file as **one string**, so a `$` anchors to its last character rather than to the end of the line the command sits on — the first version failed against a workflow that was building the image perfectly well.

## Checks

- `./tests/run_tests.sh` — 580 cases, 2 834 assertions, green (1 of them new)
- Both `shellcheck` invocations CI runs — clean
- `.github/check_sign_off.sh` over `master..HEAD` — accepted
- `docker build` — not run, for the reason this pull request documents

---
_Generated by [Claude Code](https://claude.ai/code/session_018bahjop4eoofAGhfnfzQiP)_