### PR TITLE
Stop the suite reading the machine it runs on, and pin the lookup production ships (#471)

### DIFF
--- a/tests/cases/23_cpu_temperature_source.sh
+++ b/tests/cases/23_cpu_temperature_source.sh
@@ -1243,3 +1243,54 @@ function test_a_board_serial_that_differs_is_still_a_refusal() {
   assert_contains "$SAME_MACHINE_VERDICT_REASON" "CN9999999Z9999" "both values have to be named"
   assert_contains "$SAME_MACHINE_VERDICT_REASON" "CN7016360I0026"
 }
+
+# --- The shipped lookup itself, which the harness no longer stands in for (issue #471) ---------------
+
+function test_the_shipped_dmi_lookup_is_the_one_the_kernel_uses() {
+  # Read out of functions.sh rather than out of the running shell : the harness resets the array to files
+  # that do not exist, precisely so no case reads the machine the suite runs on -- which leaves the value
+  # production actually ships watched by nothing. A typo here costs no test and no error, only a feature
+  # that silently always refuses
+  local -r SHIPPED=$(grep -E '^HOST_DMI_SERIAL_PATHS=' "$REPO_ROOT/functions.sh")
+
+  assert_contains "$SHIPPED" '"/sys/class/dmi/id/product_serial"' \
+    "the chassis service tag is where the kernel puts it"
+  assert_contains "$SHIPPED" '"/sys/class/dmi/id/board_serial"' \
+    "and so is the board serial the second pair needs"
+}
+
+function test_every_host_dmi_path_has_a_fru_field_to_be_compared_against() {
+  # The two arrays are walked by index, so a value added to one and forgotten in the other is either an
+  # unreachable path or an out-of-range read that compares against nothing. Neither fails loudly.
+  #
+  # Counted from the SHIPPED declarations, not from the running shell : the harness resets the paths to
+  # files of its own, so comparing what it set against the field list would only ever test the harness
+  local -r SHIPPED_PATH_COUNT=$(grep -cE '"/sys/class/dmi/id/[a-z_]+"' <<< "$(grep -E '^HOST_DMI_SERIAL_PATHS=' "$REPO_ROOT/functions.sh" | tr ' ' '\n')")
+  local -r SHIPPED_FIELD_COUNT=$(grep -cE '"[A-Za-z]+ Serial"' <<< "$(grep -E '^CONTROLLED_SERVER_SERIAL_FRU_FIELDS=' "$REPO_ROOT/functions.sh" | sed 's/" "/"\n"/g')")
+
+  assert_equals "$SHIPPED_PATH_COUNT" "$SHIPPED_FIELD_COUNT" \
+    "one FRU field per host path, or the pairing means nothing"
+  assert_not_equals "0" "$SHIPPED_PATH_COUNT" "and the count has to be read, not silently zero on both sides"
+}
+
+function test_the_shipped_pairing_matches_like_with_like() {
+  # The defect issue #469 found, pinned on the shipped order rather than on behaviour : a product serial
+  # answers a Product Serial and a board serial answers a Board Serial. Crossed, they can only refuse
+  local -r SHIPPED_FIELDS=$(grep -E '^CONTROLLED_SERVER_SERIAL_FRU_FIELDS=' "$REPO_ROOT/functions.sh")
+
+  assert_matches "$SHIPPED_FIELDS" '"Product Serial".*"Board Serial"' \
+    "the FRU fields must be in the same order as the host paths they answer"
+}
+
+function test_a_controller_can_be_given_either_side_of_the_pairing() {
+  # The board pair is the one the R510 of issue #378 needs, its FRU carrying no Product Serial at all.
+  # Before this the controller helper handed over a one-element array, so that pair could not be reached
+  # through run_controller() and only the direct-call cases could exercise it
+  provide_a_host_serial_to_the_controller "" "CN7016360I0026"
+
+  local -r THROWAWAY=$(cat "$CONTROLLER_WORKING_DIRECTORY/functions.sh")
+
+  assert_contains "$THROWAWAY" "controller_host_board_serial" "the board file has to reach the controller"
+  assert_contains "$THROWAWAY" "controller_host_product_serial" \
+    "and the product one has to be there too, so the two arrays stay the same length"
+}

--- a/tests/lib/harness.sh
+++ b/tests/lib/harness.sh
@@ -49,9 +49,22 @@ function setup_test_context() {
   # Same, for the fan identifiers a refused broadcast selector makes the controller discover : a test
   # starts against a server nothing has been probed on yet
   # Same, for the same-machine verdict and the two values it rests on : a test starts against a container
-  # that has not yet worked out whether it runs on the server it is cooling, and with the DMI lookup
-  # pointing where production points it rather than at whatever file the previous case wrote (issue #465)
-  HOST_DMI_SERIAL_PATHS=("/sys/class/dmi/id/product_serial" "/sys/class/dmi/id/board_serial")
+  # that has not yet worked out whether it runs on the server it is cooling (issue #465).
+  #
+  # The lookup is reset to files that DO NOT EXIST rather than to where production points it. Pointing it
+  # at the real /sys made every case that reaches the check read the machine the suite happens to be
+  # running on, and that machine differs : the suite runs twice on every pull request, and only the run
+  # inside the Docker image is root, so only that one can read product_serial. A case written without a
+  # deliberate override therefore passed on the runner and failed in the image -- which is exactly what
+  # happened, and what this default removes rather than leaving for the next case to rediscover.
+  #
+  # "Not readable" is also the honest default : it is what a container gets on most hosts, and it makes
+  # the same-machine check refuse, which is the behaviour every case that does not care about it expects.
+  # A case that DOES care says so with simulate_host_reporting_* or provide_a_host_serial_to_the_controller.
+  #
+  # The shipped value is not left untested by this : test_the_shipped_dmi_lookup_is_the_one_the_kernel_uses
+  # pins it, reading it out of functions.sh rather than out of this reset (issue #471)
+  HOST_DMI_SERIAL_PATHS=("$TEST_TEMPORARY_DIRECTORY/no_host_product_serial" "$TEST_TEMPORARY_DIRECTORY/no_host_board_serial")
   SAME_MACHINE_VERDICT=()
   SAME_MACHINE_VERDICT_REASON=""
   FRU_SERVER_SECTION=""
@@ -204,16 +217,25 @@ function provide_local_ipmi_device() {
 # runs as root -- so the same case saw an unreadable DMI on one and a readable one on the other, and
 # passed on the runner while failing in the image (issue #465).
 #
-# Usage : provide_a_host_serial_to_the_controller "5N7XXX2"   # or with no argument, an unreadable one
+# Usage : provide_a_host_serial_to_the_controller "5N7XXX2"              # a product serial only
+#         provide_a_host_serial_to_the_controller "" "CN7016360I0026"    # a board serial only
+#         provide_a_host_serial_to_the_controller                        # neither, i.e. an unreadable DMI
 function provide_a_host_serial_to_the_controller() {
-  local -r DMI_FILE="$TEST_TEMPORARY_DIRECTORY/controller_host_dmi_serial"
+  local -r PRODUCT_FILE="$TEST_TEMPORARY_DIRECTORY/controller_host_product_serial"
+  local -r BOARD_FILE="$TEST_TEMPORARY_DIRECTORY/controller_host_board_serial"
 
-  rm -f "$DMI_FILE"
-  if [ $# -gt 0 ]; then
-    printf '%s\n' "$1" > "$DMI_FILE"
+  # Both files, always, so the array the controller gets has the same length as the FRU field list it is
+  # walked against. A shorter one would leave the board pair unreachable through run_controller(), which
+  # is the pair the only real hardware this has ever run on actually needs (issue #471)
+  rm -f "$PRODUCT_FILE" "$BOARD_FILE"
+  if [ $# -gt 0 ] && [ -n "$1" ]; then
+    printf '%s\n' "$1" > "$PRODUCT_FILE"
+  fi
+  if [ $# -gt 1 ] && [ -n "$2" ]; then
+    printf '%s\n' "$2" > "$BOARD_FILE"
   fi
 
-  build_throwaway_controller_repository "HOST_DMI_SERIAL_PATHS=(\"$DMI_FILE\")"
+  build_throwaway_controller_repository "HOST_DMI_SERIAL_PATHS=(\"$PRODUCT_FILE\" \"$BOARD_FILE\")"
 }
 
 # A COMPLETE line of the temperature table. The controller prints a line with


### PR DESCRIPTION
Closes #471. The four coverage gaps #469 recorded and #470 deliberately left out. **Tests and harness only — no production code changes.**

## The harness reset the lookup to the real `/sys`

```bash
HOST_DMI_SERIAL_PATHS=("/sys/class/dmi/id/product_serial" "/sys/class/dmi/id/board_serial")
```

So every case reaching the same-machine check without a deliberate override read **the machine the suite happens to be running on** — and that machine differs between the two runs every PR gets. Only the Docker-image run is root, so only that one can read `product_serial`.

This already happened during #468: a case passed on the runner and failed inside the image, on nothing else. It was fixed **in that one case**; the default that produced it stayed.

**Measured before changing anything.** Pointing the reset at absent files left the suite fully green — 608 cases, 0 failures. Nothing depended on the real `/sys`, which is exactly when a latent hazard is cheapest to remove.

"Not readable" is also the honest default: it is what a container gets on most hosts, and it makes the check refuse — what every case not concerned with it already expects.

## Which left the shipped value watched by nothing

With the harness no longer standing in for it, `HOST_DMI_SERIAL_PATHS` as production ships it was asserted nowhere. A typo — `produkt_serial` — costs no test, no error, no log line. It costs a feature that **silently always refuses**, which from the outside is indistinguishable from hardware that simply does not match.

The pairing #469 established needs the same protection. The two arrays are walked by index, so **order matters as much as content**: swap them and every comparison crosses a service tag with a board serial — the exact defect #469 found, reachable again by a one-line edit nothing would catch.

Both are now read out of `functions.sh` and asserted: the paths, the FRU fields, their equal length, and their order.

## The controller helper could not reach the board pair

`provide_a_host_serial_to_the_controller()` handed over a **one-element** array, so index 1 — where `Board Serial` is compared — was unreachable through `run_controller()`.

That is the pair the only real hardware this has ever run on actually needs: the R510 of #378 carries no `Product Serial` in its FRU at all. The pair that matters most in practice was the one the end-to-end helper could not express. It now hands over both files, always, so the array keeps the same length as the field list it is walked against.

## What each case is worth

Measured by re-introducing the defect:

| mutation | what falls |
| --- | --- |
| typo in a shipped path (`produkt_serial`) | `the shipped dmi lookup is the one the kernel uses` |
| a forgotten FRU field (arrays of different length) | `every host dmi path has a fru field…` **and** `the shipped pairing matches like with like` |
| the pairing reversed | `the shipped pairing matches like with like` |
| the helper back to a one-element array | `a controller can be given either side of the pairing` |

One of these four cases was wrong when I first wrote it — it compared the array the *harness* had just reset against the shipped field list, so it was testing the harness rather than the code. Both sides are now read from the source. Recorded because it is the same mistake in miniature that this PR exists to remove.

## Not included

`harness.sh` keeping a second hand-written copy of the array — the fourth gap — stops being a problem once the reset no longer restates the shipped value. There is nothing left to drift.

## Testing

- Full suite: **612 test cases, 2917 assertions, 0 failures**
- Both `shellcheck` invocations CI runs (production scripts, and the suite with its five silenced codes): clean
- `.github/check_sign_off.sh` against `origin/master`: passes

---
_Generated by [Claude Code](https://claude.ai/code/session_01R5KmbXpsvdu9oRoWczxnhc)_