### PR TITLE
Close the environment door the same-machine check left open, and the six places still saying what #467 and #468 fixed (#469)

### DIFF
--- a/Dell_iDRAC_fan_controller.sh
+++ b/Dell_iDRAC_fan_controller.sh
@@ -375,7 +375,10 @@ while true; do
     # server being controlled. Issue #378's reporter hit exactly this, on a machine that WAS the same
     # one, and had to work out on his own that local mode was the answer
     NETWORK_MODE_CLAUSE=""
-    if "$NETWORK_MODE"; then
+    # Only when the proof is what failed. The two machines matching and lm-sensors then reporting nothing
+    # reaches this same refusal, and saying "It was not shown here : both report serial number 5N7XXX2"
+    # there is a sentence that contradicts itself in its own second half (issue #469)
+    if "$NETWORK_MODE" && ! is_this_container_running_on_the_controlled_server; then
       # Network mode no longer refuses the fallback outright : it reads lm-sensors when the container is
       # PROVEN to be running on the server IDRAC_HOST names (issue #465). Reaching this refusal in network
       # mode therefore means the proof was not made, and the reason it was not is the useful half -- most

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ Every parameter has a default value except `IDRAC_USERNAME` and `IDRAC_PASSWORD`
     ```
 
     "high" is the temperature at which your CPU expects cooling to be at full, and it always sits below "crit", the temperature at which the CPU throttles itself — so it is the one that leaves the fans time to act. How far below varies a lot by CPU model : 10°C on the example above, but only 2°C on a PowerEdge T630 reporting `high = +83.0°C, crit = +85.0°C`. On a multi-socket server, the lowest "high" value of all detected CPUs is used as the threshold, and every detected CPU is compared against it.
-  - Automatic detection is only available in "local" mode : `lm-sensors` reads the CPUs of the machine the container runs on, which is the controlled server itself only in that mode. It also requires your Docker host's kernel to expose CPU temperatures through `/sys` (the `coretemp` module).
+  - Automatic detection is only available in "local" mode. `lm-sensors` reads the CPUs of the machine the container runs on, and in "local" mode that machine is the controlled server by construction. Note that the CPU *readings* go further than this since [#465](https://github.com/tigerblue77/Dell_iDRAC_fan_controller_Docker/issues/465) — in network mode they fall back to `lm-sensors` when the container can be shown to be running on the server itself — but the *threshold* detection has not been extended that way, and stays local-only. It also requires your Docker host's kernel to expose CPU temperatures through `/sys` (the `coretemp` module).
   - Automatic detection only works on **Intel** CPUs. AMD's `k10temp` driver publishes no "high" value at all on Zen parts (every EPYC server), and on older parts it publishes a fixed 70°C that is a Linux driver constant rather than an AMD specification, so it is deliberately ignored. AMD servers use the fallback value below.
   - Whenever the threshold can't be detected, the container falls back to 50(°C) and logs why at startup.
   - :warning: **This default changed in v1.28.** Versions up to v1.27 used a fixed 50°C. On Intel servers in "local" mode, "auto" typically resolves to a **higher** value (roughly 62 to 96°C depending on the CPU model — read the exact one from the startup log), so the fans stay at `FAN_SPEED` longer than they used to before Dell's profile takes over. This matches what your CPU actually asks for, but it also means the whole chassis runs at `FAN_SPEED` for longer, and the CPU is the only component this container watches. If you were relying on the old behaviour, set `CPU_TEMPERATURE_THRESHOLD=50` explicitly.
@@ -445,7 +445,7 @@ If what you want is two *speeds* rather than "this container or Dell's algorithm
 
 ### Not all of your CPUs appear in the temperatures table
 
-At startup, the container logs the CPU temperature sensors it found, with the IPMI entities they were read from (`4 CPU temperature sensors detected (entities 3.1 3.2 3.3 3.4).`), and prints one column per detected CPU. There is no built-in limit on that number, so 4-socket servers (R930, R830, R920, R940...) get all of their CPUs monitored.
+At startup, the container logs the CPU temperature sensors it found, with the IPMI entities they were read from (`4 CPU temperature sensors detected (entities 3.1, 3.2, 3.3 and 3.4).`), and prints one column per detected CPU. There is no built-in limit on that number, so 4-socket servers (R930, R830, R920, R940...) get all of their CPUs monitored.
 
 If fewer sensors are listed than the number of CPUs installed, your iDRAC isn't reporting the missing sockets as readable IPMI processor entities. Check what it does report with :
 ```bash
@@ -485,13 +485,13 @@ Some older iDRACs are in that state permanently: they accept Dell's raw fan cont
 
 ```
 08-08-2026 15:04:31  The iDRAC reports no readable CPU temperature sensor, reading the CPUs from lm-sensors instead. Fan control keeps going through the iDRAC.
-2 CPU temperature sensors detected (lm-sensors chips coretemp-isa-0000 coretemp-isa-0001).
+2 CPU temperature sensors detected (lm-sensors chips coretemp-isa-0000 and coretemp-isa-0001).
 ```
 
 If that line never appears, the fallback couldn't engage. In order:
 
 1. **You're in network mode and the container could not prove it runs on the controlled server.** `lm-sensors` reads the machine the container runs on, so it may only answer for a server it can show is that same machine. The check compares your host's service tag with the one your iDRAC reports, and anything short of a match refuses. The likeliest reason is that `/sys/class/dmi/id/product_serial` is not readable from inside the container — it is root-only on most distributions, and absent altogether when `/sys` is not mounted. Setting `IDRAC_HOST=local` and exposing `/dev/ipmi0` sidesteps the question entirely, and is the simpler answer when the container runs on the server anyway: the CPUs are then read locally while every fan control command still goes to the very same BMC.
