### PR TITLE
Test the Redfish parsers against a real iDRAC document (#489)

### DIFF
--- a/tests/cases/46_redfish_cooling_response.sh
+++ b/tests/cases/46_redfish_cooling_response.sh
@@ -1205,3 +1205,66 @@ function test_a_fast_errand_that_straddles_a_second_is_not_split() {
     "crossing a second is not spending one : a server answering in milliseconds is finished with in one cycle"
   assert_equals "1" "$(grep -c "" "$MOCK_REDFISH_PATCH_LOG")" "and the setting is applied in it"
 }
+
+# The cases below drive the controller with a document no one here wrote : the System attributes of a
+# real PowerEdge R740xd2, posted on #360. Everything above builds its own body to the shape the code
+# expects, which is the shape whoever wrote the code had in mind ; these run against what an iDRAC
+# actually answered, in the order it answered it (#489).
+
+function test_a_captured_document_is_read_as_the_machine_it_came_from() {
+  # The conformant URI answered 404 on this machine, so the capture is served where it really came
+  # from : the legacy one, reached only after that 404. Its status is left at the mock's default
+  export MOCK_REDFISH_LEGACY_STATUS="200"
+  export MOCK_REDFISH_LEGACY_BODY
+  MOCK_REDFISH_LEGACY_BODY=$(make_captured_r740xd2_attributes_body)
+
+  does_this_server_expose_the_cooling_response_over_redfish
+
+  assert_equals "15" "$REDFISH_COOLING_RESPONSE_SLOT_COUNT" \
+    "the capture carries fifteen slot instances, ordered 1, 10, 11 ... 15, 2, 3 ... 9"
+  assert_empty "$REDFISH_THIRD_PARTY_SLOTS" \
+    "fourteen of its slots are empty and the fifteenth holds an AHCI controller reading \"No\""
+  assert_equals "Automatic" "$(read_the_lfm_mode_of_slot "$MOCK_REDFISH_LEGACY_BODY" 1)" \
+    "slot 1's mode is the first slot of the document, read from its real text"
+  assert_equals "Automatic" "$(read_the_lfm_mode_of_slot "$MOCK_REDFISH_LEGACY_BODY" 15)" \
+    "and slot 15 is the one a lexicographic order puts fifth, not last"
+}
+
+function test_the_attribute_a_real_document_opens_on_is_not_dropped() {
+  # Dell orders these alphabetically, so a real answer opens on PCIeSlotLFM.1.3rdPartyCard -- the exact
+  # position an anchored pattern could not reach, which cost the machine's FIRST PCIe slot until #412.
+  # That fix was proved against a body written to have the shape ; this proves it against one that has
+  # the shape because an iDRAC produced it. One value is changed, and only one : slot 1's card flag
+  export MOCK_REDFISH_LEGACY_STATUS="200"
+  export MOCK_REDFISH_LEGACY_BODY
+  MOCK_REDFISH_LEGACY_BODY=$(make_captured_r740xd2_attributes_body "1=3rdPartyCard=Yes")
+
+  does_this_server_expose_the_cooling_response_over_redfish
+
+  assert_equals "1 " "$REDFISH_THIRD_PARTY_SLOTS" \
+    "the card in the document's opening attribute is a card like any other"
+  assert_equals "15" "$REDFISH_COOLING_RESPONSE_SLOT_COUNT" "and the slot count is unchanged by it"
+}
+
+function test_the_controller_tells_a_captured_r740xd2_owner_there_is_nothing_to_apply_it_to() {
+  # End to end, on the machine the capture came from : a 14th generation iDRAC that answers the raw
+  # command with rsp=0xc1, has the setting on fifteen slots, and holds no third-party card anywhere.
+  # The column must say that rather than name the server unable or claim something was applied
+  export DISABLE_THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE=true
+  export MOCK_REDFISH_PATCH_LOG="$TEST_TEMPORARY_DIRECTORY/patches"
+  : > "$MOCK_REDFISH_PATCH_LOG"
+  simulate_server "PowerEdge R740xd2" --cpus 2
+  export MOCK_IPMITOOL_RAW_FAIL_PATTERN="0x30 0xce"
+  export MOCK_IPMITOOL_RAW_FAIL_STDERR="Unable to send RAW command (channel=0x0 netfn=0x30 lun=0x0 cmd=0xce rsp=0xc1): Invalid command"
+  export MOCK_REDFISH_LEGACY_STATUS="200"
+  export MOCK_REDFISH_LEGACY_BODY
+  MOCK_REDFISH_LEGACY_BODY=$(make_captured_r740xd2_attributes_body)
+
+  local -r OUTPUT=$(run_controller "" 3)
+
+  assert_matches "$OUTPUT" "fan control profile.*No third-party PCIe card to apply it to" \
+    "the table must report what was found rather than what the command answered"
+  assert_equals "0" "$(grep -c "" "$MOCK_REDFISH_PATCH_LOG")" \
+    "and nothing may be written to a slot holding a Dell card or no card at all"
+  assert_matches "$OUTPUT" "15 PCIe slots over Redfish" "the reader is told how many were found"
+}

--- a/tests/lib/fixtures.sh
+++ b/tests/lib/fixtures.sh
@@ -394,3 +394,208 @@ function simulate_enclosure_management_controller() {
   export MOCK_IPMITOOL_RAW_FAIL_PATTERN="0x30 0x30"
   export MOCK_IPMITOOL_RAW_FAIL_STDERR="$ENCLOSURE_REJECTED_FAN_CONTROL_STDERR"
 }
+
+# The System attributes of a real PowerEdge R740xd2, as @bitspill posted them on issue #360 on
+# 2026-08-29 : iDRAC 9 firmware 3.30.30.30, Enterprise licence, host running.
+#
+# Every other Redfish body this suite feeds the controller is one make_redfish_attributes_body() built
+# to the shape the code expects, which is the shape whoever wrote the code had in mind. This one is not
+# invented, and four things in it are only true because an iDRAC produced them :
+#
+#   - it came from the LEGACY URI. The conformant one answered 404 on this machine, which is why the
+#     cases below set MOCK_REDFISH_LEGACY_BODY and leave the conformant status at its 404 default : the
+#     fallback is not a defensive branch here, it is the only way this server ever answers ;
+#   - it is ordered ALPHABETICALLY, which is how Dell returns these documents. That puts PCIeSlotLFM
+#     before ThermalSettings and 3rdPartyCard before LFMMode, so the very first attribute of the object
+#     is "PCIeSlotLFM.1.3rdPartyCard" -- the position an anchored pattern used to drop silently (#412) ;
+#   - its slots run 1, 10, 11 ... 15, 2, 3 ... 9, because that ordering is lexicographic and not
+#     numeric. Nothing here should care, and this is what says so ;
+#   - it is the first capture of a server that HAS the setting on 15 slots and holds no third-party
+#     card at all : fourteen slots empty and one AHCI controller reading "No". The branch that reports
+#     "No third-party PCIe card to apply it to" was written against a mock because no real machine had
+#     ever shown it.
+#
+# What is reproduced is his paste, not the whole document : he ran the capture through
+# "tr ',' '\n' | grep -Ei 'thermal|pcieslotlfm|...'", so it arrived one attribute per line and carries
+# the four families that filter kept -- PCIeSlotLFM, ThermalConfig, ThermalHistorical and
+# ThermalSettings. The two the controller reads are among them, so nothing it looks at is missing ; a
+# real body would also hold the several hundred attributes it ignores, and the other two families are
+# left in precisely because they are of that kind and the parsers have to walk past them. The
+# line-per-attribute form is kept here to stay readable and re-joined below into the single minified
+# line the iDRAC really answers with. Within what he posted nothing is added, reordered or corrected --
+# 150 attributes, byte for byte and in his order -- including MFSMinimumLimit at 63, the highest of the
+# eight machines reported on that issue and the clearest evidence that the floor is not a setpoint.
+# Usage : make_captured_r740xd2_attributes_body ["<slot>=<attribute>=<value>" ...]
+#         each optional argument replaces one attribute of the capture, for a case that needs a shape
+#         the machine did not happen to have
+function make_captured_r740xd2_attributes_body() {
+  local CAPTURED_ATTRIBUTES
+  CAPTURED_ATTRIBUTES=$(cat << 'CAPTURE'
+"PCIeSlotLFM.1.3rdPartyCard":"N/A"
+"PCIeSlotLFM.1.CardType":"Empty"
+"PCIeSlotLFM.1.CustomLFM":0
+"PCIeSlotLFM.1.LFMMode":"Automatic"
+"PCIeSlotLFM.1.MaxLFM":0
+"PCIeSlotLFM.1.PCIeInletTemperature":34
+"PCIeSlotLFM.1.SlotState":"Defined"
+"PCIeSlotLFM.1.TargetLFM":"-"
+"PCIeSlotLFM.10.3rdPartyCard":"N/A"
+"PCIeSlotLFM.10.CardType":"Empty"
+"PCIeSlotLFM.10.CustomLFM":0
+"PCIeSlotLFM.10.LFMMode":"Automatic"
+"PCIeSlotLFM.10.MaxLFM":0
+"PCIeSlotLFM.10.PCIeInletTemperature":0
+"PCIeSlotLFM.10.SlotState":"Not-Defined"
+"PCIeSlotLFM.10.TargetLFM":"-"
+"PCIeSlotLFM.11.3rdPartyCard":"N/A"
+"PCIeSlotLFM.11.CardType":"Empty"
+"PCIeSlotLFM.11.CustomLFM":0
+"PCIeSlotLFM.11.LFMMode":"Automatic"
+"PCIeSlotLFM.11.MaxLFM":0
+"PCIeSlotLFM.11.PCIeInletTemperature":0
+"PCIeSlotLFM.11.SlotState":"Not-Defined"
+"PCIeSlotLFM.11.TargetLFM":"-"
+"PCIeSlotLFM.12.3rdPartyCard":"N/A"
+"PCIeSlotLFM.12.CardType":"Empty"
+"PCIeSlotLFM.12.CustomLFM":0
+"PCIeSlotLFM.12.LFMMode":"Automatic"
+"PCIeSlotLFM.12.MaxLFM":0
+"PCIeSlotLFM.12.PCIeInletTemperature":0
+"PCIeSlotLFM.12.SlotState":"Not-Defined"
+"PCIeSlotLFM.12.TargetLFM":"-"
+"PCIeSlotLFM.13.3rdPartyCard":"N/A"
+"PCIeSlotLFM.13.CardType":"Empty"
+"PCIeSlotLFM.13.CustomLFM":0
+"PCIeSlotLFM.13.LFMMode":"Automatic"
+"PCIeSlotLFM.13.MaxLFM":0
+"PCIeSlotLFM.13.PCIeInletTemperature":0
+"PCIeSlotLFM.13.SlotState":"Not-Defined"
+"PCIeSlotLFM.13.TargetLFM":"-"
+"PCIeSlotLFM.14.3rdPartyCard":"N/A"
+"PCIeSlotLFM.14.CardType":"Empty"
+"PCIeSlotLFM.14.CustomLFM":0
+"PCIeSlotLFM.14.LFMMode":"Automatic"
+"PCIeSlotLFM.14.MaxLFM":0
+"PCIeSlotLFM.14.PCIeInletTemperature":0
+"PCIeSlotLFM.14.SlotState":"Not-Defined"
+"PCIeSlotLFM.14.TargetLFM":"-"
+"PCIeSlotLFM.15.3rdPartyCard":"N/A"
+"PCIeSlotLFM.15.CardType":"Empty"
+"PCIeSlotLFM.15.CustomLFM":0
+"PCIeSlotLFM.15.LFMMode":"Automatic"
+"PCIeSlotLFM.15.MaxLFM":0
+"PCIeSlotLFM.15.PCIeInletTemperature":0
+"PCIeSlotLFM.15.SlotState":"Not-Defined"
+"PCIeSlotLFM.15.TargetLFM":"-"
+"PCIeSlotLFM.2.3rdPartyCard":"No"
+"PCIeSlotLFM.2.CardType":"AHCI"
+"PCIeSlotLFM.2.CustomLFM":0
+"PCIeSlotLFM.2.LFMMode":"Automatic"
+"PCIeSlotLFM.2.MaxLFM":390
+"PCIeSlotLFM.2.PCIeInletTemperature":34
+"PCIeSlotLFM.2.SlotState":"Defined"
+"PCIeSlotLFM.2.TargetLFM":"Airflow Controlled"
+"PCIeSlotLFM.3.3rdPartyCard":"N/A"
+"PCIeSlotLFM.3.CardType":"Empty"
+"PCIeSlotLFM.3.CustomLFM":0
+"PCIeSlotLFM.3.LFMMode":"Automatic"
+"PCIeSlotLFM.3.MaxLFM":330
+"PCIeSlotLFM.3.PCIeInletTemperature":34
+"PCIeSlotLFM.3.SlotState":"Not-Defined"
+"PCIeSlotLFM.3.TargetLFM":"-"
+"PCIeSlotLFM.4.3rdPartyCard":"N/A"
+"PCIeSlotLFM.4.CardType":"Empty"
+"PCIeSlotLFM.4.CustomLFM":0
+"PCIeSlotLFM.4.LFMMode":"Automatic"
+"PCIeSlotLFM.4.MaxLFM":180
+"PCIeSlotLFM.4.PCIeInletTemperature":34
+"PCIeSlotLFM.4.SlotState":"Not-Defined"
+"PCIeSlotLFM.4.TargetLFM":"-"
+"PCIeSlotLFM.5.3rdPartyCard":"N/A"
+"PCIeSlotLFM.5.CardType":"Empty"
+"PCIeSlotLFM.5.CustomLFM":0
+"PCIeSlotLFM.5.LFMMode":"Automatic"
+"PCIeSlotLFM.5.MaxLFM":260
+"PCIeSlotLFM.5.PCIeInletTemperature":34
+"PCIeSlotLFM.5.SlotState":"Not-Defined"
+"PCIeSlotLFM.5.TargetLFM":"-"
+"PCIeSlotLFM.6.3rdPartyCard":"N/A"
+"PCIeSlotLFM.6.CardType":"Empty"
+"PCIeSlotLFM.6.CustomLFM":0
+"PCIeSlotLFM.6.LFMMode":"Automatic"
+"PCIeSlotLFM.6.MaxLFM":290
+"PCIeSlotLFM.6.PCIeInletTemperature":34
+"PCIeSlotLFM.6.SlotState":"Not-Defined"
+"PCIeSlotLFM.6.TargetLFM":"-"
+"PCIeSlotLFM.7.3rdPartyCard":"N/A"
+"PCIeSlotLFM.7.CardType":"Empty"
+"PCIeSlotLFM.7.CustomLFM":0
+"PCIeSlotLFM.7.LFMMode":"Automatic"
+"PCIeSlotLFM.7.MaxLFM":0
+"PCIeSlotLFM.7.PCIeInletTemperature":0
+"PCIeSlotLFM.7.SlotState":"Not-Defined"
+"PCIeSlotLFM.7.TargetLFM":"-"
+"PCIeSlotLFM.8.3rdPartyCard":"N/A"
+"PCIeSlotLFM.8.CardType":"Empty"
+"PCIeSlotLFM.8.CustomLFM":0
+"PCIeSlotLFM.8.LFMMode":"Automatic"
+"PCIeSlotLFM.8.MaxLFM":0
+"PCIeSlotLFM.8.PCIeInletTemperature":0
+"PCIeSlotLFM.8.SlotState":"Not-Defined"
+"PCIeSlotLFM.8.TargetLFM":"-"
+"PCIeSlotLFM.9.3rdPartyCard":"N/A"
+"PCIeSlotLFM.9.CardType":"Empty"
+"PCIeSlotLFM.9.CustomLFM":0
+"PCIeSlotLFM.9.LFMMode":"Automatic"
+"PCIeSlotLFM.9.MaxLFM":0
+"PCIeSlotLFM.9.PCIeInletTemperature":0
+"PCIeSlotLFM.9.SlotState":"Not-Defined"
+"PCIeSlotLFM.9.TargetLFM":"-"
+"ThermalConfig.1.CriticalEventGenerationInterval":30
+"ThermalConfig.1.EventGenerationInterval":30
+"ThermalConfig.1.FreshAirCompliantConfiguration":"Not Applicable"
+"ThermalConfig.1.MaxCFM":61
+"ThermalConfig.1.ValidFanConfiguration":"Yes"
+"ThermalHistorical.1.IntervalInSeconds":0
+"ThermalSettings.1.AirExhaustTemp":"70"
+"ThermalSettings.1.AirExhaustTempSupport":"Supported"
+"ThermalSettings.1.AirTemperatureRiseLimit":"NO LIMIT"
+"ThermalSettings.1.AirTemperatureRiseLimitSupport":"Not Supported"
+"ThermalSettings.1.CurrentSystemProfileValue":"Minimum Power"
+"ThermalSettings.1.FanSpeedHighOffsetVal":75
+"ThermalSettings.1.FanSpeedLowOffsetVal":25
+"ThermalSettings.1.FanSpeedMaxOffsetVal":100
+"ThermalSettings.1.FanSpeedMediumOffsetVal":50
+"ThermalSettings.1.FanSpeedOffset":"Off"
+"ThermalSettings.1.MFSMaximumLimit":100
+"ThermalSettings.1.MFSMinimumLimit":63
+"ThermalSettings.1.MaximumPCIeInletTemperatureLimit":"55"
+"ThermalSettings.1.MaximumPCIeInletTemperatureLimitSupport":"Not Supported"
+"ThermalSettings.1.MinimumFanSpeed":255
+"ThermalSettings.1.PCIeSlotLFMSupport":"Supported"
+"ThermalSettings.1.SetAirTemperatureRiseLimit":"Disabled"
+"ThermalSettings.1.SetMaximumExhaustTemperatureLimit":"Disabled"
+"ThermalSettings.1.SystemCFMSupport":"Supported"
+"ThermalSettings.1.SystemExhaustTemperature":38
+"ThermalSettings.1.SystemInletTemperature":23
+"ThermalSettings.1.SystemInletTemperatureSupportLimitPerConfiguration":30
+"ThermalSettings.1.TargetExhaustTemperatureLimit":70
+"ThermalSettings.1.ThermalProfile":"Sound Cap"
+CAPTURE
+  )
+
+  local REPLACEMENT SLOT ATTRIBUTE VALUE
+  for REPLACEMENT in "$@"; do
+    SLOT="${REPLACEMENT%%=*}"
+    ATTRIBUTE="${REPLACEMENT#*=}"
+    VALUE="${ATTRIBUTE#*=}"
+    ATTRIBUTE="${ATTRIBUTE%%=*}"
+    CAPTURED_ATTRIBUTES=$(printf '%s\n' "$CAPTURED_ATTRIBUTES" |
+      sed "s|^\"PCIeSlotLFM\.${SLOT}\.${ATTRIBUTE}\":.*$|\"PCIeSlotLFM.${SLOT}.${ATTRIBUTE}\":\"${VALUE}\"|")
+  done
+
+  local MINIFIED
+  MINIFIED=$(printf '%s\n' "$CAPTURED_ATTRIBUTES" | paste -sd ',' -)
+
+  printf '{"Attributes":{%s}}' "$MINIFIED"
+}


### PR DESCRIPTION
Closes #489.

## The problem

Every Redfish body the suite fed the controller was one `make_redfish_attributes_body()` built to the shape the code expects — which is the shape whoever wrote the code had in mind. When a parser and its fixture share an author, they share his assumptions.

#412 is what that costs. The third-party slot pattern was anchored at `^` with `[^"]*`, so it could not cross the quote opening the enclosing `Attributes` key, and the document's **first** attribute never matched. Every generated fixture put something harmless there, so the suite stayed green while the machine's first PCIe slot was dropped from every write.

## What this adds

`make_captured_r740xd2_attributes_body()` in `tests/lib/fixtures.sh`, reproducing the System attributes @bitspill posted on #360 from a real PowerEdge R740xd2 (iDRAC 9 `3.30.30.30`, Enterprise, host running) — **150 attributes, byte for byte and in his order**. Four things in it are true only because an iDRAC produced them:

| | Why it matters |
|---|---|
| It came from the **legacy URI** | The conformant one answered `404` on this machine. The fallback is not a defensive branch here — it is the only way this server ever answers |
| It is ordered **alphabetically** | So it opens on `PCIeSlotLFM.1.3rdPartyCard` — exactly the position #412 could not reach |
| Its slots run **1, 10, 11 … 15, 2, 3 … 9** | Lexicographic, not numeric. Nothing should care, and now something says so |
| **15 slots with the setting, no third-party card at all** | Fourteen empty, one AHCI reading `No`. The `No third-party PCIe card to apply it to` branch had only ever met this in a mock |

Three cases in `tests/cases/46_redfish_cooling_response.sh` drive the parsers and the whole controller with it, over the legacy URI it really came from.

This does not replace the generated fixtures — they cover a combinatorial space a single capture never could. It adds the one thing they structurally cannot: a document nobody here wrote.

## What it modifies

- `tests/lib/fixtures.sh` — one new builder (+205 lines, of which 150 are the capture itself)
- `tests/cases/46_redfish_cooling_response.sh` — three new cases (+63)

No production code is touched.

## How to test

```bash
./tests/run_tests.sh                 # 627 passed (3041 assertions) — was 624 / 3032
./tests/run_tests.sh -f 46_redfish   # the three new cases among them
```

**That the fixture bites, not merely passes** — restore the pre-#412 anchor and the capture catches it:

```bash
sed -i '2149s|\.\*"PCIeSlotLFM|^[^"]*"PCIeSlotLFM|' functions.sh
./tests/run_tests.sh -f 46_redfish
#   fail the attribute a real document opens on is not dropped
git checkout functions.sh
```

**That the transcription is faithful** — it is mechanically checkable against the comment on #360; the 150 lines of the heredoc diff empty against the attribute lines of that paste.

Also run here: both `shellcheck` invocations clean, image built, and the suite inside it green (537 passed, 90 skipped — the usual skips for files not mounted into the image).

---
_Generated by [Claude Code](https://claude.ai/code/session_01LbwwtnuQyHu1tAuQiaRZ3f)_