### PR TITLE
Compare the serial number, not the padding a firmware wraps it in (#479)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ either way : the other sensors, and every fan control command.
 | --- | --- |
 | `supervisor.sh` | The image's entrypoint. Starts the controller and, if it dies without doing it itself, hands the fans back to Dell |
 | `Dell_iDRAC_fan_controller.sh` | Configuration validation, then the monitoring loop |
-| `functions.sh` | Every shared function (89, flat namespace, no modules). `supervisor.sh` keeps two of its own |
+| `functions.sh` | Every shared function (90, flat namespace, no modules). `supervisor.sh` keeps two of its own |
 | `constants.sh` | The fixed values everything else is measured against : bounds, thresholds, intervals, column widths, Redfish URIs. The raw IPMI commands are in `functions.sh` |
 | `healthcheck.sh` | `HEALTHCHECK` for the image |
 | `tests/` | The suite. See `tests/README.md`, which is thorough — read it before touching a test |

--- a/functions.sh
+++ b/functions.sh
@@ -1153,6 +1153,39 @@ function resolve_CPU_temperature_source() {
   esac
 }
 
+# The comparable form of a serial number, whatever the firmware that printed it padded it with
+# Usage : canonicalise_serial_number "$RAW_SERIAL_NUMBER"
+# Returns : 0 having printed the canonical form, which is empty when nothing identifying was left
+#
+# The two sides of the same-machine check come from a kernel file and from a fixed-width FRU field, and
+# neither is a clean string. Whitespace removed and case folded is what the two readers each did inline ;
+# what neither did is the reason this now exists in one place. The R510 of issue #378 reports
+# "..CN1374XXXXXXXX." for the very board its iDRAC calls "CN1374XXXXXXXX" -- same board, same serial
+# number, three padding characters, and a comparison that refused. On the only real machine this feature
+# has ever run on, and the one it was built for (issue #479).
+#
+# Only the ENDS are trimmed. A separator inside a serial number is part of it, and two identifiers that
+# differ in the middle have to go on differing.
+#
+# Trimming before the usability rules rather than after is what makes this safe as well as correct.
+# "0000000" is one character repeated and is refused ; "..0000000." is not, so the shape rule walked
+# straight past it, and two unrelated Dell boxes padding an unfilled field the same way compared EQUAL --
+# which is the whole failure issue #465 exists to prevent. Trimmed first it is "0000000", which that rule
+# does catch
+function canonicalise_serial_number() {
+  local SERIAL_NUMBER="${1//[[:space:]]/}"
+  SERIAL_NUMBER="${SERIAL_NUMBER^^}"
+
+  # The leading run of non-alphanumerics, then the trailing one. "${VAR%%[[:alnum:]]*}" is everything
+  # before the first alphanumeric, which is exactly the prefix to remove ; "${VAR##*[[:alnum:]]}" is
+  # everything after the last. A value carrying no alphanumeric at all leaves nothing, and
+  # is_this_serial_number_usable refuses it on emptiness rather than on shape
+  SERIAL_NUMBER="${SERIAL_NUMBER#"${SERIAL_NUMBER%%[[:alnum:]]*}"}"
+  SERIAL_NUMBER="${SERIAL_NUMBER%"${SERIAL_NUMBER##*[[:alnum:]]}"}"
+
+  printf '%s' "$SERIAL_NUMBER"
+}
+
 # Whether a serial number is an identifier at all, as opposed to a field nobody filled in
 # Usage : is_this_serial_number_usable "$SERIAL_NUMBER"
 # Returns : 0 if it can be compared, 1 if it must be treated as unreadable
@@ -1162,17 +1195,24 @@ function resolve_CPU_temperature_source() {
 # is what allows the host's CPU temperatures to answer for a server reached over the network. So a value
 # that is not an identifier has to be rejected before it is ever compared, not after (issue #465)
 function is_this_serial_number_usable() {
-  local -r SERIAL_NUMBER="$1"
+  # Canonicalised here as well as by the two readers. Everything below describes the identifier rather
+  # than the padding a firmware wrapped it in, so a caller reaching this function directly has to get the
+  # verdict the readers would get -- and the length rule in particular has to measure the identifier,
+  # not three characters of padding around a two-character stub (issue #479)
+  local SERIAL_NUMBER
+  SERIAL_NUMBER=$(canonicalise_serial_number "$1")
 
   [ -n "$SERIAL_NUMBER" ] || return 1
   [ "${#SERIAL_NUMBER}" -ge "$MINIMUM_USABLE_SERIAL_NUMBER_LENGTH" ] || return 1
 
-  local LOWERCASED
-  LOWERCASED=$(printf '%s' "$SERIAL_NUMBER" | tr '[:upper:]' '[:lower:]')
-
-  local PLACEHOLDER
+  # Each entry goes through the canonicaliser too, so that the list stays written the way a human reads
+  # these fields while being compared the way the machine reads them. Both sides or neither : trimming
+  # only the value is what made "To Be Filled By O.E.M." stop matching "tobefilledbyo.e.m." the moment
+  # its trailing full stop was taken off one side of the comparison alone
+  local PLACEHOLDER CANONICAL_PLACEHOLDER
   for PLACEHOLDER in "${UNUSABLE_SERIAL_NUMBERS[@]}"; do
-    [ "$LOWERCASED" == "$PLACEHOLDER" ] && return 1
+    CANONICAL_PLACEHOLDER=$(canonicalise_serial_number "$PLACEHOLDER")
+    [ "$SERIAL_NUMBER" == "$CANONICAL_PLACEHOLDER" ] && return 1
   done
 
   # A curated list can only ever chase values someone has already seen, and its own near neighbours walk
@@ -1181,14 +1221,16 @@ function is_this_serial_number_usable() {
   # shape rules catch the family rather than the instance (issue #469).
   #
   # One character repeated is not an identifier
-  local FIRST_CHARACTER="${LOWERCASED:0:1}"
+  local FIRST_CHARACTER="${SERIAL_NUMBER:0:1}"
   local REPEATED
-  printf -v REPEATED '%*s' "${#LOWERCASED}" ''
+  printf -v REPEATED '%*s' "${#SERIAL_NUMBER}" ''
   REPEATED="${REPEATED// /$FIRST_CHARACTER}"
-  [ "$LOWERCASED" == "$REPEATED" ] && return 1
+  [ "$SERIAL_NUMBER" == "$REPEATED" ] && return 1
 
-  # Nor is anything carrying no letter and no digit
-  [[ "$LOWERCASED" == *[a-z0-9]* ]] || return 1
+  # Nor is anything carrying no letter and no digit. Nothing reaches this that could fail it -- the
+  # canonicaliser leaves an alphanumeric at each end or leaves nothing at all -- so it stands as the
+  # statement of the rule rather than as the only thing enforcing it
+  [[ "$SERIAL_NUMBER" == *[[:alnum:]]* ]] || return 1
 
   return 0
 }
@@ -1205,11 +1247,14 @@ function retrieve_host_serial_number() {
 
   [ -r "$DMI_PATH" ] || return 1
 
-  # Every kind of whitespace removed rather than only the ends : the two sides of the comparison come
-  # from a kernel file and from a padded FRU field, and neither is worth trusting to match character
-  # for character on spacing alone
+  local RAW_SERIAL_NUMBER
+  RAW_SERIAL_NUMBER=$(cat "$DMI_PATH" 2>/dev/null)
+
+  # Whitespace, case and end padding all handled in the one place the other side goes through too : the
+  # two normalisations diverging is what would put a serial number on one side of the comparison in a
+  # shape the other can never take
   local SERIAL_NUMBER
-  SERIAL_NUMBER=$(tr -d '[:space:]' < "$DMI_PATH" 2>/dev/null | tr '[:lower:]' '[:upper:]')
+  SERIAL_NUMBER=$(canonicalise_serial_number "$RAW_SERIAL_NUMBER")
 
   is_this_serial_number_usable "$SERIAL_NUMBER" || return 1
 
@@ -1228,8 +1273,12 @@ function retrieve_controlled_server_serial_number() {
 
   local -r FRU_FIELD="$1"
 
+  local RAW_SERIAL_NUMBER
+  RAW_SERIAL_NUMBER=$(printf '%s\n' "$FRU_SERVER_SECTION" | grep "$FRU_FIELD" | awk -F ':' '{print $2; exit}')
+
+  # Through the same canonicaliser as the host side, for the same reason
   local SERIAL_NUMBER
-  SERIAL_NUMBER=$(printf '%s\n' "$FRU_SERVER_SECTION" | grep "$FRU_FIELD" | awk -F ':' '{gsub(/[[:space:]]/, "", $2); print toupper($2); exit}')
+  SERIAL_NUMBER=$(canonicalise_serial_number "$RAW_SERIAL_NUMBER")
 
   is_this_serial_number_usable "$SERIAL_NUMBER" || return 1
 

--- a/tests/cases/23_cpu_temperature_source.sh
+++ b/tests/cases/23_cpu_temperature_source.sh
@@ -1244,6 +1244,98 @@ function test_a_board_serial_that_differs_is_still_a_refusal() {
   assert_contains "$SAME_MACHINE_VERDICT_REASON" "CN7016360I0026"
 }
 
+# --- What the firmware pads the two sides with, which is not part of either (issue #479) -------------
+#
+# The reporter of issue #378 ran the one comparison nobody could make without a PowerEdge : his host's
+# DMI reports "..CN1374XXXXXXXX." for the very board his iDRAC calls "CN1374XXXXXXXX". Same board, same
+# serial number, three padding characters -- and until the canonicaliser, a refusal.
+
+function test_a_dmi_serial_number_padded_by_the_firmware_still_matches_the_fru_one() {
+  # The R510 of issue #378, at the shapes its owner measured. This is the machine the whole feature was
+  # built for, and an exact comparison refused it
+  export MOCK_IPMITOOL_FRU_OUTPUT
+  MOCK_IPMITOOL_FRU_OUTPUT=$(make_fru_output --no-product-serial --board-serial "CN1374ABCDEFGH")
+  NETWORK_MODE=true
+  CPU_TEMPERATURE_SOURCE="auto"
+  CPU_TEMPERATURE_SOURCE_IN_USE="ipmi"
+  SAME_MACHINE_VERDICT=()
+  simulate_readable_CPUs_in_lm_sensors
+  get_Dell_server_model
+  simulate_host_reporting_only_a_board_serial "..CN1374ABCDEFGH."
+
+  assert_command_succeeds "the padding is the firmware's, not the serial number's" \
+    is_this_container_running_on_the_controlled_server
+  assert_contains "$SAME_MACHINE_VERDICT_REASON" "Board Serial CN1374ABCDEFGH" \
+    "and the value named back has to be the canonical one, not one side's padded copy"
+}
+
+function test_padding_does_not_carry_a_placeholder_past_the_shape_rules() {
+  # The dangerous half. "0000000" is one character repeated and is refused ; "..0000000." is not, so it
+  # walked through -- and two unrelated Dell boxes padding an unfilled field the same way compared EQUAL,
+  # which is one machine's CPU temperatures driving another machine's fans
+  export MOCK_IPMITOOL_FRU_OUTPUT
+  MOCK_IPMITOOL_FRU_OUTPUT=$(make_fru_output --no-product-serial --board-serial "..0000000.")
+  NETWORK_MODE=true
+  CPU_TEMPERATURE_SOURCE="auto"
+  CPU_TEMPERATURE_SOURCE_IN_USE="ipmi"
+  SAME_MACHINE_VERDICT=()
+  simulate_readable_CPUs_in_lm_sensors
+  get_Dell_server_model
+  simulate_host_reporting_only_a_board_serial "..0000000."
+
+  assert_command_fails "an unfilled field is not an identifier, however it is padded" \
+    is_this_container_running_on_the_controlled_server
+}
+
+function test_a_separator_inside_a_serial_number_is_part_of_the_serial_number() {
+  # The negative control of the trim : only the ends are the firmware's. Two identifiers differing in the
+  # middle are two identifiers, and trimming must not reach in far enough to make them one
+  export MOCK_IPMITOOL_FRU_OUTPUT
+  MOCK_IPMITOOL_FRU_OUTPUT=$(make_fru_output --no-product-serial --board-serial "CN1374ABCDEFGH")
+  NETWORK_MODE=true
+  CPU_TEMPERATURE_SOURCE="auto"
+  CPU_TEMPERATURE_SOURCE_IN_USE="ipmi"
+  SAME_MACHINE_VERDICT=()
+  simulate_readable_CPUs_in_lm_sensors
+  get_Dell_server_model
+  simulate_host_reporting_only_a_board_serial "CN.1374ABCDEFGH"
+
+  assert_command_fails "these are two different strings and must stay two different machines" \
+    is_this_container_running_on_the_controlled_server
+}
+
+function test_every_listed_placeholder_is_still_refused_once_canonicalised() {
+  # Trimming the value alone silently retires half the list : "tobefilledbyo.e.m." keeps its full stop
+  # while the value read off a real DMI table loses it, and the two stop matching. Both sides go through
+  # the canonicaliser for that reason, and this walks the whole list rather than the one entry that
+  # exposed it -- assertions do not stop a case, so every offender is reported in one run
+  local PLACEHOLDER
+  for PLACEHOLDER in "${UNUSABLE_SERIAL_NUMBERS[@]}"; do
+    assert_command_fails "\"$PLACEHOLDER\" is a field nobody filled in, not an identifier" \
+      is_this_serial_number_usable "$PLACEHOLDER"
+
+    # And the same entry inside the padding a firmware wraps it in, which is how "..0000000." used to
+    # walk past the repeated-character rule
+    assert_command_fails "\"..$PLACEHOLDER.\" is that same field, padded" \
+      is_this_serial_number_usable "..$PLACEHOLDER."
+  done
+}
+
+function test_the_canonical_form_of_a_serial_number_is_the_identifier_alone() {
+  # The canonicaliser on its own, so that what the two readers share is pinned once rather than inferred
+  # from the comparisons above
+  assert_equals "CN1374ABCDEFGH" "$(canonicalise_serial_number "..CN1374ABCDEFGH.")" \
+    "the ends are the firmware's padding"
+  assert_equals "CN1374ABCDEFGH" "$(canonicalise_serial_number "  cn1374abcdefgh  ")" \
+    "whitespace goes and case is folded, as they always did"
+  assert_equals "CN.1374" "$(canonicalise_serial_number ".CN.1374.")" \
+    "a separator inside survives, only the ends are trimmed"
+  assert_equals "" "$(canonicalise_serial_number "....")" \
+    "a value that is nothing but padding leaves nothing to compare"
+  assert_command_fails "and nothing is not an identifier" \
+    is_this_serial_number_usable "$(canonicalise_serial_number "....")"
+}
+
 # --- The shipped lookup itself, which the harness no longer stands in for (issue #471) ---------------
 
 function test_the_shipped_dmi_lookup_is_the_one_the_kernel_uses() {


### PR DESCRIPTION
Closes #479.

## What the reporter of #378 measured

He ran the one comparison nobody could make without a PowerEdge ([comment](https://github.com/tigerblue77/Dell_iDRAC_fan_controller_Docker/issues/378#issuecomment-5433301704)):

```
# cat /sys/class/dmi/id/board_serial
..CN1374xxxxxxxx.

# ipmitool -I open fru
 Board Serial          : CN1374xxxxxxxx
```

Same board, same serial number, three padding characters. Both readers removed whitespace, folded case and stopped there — so the comparison refused. **The same-machine check said no on the only real machine it has ever run on, and the one it was built for.**

So the answer to "does the iDRAC report the same string the host's own DMI reports" is **yes**. The feature is not dead code; the comparison was too literal.

## The half that is a safety hole, not a missed match

`is_this_serial_number_usable()` refuses a value that is one character repeated, so `0000000` never reaches a comparison. **`..0000000.` is not one character repeated**, so it walked straight past — and two unrelated Dell boxes padding an unfilled field the same way compared **EQUAL**.

An equal comparison is what lets one machine's CPU temperatures drive another machine's fans. That is the whole failure #465 exists to prevent, and padding defeated the shape rule written to prevent it.

## What changes

One canonical form, produced by `canonicalise_serial_number()` and reached through it by **both** readers, so the two sides cannot be normalised differently:

1. whitespace out, case folded — as before;
2. the leading and trailing runs of non-alphanumerics trimmed. **Only the ends.** A separator inside a serial number is part of it, and two identifiers differing in the middle go on differing;
3. **before** the usability rules, not after — `..0000000.` becomes `0000000`, which the repeated-character rule does catch, and a value that is nothing but padding comes back empty and is refused on emptiness.

Every entry of `UNUSABLE_SERIAL_NUMBERS` goes through the same canonicaliser. Trimming one side alone silently retires half the list, and the suite caught that immediately: `tobefilledbyo.e.m.` keeps its full stop while the value read off a real DMI table loses it. As a side effect `default string` — carrying a space no read value could ever have kept — matches for the first time.

## Verification

Three mutations, each turning red exactly the cases that name it:

| Mutation | Cases that fall |
| --- | --- |
| no trim at all | the R510's shapes, the padded placeholder, the whole-list walk, the canonical form |
| list entry upper-cased but not trimmed | `To Be Filled By O.E.M.`, the whole-list walk |
| trim reaches inside the value | the interior separator, the canonical form |

New cases: the R510's exact shapes match; two machines both padding a blank field do not; an interior separator is preserved; the canonical form pinned directly; and every entry of the placeholder list refused both bare and padded.

- `./tests/run_tests.sh` → **621 test cases, 3021 assertions**, all passing.
- Both `shellcheck` invocations from `CLAUDE.md` clean.
- `CLAUDE.md`'s function count follows the new function — the suite's own consistency case caught that too.
- `docker build` not run — Claude Code on the web has no Docker daemon. `.github/workflows/tests.yml` builds the image and re-runs the suite inside it on this pull request.

---
_Generated by [Claude Code](https://claude.ai/code/session_01R5KmbXpsvdu9oRoWczxnhc)_