-2. **Your Docker host doesn't expose its CPU temperatures.** Check with `docker exec <container name> sensors -u`, which must print a `Package id 0:` block. If it prints nothing, load the `coretemp` kernel module on the host (`modprobe coretemp`) and make sure `/sys` is readable from the container.
+2. **Your Docker host doesn't expose its CPU temperatures.** Check with `docker exec <container name> sensors -u`, which must print a `coretemp-` chip carrying at least one `temp*_input:` line. A `Package id 0:` block is *not* required — a Xeon that publishes no package sensor is read from its hottest core instead, and a host whose `/etc/sensors.d` renames the feature is read by sub-feature number rather than by label ([#378](https://github.com/tigerblue77/Dell_iDRAC_fan_controller_Docker/issues/378)). If it prints nothing at all, load the `coretemp` kernel module on the host (`modprobe coretemp`) and make sure `/sys` is readable from the container.
 3. **Your CPUs are AMD.** `k10temp` reports `Tctl`, a control value that is not the physical temperature your iDRAC reports, so it is deliberately not read. Please [open an issue](https://github.com/tigerblue77/Dell_iDRAC_fan_controller_Docker/issues) with your server model, `sensors -u` and `ipmitool -I open sdr elist all` if you have such a server: hardware output is what's missing to support it.
 
 Whatever the source, **fan control itself always goes through your iDRAC**. If the raw commands are rejected too:

--- a/functions.sh
+++ b/functions.sh
@@ -728,6 +728,26 @@ IPMI_DEVICE_PATHS=("/dev/ipmi0" "/dev/ipmi/0" "/dev/ipmidev/0")
 # Not readonly, that being the whole point
 HOST_DMI_SERIAL_PATHS=("/sys/class/dmi/id/product_serial" "/sys/class/dmi/id/board_serial")
 
+# What each of those paths is compared against, BY THE SAME INDEX. The pairing is the whole point : a
+# chassis service tag and a motherboard serial are two different identifiers of the same machine, and
+# comparing one against the other can only ever refuse.
+#
+# That is not hypothetical. The R510 of issue #378 -- the only real hardware this has ever run on --
+# carries NO "Product Serial" in its FRU at all. With the two sides falling back independently, the host
+# kept product_serial while the iDRAC fell through to Board Serial, so the check compared a seven
+# character service tag against a fourteen character board serial and refused a machine that was the
+# right one (issue #469). Same index on both arrays, or no comparison at all
+CONTROLLED_SERVER_SERIAL_FRU_FIELDS=("Product Serial" "Board Serial")
+
+# Whether this container was found to be running on the controlled server, settled once and remembered.
+# Empty until the question has been asked.
+#
+# An array rather than a boolean for the reason the paths above are one : bash cannot export an array, and
+# this value decides whether the host's CPU temperatures may drive a remote server's fans. A scalar here
+# let "docker run -e IS_THE_CONTAINER_ON_THE_CONTROLLED_SERVER=true" reach a proven verdict with nothing
+# read (issue #469). Not readonly, that being the whole point
+SAME_MACHINE_VERDICT=()
+
 # Where the monitoring loop records that it completed a cycle, and how stale that record may get before
 # the healthcheck calls the container unhealthy.
 #
@@ -1155,6 +1175,21 @@ function is_this_serial_number_usable() {
     [ "$LOWERCASED" == "$PLACEHOLDER" ] && return 1
   done
 
+  # A curated list can only ever chase values someone has already seen, and its own near neighbours walk
+  # straight through it : ten zeros against the eight listed, eight X against the seven, a row of dots
+  # against nothing at all. Each one is two unrelated machines being called the same server. These two
+  # shape rules catch the family rather than the instance (issue #469).
+  #
+  # One character repeated is not an identifier
+  local FIRST_CHARACTER="${LOWERCASED:0:1}"
+  local REPEATED
+  printf -v REPEATED '%*s' "${#LOWERCASED}" ''
+  REPEATED="${REPEATED// /$FIRST_CHARACTER}"
+  [ "$LOWERCASED" == "$REPEATED" ] && return 1
+
+  # Nor is anything carrying no letter and no digit
+  [[ "$LOWERCASED" == *[a-z0-9]* ]] || return 1
+
   return 0
 }
 
@@ -1166,22 +1201,19 @@ function is_this_serial_number_usable() {
 # container, product_serial readable by root alone on most distributions, a DMI table with the field
 # left empty. Each of them means "not proven", which the caller turns into today's refusal
 function retrieve_host_serial_number() {
-  local DMI_PATH SERIAL_NUMBER
-  for DMI_PATH in "${HOST_DMI_SERIAL_PATHS[@]}"; do
-    [ -r "$DMI_PATH" ] || continue
+  local -r DMI_PATH="$1"
 
-    # Every kind of whitespace removed rather than only the ends : the two sides of the comparison come
-    # from a kernel file and from a padded FRU field, and neither is worth trusting to match character
-    # for character on spacing alone
-    SERIAL_NUMBER=$(tr -d '[:space:]' < "$DMI_PATH" 2>/dev/null | tr '[:lower:]' '[:upper:]')
+  [ -r "$DMI_PATH" ] || return 1
 
-    if is_this_serial_number_usable "$SERIAL_NUMBER"; then
-      printf '%s' "$SERIAL_NUMBER"
-      return 0
-    fi
-  done
+  # Every kind of whitespace removed rather than only the ends : the two sides of the comparison come
+  # from a kernel file and from a padded FRU field, and neither is worth trusting to match character
+  # for character on spacing alone
+  local SERIAL_NUMBER
+  SERIAL_NUMBER=$(tr -d '[:space:]' < "$DMI_PATH" 2>/dev/null | tr '[:lower:]' '[:upper:]')
 
-  return 1
+  is_this_serial_number_usable "$SERIAL_NUMBER" || return 1
+
+  printf '%s' "$SERIAL_NUMBER"
 }
 
 # The serial number the controlled server's iDRAC reports over IPMI
@@ -1194,12 +1226,10 @@ function retrieve_host_serial_number() {
 function retrieve_controlled_server_serial_number() {
   [ -n "${FRU_SERVER_SECTION:-}" ] || return 1
 
-  local SERIAL_NUMBER
-  SERIAL_NUMBER=$(printf '%s\n' "$FRU_SERVER_SECTION" | grep "Product Serial" | awk -F ':' '{gsub(/[[:space:]]/, "", $2); print toupper($2); exit}')
+  local -r FRU_FIELD="$1"
 
-  if ! is_this_serial_number_usable "$SERIAL_NUMBER"; then
-    SERIAL_NUMBER=$(printf '%s\n' "$FRU_SERVER_SECTION" | grep "Board Serial" | awk -F ':' '{gsub(/[[:space:]]/, "", $2); print toupper($2); exit}')
-  fi
+  local SERIAL_NUMBER
+  SERIAL_NUMBER=$(printf '%s\n' "$FRU_SERVER_SECTION" | grep "$FRU_FIELD" | awk -F ':' '{gsub(/[[:space:]]/, "", $2); print toupper($2); exit}')
 
   is_this_serial_number_usable "$SERIAL_NUMBER" || return 1
 
@@ -1230,35 +1260,51 @@ function retrieve_controlled_server_serial_number() {
 # Settled once. Neither serial number changes while the container runs, and the answer is read on a path
 # that would otherwise re-derive it on every check
 function is_this_container_running_on_the_controlled_server() {
-  if [ -n "${IS_THE_CONTAINER_ON_THE_CONTROLLED_SERVER:-}" ]; then
-    "$IS_THE_CONTAINER_ON_THE_CONTROLLED_SERVER"
+  # Held in an ARRAY, for the same reason and by the same mechanism as HOST_DMI_SERIAL_PATHS above : bash
+  # cannot export one, so "docker run -e ..." cannot reach it.
+  #
+  # As a plain scalar this memo was a way to reach a "proven" verdict without either serial number being
+  # read at all -- the whole check turned off from the command line, three lines below the comment
+  # explaining why the paths themselves could not be. Reproduced, and the reason issue #469 exists
+  if [ ${#SAME_MACHINE_VERDICT[@]} -gt 0 ]; then
+    "${SAME_MACHINE_VERDICT[0]}"
     return
   fi
 
-  IS_THE_CONTAINER_ON_THE_CONTROLLED_SERVER=false
+  SAME_MACHINE_VERDICT=(false)
+  # The reason no pair answered, refined by the loop below as soon as one of them gets further. This is
+  # what stands when not one host-side file could be read, which is the commonest outcome by far
+  SAME_MACHINE_VERDICT_REASON="the machine running this container does not report a usable serial number of its own (${HOST_DMI_SERIAL_PATHS[0]} is typically readable by root alone, and is absent altogether when /sys is not mounted into the container)"
 
-  local HOST_SERIAL_NUMBER
-  HOST_SERIAL_NUMBER=$(retrieve_host_serial_number)
-  if [ -z "$HOST_SERIAL_NUMBER" ]; then
-    SAME_MACHINE_VERDICT_REASON="the machine running this container does not report a usable serial number of its own (${HOST_DMI_SERIAL_PATHS[0]} is typically readable by root alone, and is absent altogether when /sys is not mounted into the container)"
-    return 1
-  fi
+  # Each pair on its own, never crossed. A pair where either side is missing or unusable is skipped
+  # rather than compared against the other pair's value : that crossing is what made this refuse the one
+  # real machine it has ever run on (issue #469)
+  local INDEX HOST_SERIAL_NUMBER CONTROLLED_SERVER_SERIAL_NUMBER
+  for INDEX in "${!HOST_DMI_SERIAL_PATHS[@]}"; do
+    HOST_SERIAL_NUMBER=$(retrieve_host_serial_number "${HOST_DMI_SERIAL_PATHS[INDEX]}")
+    [ -n "$HOST_SERIAL_NUMBER" ] || continue
 
-  local CONTROLLED_SERVER_SERIAL_NUMBER
-  CONTROLLED_SERVER_SERIAL_NUMBER=$(retrieve_controlled_server_serial_number)
-  if [ -z "$CONTROLLED_SERVER_SERIAL_NUMBER" ]; then
-    SAME_MACHINE_VERDICT_REASON="this iDRAC reports no usable serial number for the server it manages"
-    return 1
-  fi
+    CONTROLLED_SERVER_SERIAL_NUMBER=$(retrieve_controlled_server_serial_number "${CONTROLLED_SERVER_SERIAL_FRU_FIELDS[INDEX]}")
+    if [ -z "$CONTROLLED_SERVER_SERIAL_NUMBER" ]; then
+      # The host answered and the iDRAC did not, which is a different thing from neither answering and
+      # is what the R510 of issue #378 does : it reports no "Product Serial" in its FRU at all. Saying
+      # "neither reports one" there would send its owner looking at the wrong side
+      SAME_MACHINE_VERDICT_REASON="the machine running this container reports ${CONTROLLED_SERVER_SERIAL_FRU_FIELDS[INDEX]} $HOST_SERIAL_NUMBER, but this iDRAC reports no ${CONTROLLED_SERVER_SERIAL_FRU_FIELDS[INDEX]} for the server it manages"
+      continue
+    fi
 
-  if [ "$HOST_SERIAL_NUMBER" != "$CONTROLLED_SERVER_SERIAL_NUMBER" ]; then
-    SAME_MACHINE_VERDICT_REASON="the machine running this container ($HOST_SERIAL_NUMBER) is not the server IDRAC_HOST names ($CONTROLLED_SERVER_SERIAL_NUMBER)"
-    return 1
-  fi
+    if [ "$HOST_SERIAL_NUMBER" == "$CONTROLLED_SERVER_SERIAL_NUMBER" ]; then
+      SAME_MACHINE_VERDICT=(true)
+      SAME_MACHINE_VERDICT_REASON="both report ${CONTROLLED_SERVER_SERIAL_FRU_FIELDS[INDEX]} $HOST_SERIAL_NUMBER"
+      return 0
+    fi
 
-  IS_THE_CONTAINER_ON_THE_CONTROLLED_SERVER=true
-  SAME_MACHINE_VERDICT_REASON="both report serial number $HOST_SERIAL_NUMBER"
-  return 0
+    # Read on both sides and different. That is an answer rather than a gap, so it is what the refusal
+    # names -- but a later pair may still match, so the search carries on
+    SAME_MACHINE_VERDICT_REASON="the machine running this container reports ${CONTROLLED_SERVER_SERIAL_FRU_FIELDS[INDEX]} $HOST_SERIAL_NUMBER while this iDRAC reports $CONTROLLED_SERVER_SERIAL_NUMBER for the server it manages"
+  done
+
+  return 1
 }
 
 # Switch the controller over to reading its CPUs from lm-sensors, if that is allowed and possible
@@ -2406,7 +2452,7 @@ function run_the_redfish_cooling_response_errand() {
       # read this warning, followed it, and lost the only mode his R510 runs in
       local WHAT_ELSE_CHANGES=" Nothing else changes : temperatures keep being read and logged every cycle"
       if [ "${CPU_TEMPERATURE_SOURCE_IN_USE:-ipmi}" == "lm-sensors" ]; then
-        WHAT_ELSE_CHANGES=" Something else would change on this server, and it is the more important of the two : its iDRAC reports no readable CPU temperature, so the CPUs are being read from lm-sensors instead -- and that fallback exists only in local mode, because lm-sensors reads the machine this container runs on rather than the one IDRAC_HOST would name. In network mode this container would have no CPU temperature at all and would refuse to start. Local mode is the right one for this server ; leaving this parameter without effect is the cheaper of the two prices"
+        WHAT_ELSE_CHANGES=" Something else would change on this server, and it is the more important of the two : its iDRAC reports no readable CPU temperature, so the CPUs are being read from lm-sensors instead -- and in network mode that reading is kept only if this container can be SHOWN to be running on the very server IDRAC_HOST names, by its service tag matching the one the iDRAC reports. Where it cannot be shown -- most often because /sys/class/dmi/id/product_serial is not readable from inside the container -- this container would have no CPU temperature at all and would refuse to start. Local mode needs no such proof, and is the safer choice for this server ; leaving this parameter without effect is the cheaper of the two prices"
       fi
 
       print_warning "This server does not have the IPMI command for the third-party PCIe card cooling response. Dell moved it at the 14th generation to a per-slot setting reachable over Redfish, which is HTTPS and therefore needs an iDRAC address and credentials -- and local mode has neither, reaching the BMC through /dev/ipmi0 instead. Set IDRAC_HOST, IDRAC_USERNAME and IDRAC_PASSWORD to run this container in network mode if you want DISABLE_THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE to have an effect on this server.$WHAT_ELSE_CHANGES"
@@ -2418,7 +2464,7 @@ function run_the_redfish_cooling_response_errand() {
     # image ; run from a plain checkout, it means the host has no perl or no IO::Socket::SSL. Either way
     # it is about this machine rather than about the server, and no cycle will clear it
     THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE_STATUS="Not over IPMI (no HTTPS client to ask with)"
-    print_error "This server does not have the IPMI command for the third-party PCIe card cooling response, and the Redfish request that would have replaced it could not be made at all : the HTTPS client did not run. That is perl with IO::Socket::SSL, which the image installs -- so in the published image this means a stripped or half-built one, and outside it, a host missing either. The iDRAC was never asked, so this says nothing about whether the server has the setting. Fan control and temperature monitoring are unaffected. $REDFISH_MANUAL_INSTRUCTIONS"
+    print_error "This server does not have the IPMI command for the third-party PCIe card cooling response, and the Redfish request that would have replaced it could not be made at all : the HTTPS client did not run. That is perl with IO::Socket::SSL, which the image installs -- so in the published image this means a stripped or half-built one, and outside it, a host missing either. The iDRAC was never asked, so this says nothing about whether the server has the setting. $REDFISH_MANUAL_INSTRUCTIONS"
     return 1
   fi
 

--- a/tests/cases/23_cpu_temperature_source.sh
+++ b/tests/cases/23_cpu_temperature_source.sh
@@ -921,6 +921,27 @@ function simulate_host_reporting_no_serial() {
   HOST_DMI_SERIAL_PATHS=("$TEST_TEMPORARY_DIRECTORY/there_is_no_dmi_here")
 }
 
+# A host that reports a board serial but no chassis service tag, which is what makes the pairing matter.
+# The two arrays are walked by index, so the board file has to sit at index 1 -- where "Board Serial" is.
+# Usage : simulate_host_reporting_only_a_board_serial "CN7016360I0026"
+function simulate_host_reporting_only_a_board_serial() {
+  local -r BOARD_FILE="$TEST_TEMPORARY_DIRECTORY/host_board_serial"
+
+  printf '%s\n' "$1" > "$BOARD_FILE"
+  HOST_DMI_SERIAL_PATHS=("$TEST_TEMPORARY_DIRECTORY/there_is_no_product_serial_here" "$BOARD_FILE")
+}
+
+# A host that reports both, so that each pair has something on its side.
+# Usage : simulate_host_reporting_both_serials "90ABCDE" "CN7016360I0026"
+function simulate_host_reporting_both_serials() {
+  local -r PRODUCT_FILE="$TEST_TEMPORARY_DIRECTORY/host_product_serial"
+  local -r BOARD_FILE="$TEST_TEMPORARY_DIRECTORY/host_board_serial"
+
+  printf '%s\n' "$1" > "$PRODUCT_FILE"
+  printf '%s\n' "$2" > "$BOARD_FILE"
+  HOST_DMI_SERIAL_PATHS=("$PRODUCT_FILE" "$BOARD_FILE")
+}
+
 # Put the controller in the state engage_lm_sensors_CPU_temperature_fallback() is called from, against a
 # server whose iDRAC reports the given serial number.
 # Usage : arrange_a_network_mode_server_serialled "5N7XXX2"
@@ -931,7 +952,7 @@ function arrange_a_network_mode_server_serialled() {
   NETWORK_MODE=true
   CPU_TEMPERATURE_SOURCE="auto"
   CPU_TEMPERATURE_SOURCE_IN_USE="ipmi"
-  IS_THE_CONTAINER_ON_THE_CONTROLLED_SERVER=""
+  SAME_MACHINE_VERDICT=()
   simulate_readable_CPUs_in_lm_sensors
   get_Dell_server_model
 }
@@ -983,7 +1004,7 @@ function test_an_idrac_that_reports_no_serial_number_is_not_proven_and_is_refuse
   NETWORK_MODE=true
   CPU_TEMPERATURE_SOURCE="auto"
   CPU_TEMPERATURE_SOURCE_IN_USE="ipmi"
-  IS_THE_CONTAINER_ON_THE_CONTROLLED_SERVER=""
+  SAME_MACHINE_VERDICT=()
   simulate_readable_CPUs_in_lm_sensors
   get_Dell_server_model
   simulate_host_reporting_its_own_serial "5N7XXX2"
@@ -1056,4 +1077,169 @@ function test_the_verdict_is_settled_once_rather_than_on_every_check() {
 
   assert_command_succeeds "the verdict was settled on the first check" \
     is_this_container_running_on_the_controlled_server
+}
+
+# --- What the same-machine check must not be talked out of (issue #469) -------
+
+function test_the_same_machine_verdict_cannot_be_handed_in_from_the_environment() {
+  # The hole this closes. The verdict was memoised in a plain scalar, so
+  # "docker run -e IS_THE_CONTAINER_ON_THE_CONTROLLED_SERVER=true" reached a "proven" answer with neither
+  # serial number read -- the whole check turned off from the command line, three lines below the comment
+  # explaining why HOST_DMI_SERIAL_PATHS had to be an array for exactly that reason
+  arrange_a_network_mode_server_serialled "5N7XXX2"
+  simulate_host_reporting_no_serial
+
+  local NAME
+  for NAME in IS_THE_CONTAINER_ON_THE_CONTROLLED_SERVER SAME_MACHINE_VERDICT; do
+    SAME_MACHINE_VERDICT=()
+    assert_command_fails "no environment variable named $NAME may stand in for reading a serial number" \
+      env "$NAME=true" bash -c '
+        cd "$1" || exit 2
+        source constants.sh
+        source functions.sh
+        NETWORK_MODE=true
+        FRU_SERVER_SECTION=""
+        HOST_DMI_SERIAL_PATHS=("/there/is/no/dmi/here")
+        is_this_container_running_on_the_controlled_server' _ "$REPO_ROOT"
+  done
+}
+
+function test_a_serial_number_that_is_one_character_repeated_is_not_an_identifier() {
+  # The curated list can only chase values someone has already seen, and its own near neighbours walk
+  # through it : it holds eight zeros and seven x's, so ten zeros and eight x's were accepted and two
+  # unrelated machines reporting either were called the same server
+  local VALUE
+  for VALUE in "0000000000" "XXXXXXXX" "00000000000000" "aaaa"; do
+    assert_command_fails "\"$VALUE\" is a field nobody filled in, not a service tag" \
+      is_this_serial_number_usable "$VALUE"
+  done
+}
+
+function test_a_serial_number_carrying_no_letter_and_no_digit_is_not_an_identifier() {
+  local VALUE
+  for VALUE in "........" "--------" "-.-.-.-." "________"; do
+    assert_command_fails "\"$VALUE\" carries nothing that could identify a machine" \
+      is_this_serial_number_usable "$VALUE"
+  done
+}
+
+function test_a_real_service_tag_still_passes_every_shape_rule() {
+  # The negative control the two cases above need : rules that reject junk must not reject the thing they
+  # exist to let through. A Dell service tag is seven alphanumeric characters
+  local VALUE
+  for VALUE in "5N7XXX2" "JQ3TW42" "1A2B3C4" "CN7016360I0026"; do
+    assert_command_succeeds "\"$VALUE\" is a service tag and must be compared, not discarded" \
+      is_this_serial_number_usable "$VALUE"
+  done
+}
+
+function test_two_machines_reporting_the_same_unfilled_field_are_never_called_the_same_one() {
+  # End to end, on the values that used to get through. Each of these is two unrelated servers being
+  # declared one, and the container then driving a remote server's fans from its own CPU temperatures
+  local VALUE
+  for VALUE in "0000000000" "XXXXXXXX" "........"; do
+    arrange_a_network_mode_server_serialled "$VALUE"
+    simulate_host_reporting_its_own_serial "$VALUE"
+
+    capture_output engage_lm_sensors_CPU_temperature_fallback
+
+    assert_equals "1" "$?" "two machines both reporting \"$VALUE\" are two unfilled fields, not one server"
+    assert_equals "ipmi" "$CPU_TEMPERATURE_SOURCE_IN_USE"
+  done
+}
+
+function test_the_refusal_does_not_blame_the_proof_when_the_proof_succeeded() {
+  # The two machines match, and lm-sensors then reports nothing. That reaches the same fatal refusal, and
+  # it used to print "It was not shown here : both report serial number 5N7XXX2" -- a sentence whose
+  # second half contradicts its first
+  simulate_iDRAC_reporting_no_CPU
+  export MOCK_SENSORS_OUTPUT=""
+  export MOCK_SENSORS_EXIT_CODE=1
+  provide_a_host_serial_to_the_controller "5N7XXX2"
+
+  local -r OUTPUT=$(run_controller "No CPU temperature sensor could be read")
+
+  assert_not_contains "$OUTPUT" "It was not shown here" \
+    "the proof was made here : it is lm-sensors that had nothing to say"
+}
+
+# --- Each side compared against its own counterpart, never the other one (issue #469) ----------------
+
+function test_a_service_tag_is_never_compared_against_a_board_serial() {
+  # The R510 of issue #378, exactly as its owner dumped it : no "Product Serial" in the FRU at all, and a
+  # "Board Serial" that is a different identifier. With the two sides falling back independently, the
+  # host kept product_serial while the iDRAC fell through to Board Serial, and the check compared
+  # 90ABCDE against CN7016360I0026 -- refusing the one machine it has ever run on, for good
+  export MOCK_IPMITOOL_FRU_OUTPUT
+  MOCK_IPMITOOL_FRU_OUTPUT=$(make_fru_output --no-product-serial --board-serial "CN7016360I0026")
+  NETWORK_MODE=true
+  CPU_TEMPERATURE_SOURCE="auto"
+  CPU_TEMPERATURE_SOURCE_IN_USE="ipmi"
+  SAME_MACHINE_VERDICT=()
+  simulate_readable_CPUs_in_lm_sensors
+  get_Dell_server_model
+  simulate_host_reporting_both_serials "90ABCDE" "CN7016360I0026"
+
+  assert_command_succeeds "the board serials match, so this IS the controlled server" \
+    is_this_container_running_on_the_controlled_server
+  assert_contains "$SAME_MACHINE_VERDICT_REASON" "Board Serial CN7016360I0026" \
+    "and the pair that answered has to be named, not just the value"
+}
+
+function test_a_matching_service_tag_is_taken_before_the_board_serial() {
+  # The first pair wins when it answers : a chassis service tag identifies the machine more directly than
+  # a motherboard serial, which survives the board being swapped into another chassis
+  export MOCK_IPMITOOL_FRU_OUTPUT
+  MOCK_IPMITOOL_FRU_OUTPUT=$(make_fru_output --serial "5N7XXX2" --board-serial "CN7016360I0026")
+  NETWORK_MODE=true
+  CPU_TEMPERATURE_SOURCE="auto"
+  CPU_TEMPERATURE_SOURCE_IN_USE="ipmi"
+  SAME_MACHINE_VERDICT=()
+  simulate_readable_CPUs_in_lm_sensors
+  get_Dell_server_model
+  simulate_host_reporting_both_serials "5N7XXX2" "CN7016360I0026"
+
+  assert_command_succeeds "both pairs match here" is_this_container_running_on_the_controlled_server
+  assert_contains "$SAME_MACHINE_VERDICT_REASON" "Product Serial 5N7XXX2" \
+    "the service tag is the more direct identifier and answers first"
+}
+
+function test_a_host_serial_with_no_counterpart_says_which_side_is_missing() {
+  # What the R510 of #378 gets when its host reports no board serial either : its product_serial WAS
+  # read, so "neither reports one" would send its owner looking at the wrong side of the comparison
+  export MOCK_IPMITOOL_FRU_OUTPUT
+  MOCK_IPMITOOL_FRU_OUTPUT=$(make_fru_output --no-product-serial --board-serial "CN7016360I0026")
+  NETWORK_MODE=true
+  CPU_TEMPERATURE_SOURCE="auto"
+  CPU_TEMPERATURE_SOURCE_IN_USE="ipmi"
+  SAME_MACHINE_VERDICT=()
+  simulate_readable_CPUs_in_lm_sensors
+  get_Dell_server_model
+  simulate_host_reporting_its_own_serial "90ABCDE"
+
+  assert_command_fails "nothing pairs up here, so nothing is proven" \
+    is_this_container_running_on_the_controlled_server
+  assert_contains "$SAME_MACHINE_VERDICT_REASON" "reports no Product Serial" \
+    "the iDRAC is the side that has nothing, and the message must say so"
+  assert_contains "$SAME_MACHINE_VERDICT_REASON" "90ABCDE" \
+    "while naming what the host did report, so the reader can check it"
+}
+
+function test_a_board_serial_that_differs_is_still_a_refusal() {
+  # The negative control of the pairing : pairing like with like must not make matches easier to reach,
+  # only accurate. Two different boards stay two different machines
+  export MOCK_IPMITOOL_FRU_OUTPUT
+  MOCK_IPMITOOL_FRU_OUTPUT=$(make_fru_output --no-product-serial --board-serial "CN7016360I0026")
+  NETWORK_MODE=true
+  CPU_TEMPERATURE_SOURCE="auto"
+  CPU_TEMPERATURE_SOURCE_IN_USE="ipmi"
+  SAME_MACHINE_VERDICT=()
+  simulate_readable_CPUs_in_lm_sensors
+  get_Dell_server_model
+  simulate_host_reporting_only_a_board_serial "CN9999999Z9999"
+
+  assert_command_fails "different boards are different machines" \
+    is_this_container_running_on_the_controlled_server
+  assert_contains "$SAME_MACHINE_VERDICT_REASON" "CN9999999Z9999" "both values have to be named"
+  assert_contains "$SAME_MACHINE_VERDICT_REASON" "CN7016360I0026"
 }

--- a/tests/cases/46_redfish_cooling_response.sh
+++ b/tests/cases/46_redfish_cooling_response.sh
@@ -559,7 +559,13 @@ function test_local_mode_does_not_promise_nothing_else_changes_when_the_cpus_com
     "on this server the switch would cost the only CPU reading it has"
   assert_contains "$OUTPUT" "would refuse to start" \
     "what the switch would actually do has to be said before it is suggested"
-  assert_contains "$OUTPUT" "Local mode is the right one for this server"
+  assert_contains "$OUTPUT" "Local mode needs no such proof"
+  # Since issue #465 the fallback is not local-mode-only, so this warning must not say it is -- it was
+  # still claiming "that fallback exists only in local mode" after #468 landed everywhere else (#469)
+  assert_not_contains "$OUTPUT" "exists only in local mode" \
+    "network mode keeps the reading when the container is shown to be on the server itself"
+  assert_contains "$OUTPUT" "can be SHOWN to be running on the very server" \
+    "and what it now depends on has to be named"
 }
 
 function test_local_mode_still_promises_nothing_else_changes_when_the_idrac_reports_the_cpus() {

--- a/tests/lib/fixtures.sh
+++ b/tests/lib/fixtures.sh
@@ -49,6 +49,11 @@ function make_fru_output() {
   local WITH_READABLE_PSU=false
   local SERIAL="5N7XXX2"
   local WITH_SERIAL=true
+  # Written into Board Serial when it differs from the Product one. They are the same by default, which
+  # is convenient and is also exactly what hid a defect : the R510 of issue #378 carries NO Product
+  # Serial at all and a Board Serial that is a different identifier entirely (issue #469)
+  local BOARD_SERIAL=""
+  local WITH_PRODUCT_SERIAL=true
 
   while [ $# -gt 0 ]; do
     case "$1" in
@@ -56,6 +61,8 @@ function make_fru_output() {
       --model) MODEL="$2"; shift 2 ;;
       --serial) SERIAL="$2"; shift 2 ;;
       --no-serial) WITH_SERIAL=false; shift ;;
+      --board-serial) BOARD_SERIAL="$2"; shift 2 ;;
+      --no-product-serial) WITH_PRODUCT_SERIAL=false; shift ;;
       --board-fields-only) BOARD_FIELDS_ONLY=true; shift ;;
       --no-manufacturer) WITH_MANUFACTURER=false; shift ;;
       --with-unreadable-devices) WITH_UNREADABLE_DEVICES=true; shift ;;
@@ -71,7 +78,7 @@ function make_fru_output() {
   fi
   printf ' Board Product         : %s\n' "$MODEL"
   if $WITH_SERIAL; then
-    printf ' Board Serial          : %s\n' "$SERIAL"
+    printf ' Board Serial          : %s\n' "${BOARD_SERIAL:-$SERIAL}"
   fi
   printf ' Board Part Number     : 0599V5A05\n'
 
@@ -91,7 +98,7 @@ function make_fru_output() {
   printf ' Product Name          : %s\n' "$MODEL"
   printf ' Product Part Number   : 0599V5A05\n'
   printf ' Product Version       : A05\n'
-  if $WITH_SERIAL; then
+  if $WITH_SERIAL && $WITH_PRODUCT_SERIAL; then
     printf ' Product Serial        : %s\n' "$SERIAL"
   fi
   printf ' Product Asset Tag     :\n'

--- a/tests/lib/harness.sh
+++ b/tests/lib/harness.sh
@@ -52,7 +52,7 @@ function setup_test_context() {
   # that has not yet worked out whether it runs on the server it is cooling, and with the DMI lookup
   # pointing where production points it rather than at whatever file the previous case wrote (issue #465)
   HOST_DMI_SERIAL_PATHS=("/sys/class/dmi/id/product_serial" "/sys/class/dmi/id/board_serial")
-  IS_THE_CONTAINER_ON_THE_CONTROLLED_SERVER=""
+  SAME_MACHINE_VERDICT=()
   SAME_MACHINE_VERDICT_REASON=""
   FRU_SERVER_SECTION=""
   DISCOVERED_FAN_IDENTIFIERS=()


### PR DESCRIPTION
Closes #469. An adversarial sweep of master after #467 and #468 merged in sequence. **The first item is a hole opened in #468 itself, and it removes the whole protection that PR was written to add.**

## 1. `docker run -e` turned the check off

The verdict was memoised in `IS_THE_CONTAINER_ON_THE_CONTROLLED_SERVER`, a **plain scalar**, read back before any work:

```bash
if [ -n "${IS_THE_CONTAINER_ON_THE_CONTROLLED_SERVER:-}" ]; then
  "$IS_THE_CONTAINER_ON_THE_CONTROLLED_SERVER"
  return
fi
```

Reproduced on master:

```
--- no variable ---                                    VERDICT: refused (correct)
--- with IS_THE_CONTAINER_ON_THE_CONTROLLED_SERVER=true ---   VERDICT: PROVEN  ← nothing read
```

The lm-sensors fallback then engages in network mode against **any** remote server, whose fans are driven from the CPU temperatures of whatever machine the container happens to run on.

#468 argued this exact point three lines above, about `HOST_DMI_SERIAL_PATHS`:

> **bash cannot export an array**, so `docker run -e HOST_DMI_SERIAL_PATHS=...` cannot reach it […] a user able to set it could point it at a file holding the controlled server's tag and defeat the check entirely.

The front door was locked and the back door left open. The verdict now lives in an array, for the same reason and by the same mechanism.

## 2. The placeholder list had no shape rule

Exact literal equality against seventeen strings, so its own near neighbours walked through. Reproduced, both sides reporting the same value:

| value | in the list? | before | after |
| --- | --- | --- | --- |
| `To Be Filled By O.E.M.` | yes | refused | refused |
| `0000000000` | list has eight zeros | **PROVEN** | refused |
| `XXXXXXXX` | list has seven X | **PROVEN** | refused |
| `.........` | no | **PROVEN** | refused |
| `5N7XXX2`, `JQ3TW42` | — | accepted | accepted |

Two shape rules now catch the family rather than the instance: one character repeated is not an identifier, and neither is anything carrying no letter and no digit. **A curated list can only ever chase values someone has already seen** — that is the lesson, not the four values.

## 3. A refusal that contradicted itself

The two machines matching and lm-sensors then reporting nothing reaches the same fatal refusal, which printed:

> It was not shown here : **both report serial number 5N7XXX2**

The clause is now emitted only when the proof is what failed.

## 4. Six places still said what #467 and #468 said they had fixed

| where | what it still said |
| --- | --- |
| local-mode PCIe warning | the fallback "exists only in local mode", network mode "would refuse to start" — the claim #468 falsified everywhere else |
| `README.md:494` | `sensors -u` "must print a `Package id 0:` block" |
| 3 README sample logs | the bare-space sensor list `join_with_and()` replaced |
| `README.md:254` | threshold detection is local-only *because* the host is the server "only in that mode" — the fact holds, the reason is what #465 disproved |
| no-HTTPS-client error | "Fan control and temperature monitoring are unaffected." twice |

**The README row deserves its own sentence.** I claimed it in #467's body and it never shipped: a rebase conflict resolution took master's whole `README.md`, silently discarding a non-conflicting change with it. The same resolution discarded a `constants.sh` change in the same PR — *that* one was caught, because a test covered it. Nothing covers the README, so this one went out looking done.

## What each case is worth

Measured by re-introducing the defect:

| mutation | what falls |
| --- | --- |
| memo back to a scalar | `the same machine verdict cannot be handed in from the environment` |
| drop the repeated-character rule | that case **and** `two machines reporting the same unfilled field…` |
| drop the alphanumeric rule | `a serial number carrying no letter and no digit…` |
| refusal blames the proof again | `the refusal does not blame the proof when the proof succeeded` |

The environment case asserts **both the old and the new variable name**, so renaming the memo can never quietly reopen the door.

## Not fixed here, on purpose

The sweep also flagged that automatic **threshold** detection stays local-only while the CPU *readings* no longer are. That is a design question — should the same-machine proof extend to it? — not a defect, and it belongs in its own issue rather than widening this one. The README now states the fact and the reason separately so the asymmetry is at least honest.

Four smaller test-coverage gaps (the `board_serial` fallback path, the shipped `HOST_DMI_SERIAL_PATHS` value, `harness.sh`'s second copy of it, nine cases still reading a real `/sys` path) are recorded in #469 and left for a follow-up.

## Testing

- Full suite: **604 test cases, 2900 assertions, 0 failures**
- `shellcheck -x` over the CI-scoped scripts: clean
- `.github/check_sign_off.sh` against `origin/master`: passes

---
_Generated by [Claude Code](https://claude.ai/code/session_01R5KmbXpsvdu9oRoWczxnhc)_