### PR TITLE
Skip the redundant post-merge rerun of "Tests" when the tree already passed

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,8 +17,92 @@ permissions:
   contents: read
 
 jobs:
+  detect-reuse:
+    name: Look for an already-tested identical tree
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      actions: read
+      checks: read
+      pull-requests: read
+    outputs:
+      reuse-run-id: ${{ steps.detect.outputs.reuse-run-id }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      # A push to master that merged a pull request lands a tree this workflow
+      # already ran to green on that same pull request : branch protection
+      # requires it, and "Auto-update pull request branches" keeps every open
+      # pull request rebased onto master, so by the time it is merged its base
+      # is already master's current tip. Rebuilding the Docker image and
+      # rerunning the whole suite a second time on that same tree proves
+      # nothing new -- issue #500 measured it as a wasted rerun of "Tests" on
+      # every single merge.
+      #
+      # This looks for that situation and, only when every check below holds,
+      # hands "publish-test-results" the run ID to copy results from instead of
+      # asking "test" and "test-in-docker-image" to redo the work :
+      #   - this commit is the merge product of a specific pull request
+      #   - the ref GitHub keeps for that pull request's head (which survives
+      #     the head branch being deleted) still resolves to the exact head
+      #     sha the API reports, and its tree is identical to this commit's
+      #     (a content comparison, not a commit comparison, so it survives
+      #     whichever merge strategy -- squash, merge or rebase -- produced
+      #     this commit)
+      #   - the "Test results" check already passed on that head
+      #   - a completed, successful "Tests" run for that head still has its
+      #     artifacts
+      #
+      # Every failure mode here -- no pull request found yet (GitHub can take
+      # a moment to record merge_commit_sha after a squash or rebase merge), a
+      # squash edited by hand, an expired artifact, a GitHub API error -- falls
+      # through to an empty output. "test" and "test-in-docker-image" read that
+      # as "run for real", and so does an outright failure of this job itself :
+      # nothing here can make them skip without a positive match
+      - name: Decide whether to reuse a pull request's results
+        id: detect
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          reuse_run_id=""
+
+          if [[ "${{ github.event_name }}" == "push" ]]; then
+            pr_number=$(gh api "repos/{owner}/{repo}/commits/${GITHUB_SHA}/pulls" \
+              --jq ".[] | select(.merge_commit_sha == \"${GITHUB_SHA}\") | .number" 2>/dev/null \
+              | head -n1) || pr_number=""
+
+            if [[ -n "$pr_number" ]]; then
+              pr_head_sha=$(gh api "repos/{owner}/{repo}/pulls/${pr_number}" --jq '.head.sha' 2>/dev/null) || pr_head_sha=""
+            fi
+
+            if [[ -n "${pr_head_sha:-}" ]] && git fetch --depth 1 origin "refs/pull/${pr_number}/head" 2>/dev/null; then
+              fetched_sha=$(git rev-parse FETCH_HEAD 2>/dev/null) || fetched_sha=""
+            fi
+
+            if [[ -n "${fetched_sha:-}" && "$fetched_sha" == "$pr_head_sha" ]]; then
+              head_tree=$(git rev-parse FETCH_HEAD^{tree} 2>/dev/null) || head_tree=""
+              merge_tree=$(git rev-parse HEAD^{tree} 2>/dev/null) || merge_tree=""
+            fi
+
+            if [[ -n "${head_tree:-}" && "$head_tree" == "${merge_tree:-}" ]]; then
+              check_conclusion=$(gh api --paginate "repos/{owner}/{repo}/commits/${pr_head_sha}/check-runs" \
+                --jq '.check_runs[] | select(.name == "Test results") | .conclusion' 2>/dev/null) || check_conclusion=""
+            fi
+
+            if [[ "${check_conclusion:-}" == "success" ]]; then
+              reuse_run_id=$(gh api "repos/{owner}/{repo}/actions/workflows/tests.yml/runs?head_sha=${pr_head_sha}&event=pull_request&status=completed" \
+                --jq '.workflow_runs[] | select(.conclusion == "success") | .id' 2>/dev/null | head -n1) || reuse_run_id=""
+            fi
+          fi
+
+          echo "reuse-run-id=${reuse_run_id}" >> "$GITHUB_OUTPUT"
+
   test:
     name: Run the test suite
+    needs: detect-reuse
+    if: always() && needs.detect-reuse.outputs.reuse-run-id == ''
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -42,6 +126,8 @@ jobs:
 
   test-in-docker-image:
     name: Run the test suite inside the Docker image
+    needs: detect-reuse
+    if: always() && needs.detect-reuse.outputs.reuse-run-id == ''
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -82,7 +168,7 @@ jobs:
 
   publish-test-results:
     name: Publish the test results
-    needs: [test, test-in-docker-image]
+    needs: [detect-reuse, test, test-in-docker-image]
     runs-on: ubuntu-latest
     # A pull request opened from a fork runs with a read-only token, so it cannot
     # publish anything from here : the "Test results" workflow does it instead,
@@ -97,10 +183,14 @@ jobs:
       pull-requests: write
       actions: read
     steps:
+      # Own run by default ; the run of the pull request whose results are
+      # being reused instead, when "detect-reuse" found one
       - name: Download the test results
         uses: actions/download-artifact@v8
         with:
           pattern: Test Results (*)
+          run-id: ${{ needs.detect-reuse.outputs.reuse-run-id || github.run_id }}
+          github-token: ${{ github.token }}
           path: test-results
 
       - name: Publish the test results


### PR DESCRIPTION
Closes #500.

## Summary

Every merge to `master` pushes a tree that, in the ordinary case, is byte-for-byte identical to the pull request's head : branch protection already required that exact tree to pass, and "Auto-update pull request branches" keeps every open pull request rebased onto `master`. The `push`-to-`master` trigger kept by #186 for its baseline/visibility value therefore rebuilds the Docker image and reruns the whole suite a second time on an answer already known — observed directly on the merge of #495 (squash commit `24fa182`): `Tests` ran to completion on the pull request (`pull_request: synchronize`, ~3m1s) and then ran again in full on the push to `master` moments later (~3m1s).

This adds `detect-reuse`, a job that runs first and, only on a `push` that is provably the merge of a specific pull request (same **tree**, via `git rev-parse ...^{tree}`, not a commit-message guess, so it holds regardless of merge strategy — squash, merge, or rebase), whose head already carries a passing "Test results" check : hands `publish-test-results` that pull request's own run ID to copy artifacts from (the same cross-run `actions/download-artifact` + `github-token` pattern `test-results.yml` already uses for forks) instead of asking `test` and `test-in-docker-image` to redo the work.

Every case that can't be positively confirmed — no matching pull request yet, a hand-edited squash, an expired artifact, a GitHub API error, or an outright failure of `detect-reuse` itself — falls through to running the suite for real. `test` and `test-in-docker-image` use `if: always() && needs.detect-reuse.outputs.reuse-run-id == ''` specifically so that an infra failure of `detect-reuse` (not just an empty output) can never skip real test coverage : GitHub Actions implicitly ANDs `success()` onto a job's `needs` unless the `if:` references `always()`/`success()`/`failure()`/`cancelled()`, so a plain equality check alone would have silently skipped the real jobs on any `detect-reuse` hiccup.

This keeps both properties #186 cared about (a baseline is still published for every merge, and a real break is still caught by the normal `pull_request` run) while cutting the redundant compute for the common case.

## Testing

- `./tests/run_tests.sh`: **654 passed** (3133 assertions) — unaffected, since this change touches only `.github/workflows/tests.yml`.
- Both `shellcheck` invocations are clean (no shell scripts were touched by this change).
- `docker build` could not be attempted: this session has no Docker daemon.
- The new job graph's YAML was validated with `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/tests.yml'))"`.
- The design went through three independent adversarial reviews (GitHub Actions syntax/semantics, REST API correctness, fail-open safety) before being applied ; all three converged on the same blocker (the `if:` condition needing `always()` to escape the implicit `needs`-success gate) and the same missing `checks: read` permission, both fixed in this PR. Two further minor hardening suggestions (pagination on the check-runs lookup, and asserting the fetched PR-head sha matches the API-reported one before trusting the tree comparison) are also included.
- Actual end-to-end behavior (does `detect-reuse` correctly find and reuse a merged PR's run) can only be observed once this lands on `master` and a subsequent pull request is merged — there is no way to simulate a real squash-merge event from this session.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CbmHpK7mfRGcvZVvip4ssg

---
_Generated by [Claude Code](https://claude.ai/code/session_01CbmHpK7mfRGcvZVvip4ssg)_