### PR TITLE
Split the static and interpolated profile lists into two loops

### DIFF
--- a/tests/cases/60_cpu_topologies.sh
+++ b/tests/cases/60_cpu_topologies.sh
@@ -633,6 +633,8 @@ function test_no_fan_control_profile_can_outgrow_the_column_reserved_for_it() {
     local -a PROFILES=("Dell default dynamic fan control profile")
     for SPEED in 1 5 10 50 100; do
       PROFILES+=("User static fan control profile ($SPEED%)")
+    done
+    for SPEED in 1 5 10 50 100; do
       # The ramp's own profile : shorter than the static one so as to leave room for the
       # " (monitoring only, not applied)" badge, which "User interpolated fan control profile" -- the
       # straightforward name -- did not (issue #44)


### PR DESCRIPTION
Closes #498.

## What

`test_no_fan_control_profile_can_outgrow_the_column_reserved_for_it` (added by #495) built its list of every possible fan-control profile label from a single `for SPEED in 1 5 10 50 100` loop that generated both the static profile and the interpolation ramp's profile together, reusing the same speed list rather than expressing that the two are unrelated enumerations.

## Fix

Two loops instead of one, each producing its own profile kind. No behaviour change : same two strings per speed, same 60 assertions, same coverage.

## Testing

- `./tests/run_tests.sh`: **654 passed** (3133 assertions) — identical to master.
- Both `shellcheck` invocations clean.
- `docker build` could not be attempted: this session has no Docker daemon.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HLEkEm1nfQSCHMdYgdYLtW

---
_Generated by [Claude Code](https://claude.ai/code/session_01HLEkEm1nfQSCHMdYgdYLtW)_