### PR TITLE
Sweep tests/ for the local-mode-only claim the guard was written to forbid (#477)

### DIFF
--- a/tests/cases/10_shell_scripts.sh
+++ b/tests/cases/10_shell_scripts.sh
@@ -1696,18 +1696,34 @@ function test_nothing_still_calls_the_lm_sensors_fallback_local_mode_only() {
   # code around it was already right. #465 made the lm-sensors CPU fallback reachable in network mode on
   # a container shown to be running on the controlled server, and #473 did the same for the threshold --
   # but a comment written to explain the OLD behaviour, and a placeholder string nothing prints today,
-  # both went on asserting "only in local mode" long after that stopped being the rule (issue #475).
+  # both went on presenting local mode as that fallback's only home long after it had stopped being
+  # (issue #475).
+  #
+  # The guard written for that swept the scripts and two documents and stopped there, which left out
+  # tests/ -- where the largest share of this project's prose lives, and where three more of the same
+  # claim were still standing the day after it landed (issue #477). A guard covering the smaller half
+  # of the prose reads, from a green run, exactly like one covering all of it, so it sweeps everything
+  # now.
   #
   # Prose is what a reader trusts when the code is too subtle to re-derive, so a claim this load-bearing
   # is worth a guard. Deliberately narrow : it forbids the absolute, not the words. Saying that local
   # mode needs no proof, or that a given path is local-only, stays perfectly sayable
   local -r FORBIDDEN='only (be )?(available |reachable |kept |read )?in ("local"|.local.|local) mode|local[- ]mode only|exists only in local'
 
+  # Two kinds of line have to spell the claim out to do their job : an assertion that it is ABSENT from
+  # what the controller printed, and the pattern above itself. Naming a claim in order to forbid it is
+  # not making it. Nothing else gets the pass -- a comment can always describe the claim instead of
+  # quoting it, and every comment that used to quote it was reworded rather than exempted. The line
+  # number grep -n prefixes is what the anchor steps over
+  local -r NAMING_IT_IN_ORDER_TO_FORBID_IT='assert_not_(contains|matches)|^[0-9]+:[[:space:]]*local -r FORBIDDEN='
+
   local FILE OFFENDING
-  for FILE in "$REPO_ROOT"/*.sh "$REPO_ROOT/README.md" "$REPO_ROOT/CLAUDE.md"; do
+  for FILE in "$REPO_ROOT"/*.sh "$REPO_ROOT"/*.md "$REPO_ROOT"/.github/*.sh \
+              "$TESTS_DIRECTORY"/*.sh "$TESTS_DIRECTORY"/*.md "$TESTS_DIRECTORY"/lib/*.sh \
+              "$TESTS_DIRECTORY"/cases/*.sh "$TESTS_DIRECTORY"/mocks/*; do
     [ -f "$FILE" ] || continue
 
-    OFFENDING=$(grep -nEi "$FORBIDDEN" "$FILE" || true)
+    OFFENDING=$(grep -nEi "$FORBIDDEN" "$FILE" | grep -Ev "$NAMING_IT_IN_ORDER_TO_FORBID_IT" || true)
 
     assert_empty "$OFFENDING" \
       "${FILE#"$REPO_ROOT"/} still calls the lm-sensors fallback local-mode-only, which #465 and #473 made untrue"

--- a/tests/cases/46_redfish_cooling_response.sh
+++ b/tests/cases/46_redfish_cooling_response.sh
@@ -546,7 +546,9 @@ function test_local_mode_says_the_transport_is_missing_rather_than_blaming_the_s
 function test_local_mode_does_not_promise_nothing_else_changes_when_the_cpus_come_from_lm_sensors() {
   # The sentence that cost issue #378's reporter a run. He read "Nothing else changes", followed the
   # advice, and his container refused to start : his iDRAC publishes no CPU temperature, so his CPUs
-  # come from lm-sensors -- and that fallback exists only in local mode
+  # come from lm-sensors, and network mode refused that fallback outright at the time. Issue #465 has
+  # since made it survive the switch on a container that can be shown to be running on the controlled
+  # server, which is what the warning below now says instead of a flat promise
   export IDRAC_HOST="local"
   CPU_TEMPERATURE_SOURCE_IN_USE="lm-sensors"
   REDFISH_ATTEMPTS=0
@@ -560,8 +562,9 @@ function test_local_mode_does_not_promise_nothing_else_changes_when_the_cpus_com
   assert_contains "$OUTPUT" "would refuse to start" \
     "what the switch would actually do has to be said before it is suggested"
   assert_contains "$OUTPUT" "Local mode needs no such proof"
-  # Since issue #465 the fallback is not local-mode-only, so this warning must not say it is -- it was
-  # still claiming "that fallback exists only in local mode" after #468 landed everywhere else (#469)
+  # Since issue #465 the fallback survives the switch on a container that proves where it runs, so this
+  # warning must not go on presenting local mode as the only place it exists -- it still did after #468
+  # had landed everywhere else (#469)
   assert_not_contains "$OUTPUT" "exists only in local mode" \
     "network mode keeps the reading when the container is shown to be on the server itself"
   assert_contains "$OUTPUT" "can be SHOWN to be running on the very server" \

--- a/tests/cases/55_enclosure_housed_servers.sh
+++ b/tests/cases/55_enclosure_housed_servers.sh
@@ -238,8 +238,9 @@ function test_the_controller_refuses_to_run_on_a_server_reporting_no_cpu_sensor(
   assert_contains "$OUTPUT" "github.com/tigerblue77/Dell_iDRAC_fan_controller_Docker/issues" \
     "and where to report it"
   # The likeliest cause by far, and the only one the user can fix themselves :
-  # lm-sensors cannot rescue this one either, the fallback being local mode only
-  # and the enclosure rejecting the fan control commands anyway
+  # lm-sensors cannot rescue this one either, a blade carrying no fan of its own
+  # for the container to drive even where a host reading is to be had, and the
+  # enclosure rejecting the fan control commands anyway
   assert_contains "$OUTPUT" "chassis management controller" \
     "the chassis mistake is named first, being the likeliest cause"
   assert_contains "$OUTPUT" "point it at a node's own iDRAC instead" \


### PR DESCRIPTION
Closes #477.

## The problem

#476 added `test_nothing_still_calls_the_lm_sensors_fallback_local_mode_only()` to stop the project going on calling the lm-sensors CPU fallback local-mode-only, which #465 and #473 had made untrue. It swept:

```bash
for FILE in "$REPO_ROOT"/*.sh "$REPO_ROOT/README.md" "$REPO_ROOT/CLAUDE.md"; do
```

— the production scripts and two documents, and stopped there. `tests/` was left out, and that is where the largest share of this project's prose lives. Three instances of the very claim the guard forbids were still standing there the day after it landed.

A guard covering the smaller half of the prose reads, from a green run, exactly like one covering all of it. That is what makes this worth a fix rather than a note.

## What changes

**The sweep** now takes the root `.sh` and `.md` files, `.github/*.sh`, and all of `tests/` — `run_tests.sh`, the READMEs, `lib/`, `cases/` and `mocks/`.

**One exemption, by line shape.** Two kinds of line have to spell the claim out to do their job:

- an `assert_not_contains` / `assert_not_matches` asserting it is **absent** from what the controller printed;
- the `FORBIDDEN=` pattern definition itself.

Naming a claim in order to forbid it is not making it. The exemption is a regex on line shape rather than a marker anyone could sprinkle, and comments get no pass — a comment can always describe the claim instead of quoting it.

**The three comments found were reworded, not exempted:**

| File | Was | Is |
| --- | --- | --- |
| `55_enclosure_housed_servers.sh:241` | lm-sensors could not rescue a blade *because the fallback was local mode only* | because a blade carries no fan of its own for the container to drive |
| `46_redfish_cooling_response.sh:549` | stated in the present tense what network mode did to the fallback **before** #465 | says it in the past, and names what #465 replaced it with |
| `46_redfish_cooling_response.sh:564` | quoted the forbidden sentence to explain the assertion beneath it | describes it |

## Verification

- **Mutation, three times.** Restoring any one of the three comments turns the suite red, each on its own line, with the file and line number in the failure.
- **The exemption is load-bearing, and no wider than it claims.** Neutering it to a never-matching pattern catches exactly three lines — the two `assert_not_contains` and the pattern definition — and nothing else.
- `./tests/run_tests.sh` → **616 test cases, 2976 assertions**, all passing (2928 before; the +48 is the widened sweep).
- Both `shellcheck` invocations from `CLAUDE.md` clean.
- `docker build` not run — Claude Code on the web has no Docker daemon. `.github/workflows/tests.yml` builds the image and re-runs the suite inside it on this pull request.

---
_Generated by [Claude Code](https://claude.ai/code/session_01R5KmbXpsvdu9oRoWczxnhc)_