### PR TITLE
Keep the licence on the nightly refresh, and annotate the index (#493)

### DIFF
--- a/.github/workflows/base_image_refresh.yml
+++ b/.github/workflows/base_image_refresh.yml
@@ -377,6 +377,11 @@ jobs:
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v6
+        # Same two levels as "Docker image CI" : the "latest" republished here is
+        # meant to stay structurally identical to the one the release build
+        # produces, and that now includes where its annotations sit
+        env:
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
         with:
           # The two entries below are docker.io/tigerblue77/dell_idrac_fan_controller
           # and ghcr.io/tigerblue77/dell_idrac_fan_controller. Said here rather than
@@ -393,8 +398,30 @@ jobs:
             latest=false
           # version and revision would otherwise describe the default branch,
           # which is not what is being built here. base.digest is what the next
-          # run compares against
+          # run compares against.
+          #
+          # The licence is spelled out for the reason "Docker image CI" spells it
+          # out, and its absence here was a real defect rather than a cosmetic
+          # one : metadata-action derives that label from GitHub's licence
+          # detection, which reports the plain "AGPL-3.0" for this repository,
+          # and this workflow republishes the SAME "latest" tag the release build
+          # published with "AGPL-3.0-only" on it. So every night the base moved,
+          # the published image quietly stopped stating the project's own terms
+          # and started stating GitHub's guess at them. In a dual-licensed
+          # project that is not a detail : see LICENSE, LICENSE-COMMERCIAL.md and
+          # the note in .github/check_sign_off.sh on what the licence record is
+          # load-bearing for
           labels: |
+            org.opencontainers.image.licenses=AGPL-3.0-only
+            org.opencontainers.image.base.name=${{ needs.check.outputs.base-image }}
+            org.opencontainers.image.base.digest=${{ needs.check.outputs.base-digest }}
+            org.opencontainers.image.version=${{ needs.check.outputs.release-tag }}
+            org.opencontainers.image.revision=${{ needs.check.outputs.release-sha }}
+          # Stated again because getAnnotations() reads this input and never the
+          # one above, so a custom label declared there alone never becomes an
+          # annotation. See the same block in "Docker image CI"
+          annotations: |
+            org.opencontainers.image.licenses=AGPL-3.0-only
             org.opencontainers.image.base.name=${{ needs.check.outputs.base-image }}
             org.opencontainers.image.base.digest=${{ needs.check.outputs.base-digest }}
             org.opencontainers.image.version=${{ needs.check.outputs.release-tag }}
@@ -422,3 +449,4 @@ jobs:
             BASE_IMAGE=${{ needs.check.outputs.base-pinned }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}

--- a/.github/workflows/build_and_publish_docker_image.yml
+++ b/.github/workflows/build_and_publish_docker_image.yml
@@ -268,6 +268,12 @@ jobs:
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v6
+        # Annotations are attached to the image manifests alone by default. The
+        # index is what "docker pull" and "imagetools inspect" resolve first, and
+        # reading annotations there is what a registry showing a description
+        # does, so both levels are named
+        env:
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
         with:
           # The two entries below are docker.io/tigerblue77/dell_idrac_fan_controller
           # and ghcr.io/tigerblue77/dell_idrac_fan_controller. Said here rather than
@@ -317,6 +323,18 @@ jobs:
             org.opencontainers.image.base.name=${{ steps.base.outputs.image }}
             org.opencontainers.image.base.digest=${{ steps.base.outputs.digest }}
             org.opencontainers.image.version=${{ github.ref_name }}
+          # The same four again, and not a duplication that could be dropped :
+          # getAnnotations() returns getOCIAnnotationsWithCustoms(inputs.annotations),
+          # so it reads THIS input and never the one above. A custom label stated
+          # only there reaches the image config and nothing else. Left unstated
+          # here, the licence annotation would be the "AGPL-3.0" guess sitting on
+          # the index beside a config label reading "AGPL-3.0-only" -- the exact
+          # disagreement the block above exists to prevent
+          annotations: |
+            org.opencontainers.image.licenses=AGPL-3.0-only
+            org.opencontainers.image.base.name=${{ steps.base.outputs.image }}
+            org.opencontainers.image.base.digest=${{ steps.base.outputs.digest }}
+            org.opencontainers.image.version=${{ github.ref_name }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
@@ -344,6 +362,7 @@ jobs:
             BASE_IMAGE=${{ steps.base.outputs.pinned }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}
 
       - name: Wait for the registry before retrying
         if: steps.build.outcome == 'failure'
@@ -368,6 +387,7 @@ jobs:
             BASE_IMAGE=${{ steps.base.outputs.pinned }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}
 
       # Last, where it used to sit right after the checkout : a release note is
       # the announcement that a version is out, and announcing it before the

--- a/tests/cases/12_github_workflows.sh
+++ b/tests/cases/12_github_workflows.sh
@@ -260,3 +260,126 @@ function test_every_shell_block_the_workflows_run_has_a_valid_syntax() {
     fail "no shell block was found across the workflows, and every one of them runs shell"
   fi
 }
+
+# The content of a "<key>: |" block scalar, indentation stripped, wherever it
+# appears in a workflow. Shared by the two tests below, which compare one block
+# against another.
+#
+# The block ends where the indentation returns to the key or above it, and a
+# blank line inside it is content rather than its end -- the same reading
+# test_no_docker_action_list_entry_ends_with_a_comment does, kept in one place
+# rather than copied into both callers. Character classes are spelled out rather
+# than [[:space:]] for the reason that test gives : the suite runs on mawk on the
+# runner and on GNU awk inside the image, and this form is read the same way by
+# both
+function extract_block_scalar() {
+  local -r KEY="$1"
+  local -r FILE="$2"
+
+  awk -v key="$KEY" '
+    $0 ~ "^[ \t]*" key ":[ \t]*[|>]" {
+      in_block = 1
+      key_indent = match($0, /[^ \t]/) - 1
+      next
+    }
+
+    in_block {
+      if ($0 ~ /^[ \t]*$/) next
+
+      if (match($0, /[^ \t]/) - 1 <= key_indent) {
+        in_block = 0
+        next
+      }
+
+      sub(/^[ \t]+/, "")
+      print
+    }
+  ' "$FILE"
+}
+
+function test_every_publishing_workflow_states_the_project_licence() {
+  # metadata-action fills org.opencontainers.image.licenses from GitHub's licence
+  # detection, and GitHub reports the plain "AGPL-3.0" for this repository rather
+  # than the "-only" the project actually chose. "Docker image CI" has always
+  # overridden it. "Base image refresh" did not -- and it republishes the SAME
+  # "latest" tag, so every night the base moved, the published image quietly
+  # stopped stating the project's own terms and started stating GitHub's guess at
+  # them (issue #493). In a dual-licensed project that is not cosmetic : see
+  # LICENSE, LICENSE-COMMERCIAL.md and what .github/check_sign_off.sh says the
+  # licence record is load-bearing for.
+  #
+  # Both blocks are read, not just the labels : getAnnotations() returns
+  # getOCIAnnotationsWithCustoms(inputs.annotations) and never looks at
+  # inputs.labels, so a licence stated once reaches the image config and stops
+  # there, leaving the index to carry the guess beside a config that disagrees.
+  #
+  # Swept over every publishing workflow rather than over a list of two, so that a
+  # third publisher added later fails here instead of quietly reopening this
+  if [ ! -d "$REPO_ROOT/.github/workflows" ]; then
+    skip_test "no .github/workflows next to the scripts"
+    return 0
+  fi
+
+  local WORKFLOW
+  for WORKFLOW in "$REPO_ROOT"/.github/workflows/*.yml; do
+    [ -f "$WORKFLOW" ] || continue
+    grep -q '^ *push: true$' "$WORKFLOW" || continue
+
+    local KEY
+    for KEY in labels annotations; do
+      local BLOCK
+      BLOCK=$(extract_block_scalar "$KEY" "$WORKFLOW")
+
+      assert_contains "$BLOCK" "org.opencontainers.image.licenses=AGPL-3.0-only" \
+        "${WORKFLOW#"$REPO_ROOT"/} publishes an image whose $KEY do not state the project's licence, so metadata-action fills in GitHub's guess"
+    done
+  done
+}
+
+function test_every_publishing_workflow_annotates_the_image_index() {
+  # Labels live in each per-platform image config ; annotations live on the
+  # manifests and on the index. The index is what "docker pull" and
+  # "imagetools inspect" resolve first, and until issue #493 neither publisher
+  # passed the annotations input at all -- measured on the published image, the
+  # index and both platform manifests carried none.
+  #
+  # Three things have to hold together, and each is inert without the others : the
+  # levels variable has to name "index", because metadata-action attaches to
+  # "manifest" alone by default ; every pushing build has to be handed the
+  # annotations output beside the labels one ; and the two block scalars have to
+  # agree, for the reason the licence test above gives. The third is the one that
+  # keeps this from drifting back : a custom entry added to one block and not the
+  # other is exactly how the licence went missing in the first place
+  if [ ! -d "$REPO_ROOT/.github/workflows" ]; then
+    skip_test "no .github/workflows next to the scripts"
+    return 0
+  fi
+
+  local WORKFLOW
+  for WORKFLOW in "$REPO_ROOT"/.github/workflows/*.yml; do
+    [ -f "$WORKFLOW" ] || continue
+    grep -q '^ *push: true$' "$WORKFLOW" || continue
+
+    local RELATIVE_PATH="${WORKFLOW#"$REPO_ROOT"/}"
+
+    local LEVELS
+    LEVELS=$(grep -c '^ *DOCKER_METADATA_ANNOTATIONS_LEVELS: .*\bindex\b' "$WORKFLOW")
+    assert_not_equals "$LEVELS" "0" \
+      "$RELATIVE_PATH publishes an image without naming \"index\" in DOCKER_METADATA_ANNOTATIONS_LEVELS, so its annotations never reach the index"
+
+    # One "annotations:" handed to a build for every "labels:" handed to one. The
+    # single-line output form only, which is what a build step takes ; the block
+    # scalars above are the action's inputs and are compared separately below
+    local LABELS_PASSED ANNOTATIONS_PASSED
+    LABELS_PASSED=$(grep -c '^ *labels: \${{ steps\.meta\.outputs\.labels }}$' "$WORKFLOW")
+    ANNOTATIONS_PASSED=$(grep -c '^ *annotations: \${{ steps\.meta\.outputs\.annotations }}$' "$WORKFLOW")
+    assert_equals "$ANNOTATIONS_PASSED" "$LABELS_PASSED" \
+      "$RELATIVE_PATH hands its builds $LABELS_PASSED labels output(s) and $ANNOTATIONS_PASSED annotations one(s) ; a build given one and not the other publishes an image that describes itself in one place only"
+
+    local LABELS_BLOCK ANNOTATIONS_BLOCK
+    LABELS_BLOCK=$(extract_block_scalar labels "$WORKFLOW")
+    ANNOTATIONS_BLOCK=$(extract_block_scalar annotations "$WORKFLOW")
+    assert_equals "$ANNOTATIONS_BLOCK" "$LABELS_BLOCK" \
+      "$RELATIVE_PATH states different custom entries as labels and as annotations ; getAnnotations() never reads the labels input, so whatever is missing here is missing from the index"
+  done
+}


### PR DESCRIPTION
Closes #493.

The two workflows that publish this image both push `latest`, and only one of them described it in full.

## The licence

`build_and_publish_docker_image.yml` states `org.opencontainers.image.licenses=AGPL-3.0-only` explicitly, and its own comment says why: metadata-action would otherwise fill that label from GitHub's licence detection, which reports the plain identifier.

```console
$ curl -s https://api.github.com/repos/tigerblue77/Dell_iDRAC_fan_controller_Docker | jq -r '.license.spdx_id'
AGPL-3.0
```

`base_image_refresh.yml` set `base.name`, `base.digest`, `version` and `revision` but not the licence — and it republishes the same `latest` tag. So every night the base moved, the published image quietly stopped stating the project's own terms and started stating GitHub's guess at them. `latest` carries `AGPL-3.0-only` today only because the release build published it last, for v1.107 on 2026-08-27.

## The annotations

Neither workflow passed the `annotations` input to `build-push-action`, so nothing was annotated anywhere. Measured on the published image:

```console
$ # index of ghcr.io/tigerblue77/dell_idrac_fan_controller:latest
INDEX-LEVEL annotations: *** NONE ***
  linux/amd64  manifest-annotations=NONE
  linux/arm64  manifest-annotations=NONE
```

The only annotated entries in that index are BuildKit's own attestation manifests.

That is **not** fixed by handing the output along, which is why the custom entries are restated rather than duplicated by accident. `getAnnotations()` returns `getOCIAnnotationsWithCustoms(inputs.annotations)` and never reads `inputs.labels`, so a custom label declared once reaches the image config and stops there. Passing the output alone would have put the `AGPL-3.0` guess on the index beside a config label reading `AGPL-3.0-only` — the exact disagreement the licence block exists to prevent. `DOCKER_METADATA_ANNOTATIONS_LEVELS` names `index` for the same reason: its default is `manifest` alone, and the index is what `docker pull` and `imagetools inspect` resolve first.

## Tests

Two cases added to `tests/cases/12_github_workflows.sh`, swept over every workflow that pushes rather than over a list of two, so a third publisher added later fails there instead of reopening this.

Both are load-bearing — reverted to the previous workflows, keeping the test file, they fail and name each file and each invariant separately:

```
  fail every publishing workflow states the project licence
  fail every publishing workflow annotates the image index
       base_image_refresh.yml publishes an image without naming "index" in DOCKER_METADATA_ANNOTATIONS_LEVELS…
       base_image_refresh.yml hands its builds 1 labels output(s) and 0 annotations one(s)…
       base_image_refresh.yml states different custom entries as labels and as annotations…
       build_and_publish_docker_image.yml … (same three)
```

The third assertion is the one that keeps this from drifting back: the `labels` and `annotations` blocks have to agree. An entry added to one and not the other is exactly how the licence went missing.

With the change: **629 test cases passed (3051 assertions)**, and `shellcheck -x -e SC2155,SC2034,SC2016,SC1091,SC1090` clean over `tests/run_tests.sh`, `tests/lib/*.sh`, `tests/cases/*.sh` and `tests/mocks/*` — the CI invocation verbatim.

## What is not verified here

Neither publishing workflow runs on a pull request, so the first real proof is the next release build or the next night the base moves. What is checked here is the file contract and the suite; what the registry then shows is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DVL2JHdLFWZugU7qtiwPWj

---
_Generated by [Claude Code](https://claude.ai/code/session_01DVL2JHdLFWZugU7qtiwPWj)_