### PR TITLE
Stop calling the lm-sensors fallback local-mode-only, and guard the claim (#475)

### DIFF
--- a/Dell_iDRAC_fan_controller.sh
+++ b/Dell_iDRAC_fan_controller.sh
@@ -151,7 +151,16 @@ if [[ "${CPU_TEMPERATURE_THRESHOLD,,}" == "auto" ]]; then
     # Deferred rather than moved wholesale : an explicitly configured threshold is still validated right
     # here, so a typo is refused before this container touches any hardware (issue #473)
     CPU_TEMPERATURE_THRESHOLD=$FALLBACK_CPU_TEMPERATURE_THRESHOLD
-    CPU_TEMPERATURE_THRESHOLD_SOURCE=" (fallback value, automatic detection is only available in local mode)"
+    # Says that the question is still open rather than answering it. The block below overwrites this in
+    # all three of its branches before the banner prints, so nothing here reaches a user today -- but it
+    # used to name local mode as the only place automatic detection happens, which #465 stopped making
+    # true. A placeholder that is false the moment anything makes it visible is a trap for whoever next
+    # adds an early exit between here and there, so it states what is actually known at this point.
+    #
+    # test_nothing_still_calls_the_lm_sensors_fallback_local_mode_only() guards the whole class, and it
+    # is why this comment describes the old wording instead of quoting it : a false sentence reproduced
+    # verbatim in a comment is exactly how it survives the next search for it (issue #475)
+    CPU_TEMPERATURE_THRESHOLD_SOURCE=" (fallback value, pending the check that decides whether lm-sensors describes this server)"
     IS_THE_AUTOMATIC_THRESHOLD_STILL_TO_BE_RESOLVED=true
   else
     DETECTED_CPU_TEMPERATURE_THRESHOLD=$(retrieve_CPU_high_temperature_from_lm_sensors)
@@ -400,10 +409,10 @@ while true; do
     fi
 
     # The one remedy this server actually has, said to the only people it applies to. An iDRAC that
-    # reports no CPU temperature is read from lm-sensors instead -- but only in local mode, because
-    # lm-sensors reads the machine this container runs on and network mode does not assume that is the
-    # server being controlled. Issue #378's reporter hit exactly this, on a machine that WAS the same
-    # one, and had to work out on his own that local mode was the answer
+    # reports no CPU temperature is read from lm-sensors instead -- in local mode always, and in network
+    # mode only where this container can be SHOWN to be running on the server IDRAC_HOST names, since
+    # lm-sensors reads the machine it runs on (issue #465). Issue #378's reporter hit exactly this, on a
+    # machine that WAS the same one, and had to work out on his own that local mode was the answer
     NETWORK_MODE_CLAUSE=""
     # Only when the proof is what failed. The two machines matching and lm-sensors then reporting nothing
     # reaches this same refusal, and saying "It was not shown here : both report serial number 5N7XXX2"

--- a/functions.sh
+++ b/functions.sh
@@ -2447,9 +2447,11 @@ function run_the_redfish_cooling_response_errand() {
       # What switching modes would cost, said before it is suggested rather than discovered afterwards.
       #
       # "Nothing else changes" was printed unconditionally, and on a server whose CPUs are read from
-      # lm-sensors it is false : that fallback exists only in local mode, so network mode would leave the
-      # container with no CPU temperature at all and it would refuse to start. The reporter of issue #378
-      # read this warning, followed it, and lost the only mode his R510 runs in
+      # lm-sensors it is false : in network mode that fallback is kept only where this container can be
+      # SHOWN to be running on the server IDRAC_HOST names (issue #465), and where it cannot -- most often
+      # because /sys/class/dmi/id/product_serial is unreadable from inside the container -- there would be
+      # no CPU temperature at all and it would refuse to start. The reporter of issue #378 read this
+      # warning, followed it, and lost the only mode his R510 runs in
       local WHAT_ELSE_CHANGES=" Nothing else changes : temperatures keep being read and logged every cycle"
       if [ "${CPU_TEMPERATURE_SOURCE_IN_USE:-ipmi}" == "lm-sensors" ]; then
         WHAT_ELSE_CHANGES=" Something else would change on this server, and it is the more important of the two : its iDRAC reports no readable CPU temperature, so the CPUs are being read from lm-sensors instead -- and in network mode that reading is kept only if this container can be SHOWN to be running on the very server IDRAC_HOST names, by its service tag matching the one the iDRAC reports. Where it cannot be shown -- most often because /sys/class/dmi/id/product_serial is not readable from inside the container -- this container would have no CPU temperature at all and would refuse to start. Local mode needs no such proof, and is the safer choice for this server ; leaving this parameter without effect is the cheaper of the two prices"

--- a/tests/cases/10_shell_scripts.sh
+++ b/tests/cases/10_shell_scripts.sh
@@ -1690,3 +1690,26 @@ function test_no_case_reaches_the_healthcheck_through_the_repository_root() {
   assert_empty "$OFFENDERS" \
     "a case must reach the healthcheck through CONTROLLER_WORKING_DIRECTORY, or it reads the machine's own heartbeat"
 }
+
+function test_nothing_still_calls_the_lm_sensors_fallback_local_mode_only() {
+  # Three pull requests in a row corrected prose that had quietly stopped being true, and each time the
+  # code around it was already right. #465 made the lm-sensors CPU fallback reachable in network mode on
+  # a container shown to be running on the controlled server, and #473 did the same for the threshold --
+  # but a comment written to explain the OLD behaviour, and a placeholder string nothing prints today,
+  # both went on asserting "only in local mode" long after that stopped being the rule (issue #475).
+  #
+  # Prose is what a reader trusts when the code is too subtle to re-derive, so a claim this load-bearing
+  # is worth a guard. Deliberately narrow : it forbids the absolute, not the words. Saying that local
+  # mode needs no proof, or that a given path is local-only, stays perfectly sayable
+  local -r FORBIDDEN='only (be )?(available |reachable |kept |read )?in ("local"|.local.|local) mode|local[- ]mode only|exists only in local'
+
+  local FILE OFFENDING
+  for FILE in "$REPO_ROOT"/*.sh "$REPO_ROOT/README.md" "$REPO_ROOT/CLAUDE.md"; do
+    [ -f "$FILE" ] || continue
+
+    OFFENDING=$(grep -nEi "$FORBIDDEN" "$FILE" || true)
+
+    assert_empty "$OFFENDING" \
+      "${FILE#"$REPO_ROOT"/} still calls the lm-sensors fallback local-mode-only, which #465 and #473 made untrue"
+  done
+}


### PR DESCRIPTION
Closes #475. Found while re-verifying **one by one** that the nine defects #466 recorded from a real field log are actually fixed on master. Six are.

## The three

#465 made the lm-sensors CPU fallback reachable in network mode on a container **shown** to be running on the controlled server. #473 did the same for the threshold. Three places never got the message:

| where | kind |
| --- | --- |
| `functions.sh:2450` | the comment written in **#467 to explain the very defect it was fixing**, falsified by #465 two hours later |
| `Dell_iDRAC_fan_controller.sh:154` | **a user-facing string** |
| `Dell_iDRAC_fan_controller.sh:403` | a comment sitting three lines above a clause that already says the opposite |

## The middle one is a trap, not a visible bug — and it was traced, not assumed

`:154` is a placeholder set before #473's deferral. The block at `:213` overwrites it in **all three** of its branches; only then does the banner print at `:238`. **It cannot reach a user today.**

What it can do is become true the moment somebody adds an early exit between `:155` and `:213` that still prints the banner — shipping a lie without touching either line. Dead text that is wrong costs the same to fix as dead text that is right.

## The pattern is the actual finding

Fourth consecutive round of correcting prose that had quietly stopped being true while the code around it was already right:

- **#467** — nine such statements, from a real log
- **#469** — six more that #467 and #468 had *claimed* to fix
- **#471** — the harness asserting a value production no longer used
- **#475** — these three

**Every one was found by someone reading the text. Never by the suite.** So this PR does not just correct them.

## The guard

`test_nothing_still_calls_the_lm_sensors_fallback_local_mode_only()` sweeps the shell scripts, `README.md` and `CLAUDE.md`.

**Deliberately narrow: it forbids the absolute, not the words.** *"Local mode needs no such proof"* and *"local-only by construction"* are both true and stay sayable. Only the claim that the fallback happens **nowhere else** is refused.

| mutation | result |
| --- | --- |
| restore the `functions.sh` comment | ❌ caught |
| restore the placeholder string | ❌ caught |
| restore the refusal comment | ❌ caught |
| add a legitimate *"local-only by construction"* line | ✅ passes — no false positive |

## It bit on its first run, on the comment introducing it

My comment explaining the change **quoted the false sentence verbatim**. The guard refused it — correctly. Reproducing a false sentence inside a comment is precisely how it survives the next search for it, so the comment now describes the old wording instead of repeating it.

I would rather report that than quietly widen the pattern to let my own prose through.

## Testing

- Full suite: **616 test cases, 2928 assertions, 0 failures**
- Both `shellcheck` invocations CI runs: clean
- `.github/check_sign_off.sh` against `origin/master`: passes

---
_Generated by [Claude Code](https://claude.ai/code/session_01R5KmbXpsvdu9oRoWczxnhc)_