### PR TITLE
Name both causes of the PCIe cooling refusal instead of asserting one (#481)

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -2506,7 +2506,17 @@ function run_the_redfish_cooling_response_errand() {
         WHAT_ELSE_CHANGES=" Something else would change on this server, and it is the more important of the two : its iDRAC reports no readable CPU temperature, so the CPUs are being read from lm-sensors instead -- and in network mode that reading is kept only if this container can be SHOWN to be running on the very server IDRAC_HOST names, by its service tag matching the one the iDRAC reports. Where it cannot be shown -- most often because /sys/class/dmi/id/product_serial is not readable from inside the container -- this container would have no CPU temperature at all and would refuse to start. Local mode needs no such proof, and is the safer choice for this server ; leaving this parameter without effect is the cheaper of the two prices"
       fi
 
-      print_warning "This server does not have the IPMI command for the third-party PCIe card cooling response. Dell moved it at the 14th generation to a per-slot setting reachable over Redfish, which is HTTPS and therefore needs an iDRAC address and credentials -- and local mode has neither, reaching the BMC through /dev/ipmi0 instead. Set IDRAC_HOST, IDRAC_USERNAME and IDRAC_PASSWORD to run this container in network mode if you want DISABLE_THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE to have an effect on this server.$WHAT_ELSE_CHANGES"
+      # And what switching modes could WIN, which is the half #467 and #468 left behind. This line is
+      # reached because the BMC refused "raw 0x30 0xce", and that refusal has two opposite causes it does
+      # not tell apart : a server NEWER than the 13th generation, where Dell moved the setting to a
+      # per-slot Redfish attribute, and a server OLDER than the ones that ever had it, where there is
+      # nothing to reach over any transport. Saying only the first sends the second's owner to a mode
+      # that has nothing for them -- which is what the R510 of issue #378 was told, twice, while its
+      # iDRAC 6 has no Redfish at all. #173 deliberately retired guessing the generation from the model
+      # name, so the container genuinely does not know which case this is : it must name both rather than
+      # assert one, and REDFISH_MANUAL_INSTRUCTIONS has said the honest version on the network path all
+      # along (issue #481)
+      print_warning "This server refused the IPMI command for the third-party PCIe card cooling response. Two different things look like that from local mode, and the refusal does not say which. Dell moved this setting at the 14th generation to a per-slot attribute reachable over Redfish, which is HTTPS and therefore needs an iDRAC address and credentials -- and local mode has neither, reaching the BMC through /dev/ipmi0 instead. But a server older than the generations that ever had the setting refuses the very same command in the very same way, and on one of those there is nothing for network mode to reach either. Set IDRAC_HOST, IDRAC_USERNAME and IDRAC_PASSWORD to run this container in network mode if you want DISABLE_THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE to have an effect on a 14th generation server or newer ; on an older one the switch changes nothing here.$WHAT_ELSE_CHANGES"
       return 1
     fi
 

--- a/tests/cases/46_redfish_cooling_response.sh
+++ b/tests/cases/46_redfish_cooling_response.sh
@@ -543,6 +543,32 @@ function test_local_mode_says_the_transport_is_missing_rather_than_blaming_the_s
   assert_matches "$(cat "$TEST_TEMPORARY_DIRECTORY/local")" "Set IDRAC_HOST, IDRAC_USERNAME and IDRAC_PASSWORD"
 }
 
+function test_local_mode_names_both_causes_of_the_refusal_rather_than_asserting_one() {
+  # The refusal of "raw 0x30 0xce" has two opposite causes and does not say which : a server NEWER than
+  # the 13th generation, where Dell moved the setting to a per-slot Redfish attribute, and one OLDER than
+  # any that ever had it, where network mode would find nothing at all. The warning asserted the first
+  # and suggested acting on it -- which is how the R510 of issue #378, 11th generation and no Redfish
+  # anywhere on it, was sent to a mode that had nothing in it for him. #173 deliberately retired guessing
+  # the generation from the model name, so the container genuinely cannot tell which case it is in and
+  # has to name both (issue #481)
+  export IDRAC_HOST="local"
+  REDFISH_ATTEMPTS=0
+  REDFISH_COOLING_RESPONSE_SETTLED=false
+
+  attempt_the_redfish_cooling_response "Disabled" "Disabled" \
+    > "$TEST_TEMPORARY_DIRECTORY/both_causes" 2>&1
+  local -r OUTPUT=$(cat "$TEST_TEMPORARY_DIRECTORY/both_causes")
+
+  assert_contains "$OUTPUT" "the refusal does not say which" \
+    "the container does not know the cause, and must not read as though it did"
+  assert_contains "$OUTPUT" "older than the generations that ever had the setting" \
+    "the second cause has to be named, not only the one that makes the switch worth making"
+  assert_contains "$OUTPUT" "nothing for network mode to reach either" \
+    "and what that cause means for the reader has to be spelt out"
+  assert_not_contains "$OUTPUT" "to have an effect on this server" \
+    "an effect on THIS server cannot be promised when its generation is exactly what is unknown"
+}
+
 function test_local_mode_does_not_promise_nothing_else_changes_when_the_cpus_come_from_lm_sensors() {
   # The sentence that cost issue #378's reporter a run. He read "Nothing else changes", followed the
   # advice, and his container refused to start : his iDRAC publishes no CPU temperature, so his CPUs


### PR DESCRIPTION
Closes #481.

## The problem

The local-mode branch of `attempt_the_redfish_cooling_response()` is reached because the BMC **refused `raw 0x30 0xce`**. That refusal has two opposite causes and does not say which:

| Cause | What network mode would find |
| --- | --- |
| the server is **newer** than the 13th generation — Dell moved the setting to a per-slot Redfish attribute | the setting, reachable |
| the server is **older** than any that ever had it | nothing, over any transport |

The warning asserted the first and told the reader to switch modes *"if you want `DISABLE_THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE` to have an effect **on this server**"*.

Since #173 the code deliberately stopped inferring the generation from the model name — it sends the command and reads the answer. So the container **genuinely does not know** which case it is in. It stated as fact something it had given up knowing, and promised an effect it could not deliver.

## Who paid for it

The R510 of #378 is the second case: 11th generation, iDRAC 6, no Redfish anywhere on it. He read this warning, switched, and [his container refused to start](https://github.com/tigerblue77/Dell_iDRAC_fan_controller_Docker/issues/378#issuecomment-5403165850).

#467 and #468 fixed the half of that about what the switch **costs** — the `Nothing else changes` promise that was false on his machine. This is the half about whether it can **pay off at all**, which on his server it never could. He was told so twice by hand in the issue thread, while the container went on telling him the opposite at every start.

## What changes

**No generation detection comes back** — #173 retired that for good reasons and this does not need it. The fix is to stop asserting a cause: both are named, the container says plainly that it cannot tell them apart from local mode, and the suggestion becomes conditional rather than a promise.

`REDFISH_MANUAL_INSTRUCTIONS` has carried the honest version on the *network* path all along; the local branch never got the same treatment.

Before → after, the closing sentence:

> ~~Set IDRAC_HOST, IDRAC_USERNAME and IDRAC_PASSWORD to run this container in network mode if you want DISABLE_… to have an effect **on this server**.~~

> But a server older than the generations that ever had the setting refuses the very same command in the very same way, and on one of those there is nothing for network mode to reach either. Set IDRAC_HOST, IDRAC_USERNAME and IDRAC_PASSWORD to run this container in network mode if you want DISABLE_… to have an effect **on a 14th generation server or newer** ; on an older one the switch changes nothing here.

The existing `Set IDRAC_HOST, IDRAC_USERNAME and IDRAC_PASSWORD` phrase is kept verbatim, so the two assertions already built on it hold unchanged.

## Verification

| Mutation | Result |
| --- | --- |
| restore the unconditional "an effect on this server" promise | new case red |
| drop the second cause from the message | new case red |

- `./tests/run_tests.sh` → **622 test cases, 3025 assertions**, all passing.
- Both `shellcheck` invocations from `CLAUDE.md` clean.
- `docker build` not run — Claude Code on the web has no Docker daemon. `.github/workflows/tests.yml` builds the image and re-runs the suite inside it on this pull request.

---
_Generated by [Claude Code](https://claude.ai/code/session_01R5KmbXpsvdu9oRoWczxnhc)_